### PR TITLE
chore: set all component header badge's type to "information"

### DIFF
--- a/src/components/component-header/ComponentHeader.tsx
+++ b/src/components/component-header/ComponentHeader.tsx
@@ -1,11 +1,11 @@
-import { GoABadge } from "@abgov/react-components";
+import {GoABadge} from "@abgov/react-components";
 import "./ComponentHeader.css";
 
 interface Props {
-  category?: string;
+  category?: Category;
   name: string;
   description?: string;
-  relatedComponents?: { link: string; name: string }[];
+  relatedComponents?: {link: string; name: string}[];
 }
 
 export enum Category {
@@ -17,26 +17,9 @@ export enum Category {
 }
 
 export const ComponentHeader: React.FC<Props> = (props: Props) => {
-  const category = () => {
-    switch (props.category) {
-      case Category.CONTENT_AND_LAYOUT:
-        return "emergency";
-      case Category.FEEDBACK_AND_ALERTS:
-        return "important";
-      case Category.STRUCTURE_AND_NAVIGATION:
-        return "success";
-      case Category.INPUTS_AND_ACTIONS:
-        return "information";
-      case Category.UTILITIES:
-        return "midtone";
-      default:
-        return "information";
-    }
-  };
-
   return (
     <div className="component-header">
-      <GoABadge type={category()} content={props.category} />
+      <GoABadge type="information" content={props.category} />
       <h1>{props.name}</h1>
       <h3>{props.description}</h3>
 


### PR DESCRIPTION
Based on Tom's feedback: we will change the component header's badge to the default type `information`
![image](https://github.com/GovAlta/ui-components-docs/assets/120135417/6fa58bbf-5068-4b90-95db-1e8c95d23aa6)
