### PR TITLE
fix(#1488): angular code cannot have shorten tag.

### DIFF
--- a/src/components/sandbox/ComponentSerializer.ts
+++ b/src/components/sandbox/ComponentSerializer.ts
@@ -92,7 +92,7 @@ export class ComponentSerializer {
     }
 
     if (!component.props.children) {
-      return `<${elementType}${props} />`;
+      return `<${elementType}${props}></${elementType}>`;
     }
 
     let children: string = "";


### PR DESCRIPTION
Angular code cannot have shorten tag like React, so copy paste the code will cause errors. 
Describe the issue at https://github.com/GovAlta/ui-components/issues/1488