### PR TITLE
chore: Removing links to the Service Principles page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -86,7 +86,6 @@ import GetStartedLayout from "@routes/get-started/GetStartedLayout";
 import GetStartedOverviewPage from "@routes/get-started/GetStartedOverview";
 import QATestingOverviewPage from "@routes/get-started/qa-testing/QATestingOverview";
 import RoadmapPage from "@routes/get-started/Roadmap";
-import ServicePrinciplesPage from "@routes/get-started/ServicePrinciples";
 import SupportedBrowsersPage from "@routes/get-started/developers/SupportedBrowsers";
 import UxDesignerPage from "@routes/get-started/designers/UxDesigner";
 
@@ -190,7 +189,6 @@ const router = createBrowserRouter(
           <Route index element={<QATestingOverviewPage />} />
         </Route>
         <Route path="roadmap" element={<RoadmapPage />} />
-        <Route path="service-principles" element={<ServicePrinciplesPage />} />
       </Route>
 
       <Route path="patterns" element={<PatternsLayout />} errorElement={<ComponentNotFoundPage />}>

--- a/src/routes/get-started/GetStartedLayout.tsx
+++ b/src/routes/get-started/GetStartedLayout.tsx
@@ -19,7 +19,6 @@ export default function GetStartedLayout() {
           </GoASideMenuGroup>
           <Link to="qa-testing">QA testing</Link>
           <Link to="roadmap">Roadmap</Link>
-          <Link to="service-principles">Service principles</Link>
         </GoASideMenu>
       </section>
 


### PR DESCRIPTION
This is being done on request from Mark. The page may be used in the future so it isn't being deleted, but the principles haven't been made official yet, so removing links to this page so people can't view it just yet.