### PR TITLE
chore: center components in sandbox - code review needed

### DIFF
--- a/src/routes/components/Block.tsx
+++ b/src/routes/components/Block.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { ComponentBinding, Sandbox } from "@components/sandbox";
 import {
   ComponentProperties,
@@ -35,6 +35,7 @@ export default function BlockPage() {
       defaultValue: "start",
     },
   ]);
+  const [sandboxFullWidth, setSandboxFullWidth] = useState<boolean>(false);
   const componentProperties: ComponentProperty[] = [
     {
       name: "gap",
@@ -55,6 +56,11 @@ export default function BlockPage() {
       defaultValue: "start",
     },
   ];
+
+  useEffect(() => {
+    const direction = blockBindings.find(binding => binding.name === "direction");
+    setSandboxFullWidth(direction?.value === "column");
+  }, [blockBindings]);
 
   function onSandboxChange(blockBindings: ComponentBinding[], props: Record<string, unknown>) {
     setBlockBindings(blockBindings);
@@ -78,7 +84,7 @@ export default function BlockPage() {
       <GoATabs>
         <GoATab heading="Code examples">
           {/*Block sandbox*/}
-          <Sandbox properties={blockBindings} onChange={onSandboxChange} fullWidth>
+          <Sandbox properties={blockBindings} onChange={onSandboxChange} fullWidth={sandboxFullWidth}>
             <GoABlock {...blockProps}>
               <div
                 style={{

--- a/src/routes/components/ButtonGroup.tsx
+++ b/src/routes/components/ButtonGroup.tsx
@@ -10,7 +10,7 @@ import { Alignment } from "@abgov/react-components/common/styling";
 
 export default function ButtonGroupPage() {
   const [buttonGroupProps, setButtonGroupProps] = useState({
-    alignment: "start" as Alignment,
+    alignment: "center" as Alignment,
   });
   const [buttonGroupBindings, setButtonGroupBindings] = useState<ComponentBinding[]>([
     {
@@ -18,7 +18,7 @@ export default function ButtonGroupPage() {
       type: "list",
       name: "alignment",
       options: ["start", "end", "center"],
-      value: "start",
+      value: "center",
     },
     {
       label: "Gap",

--- a/src/routes/components/Dropdown.tsx
+++ b/src/routes/components/Dropdown.tsx
@@ -248,7 +248,6 @@ export default function DropdownPage() {
             formItemProperties={formItemBindings}
             onChange={onSandboxChange}
             onChangeFormItemBindings={onFormItemChange}
-            fullWidth
             flags={["reactive"]}>
             <CodeSnippet
               lang="typescript"

--- a/src/routes/components/Spacer.tsx
+++ b/src/routes/components/Spacer.tsx
@@ -95,7 +95,7 @@ export default function SpacerPage() {
 
       <GoATabs>
         <GoATab heading="Code examples">
-          <Sandbox properties={hSpacerBindings} onChange={onHSandboxChange} fullWidth>
+          <Sandbox properties={hSpacerBindings} onChange={onHSandboxChange}>
             <GoABlock gap="none">
               <div style={styles}>
                 Item 1
@@ -111,7 +111,7 @@ export default function SpacerPage() {
             </GoABlock>
           </Sandbox>
 
-          <Sandbox properties={vSpacerBindings} onChange={onVSandboxChange} fullWidth>
+          <Sandbox properties={vSpacerBindings} onChange={onVSandboxChange}>
             <GoABlock direction="column" gap="none">
               <div style={styles}>
                 Item 1

--- a/src/routes/components/Table.tsx
+++ b/src/routes/components/Table.tsx
@@ -16,21 +16,28 @@ import {
   GoATabs,
 } from "@abgov/react-components";
 import { CodeSnippet } from "@components/code-snippet/CodeSnippet.tsx";
+import { GoATableProps } from "@abgov/react-components/lib/table/table";
 
 interface User {
   firstName: string;
   lastName: string;
   age: number;
 }
-
+type ComponentPropsType = GoATableProps;
+type CastingType = {
+  width: string;
+  [key: string]: unknown;
+}
 export default function TablePage() {
-  const [tableProps, setTableProps] = useState({});
+  const [tableProps, setTableProps] = useState<ComponentPropsType>({
+    width: "100%"
+  });
   const [tableBindings, setTableBindings] = useState<ComponentBinding[]>([
     {
       label: "Width",
       type: "string",
       name: "width",
-      value: "",
+      value: "100%",
     },
     {
       label: "Variant",
@@ -70,7 +77,7 @@ export default function TablePage() {
 
   function onSandboxChange(tableBindings: ComponentBinding[], props: Record<string, unknown>) {
     setTableBindings(tableBindings);
-    setTableProps(props);
+    setTableProps(props as CastingType);
   }
 
   // For table demo -- needs to do sort functionality

--- a/src/routes/components/TextField.tsx
+++ b/src/routes/components/TextField.tsx
@@ -403,7 +403,6 @@ export default function TextFieldPage() {
             formItemProperties={formItemBindings}
             onChange={onSandboxChange}
             onChangeFormItemBindings={onFormItemChange}
-            fullWidth
             flags={["reactive"]}>
             <CodeSnippet
               lang="typescript"


### PR DESCRIPTION
- [x] ButtonGroup
- [x] Dropdown,
- [x] TextField,
- [] TextArea (kind of a bug on Textarea, agree to ignore it for now)
- [x] Table
- [x] Spacer
- [x] Block

![image](https://github.com/GovAlta/ui-components-docs/assets/120135417/00d84b4a-b231-46d3-834a-b66c27cc9d1b)

![image](https://github.com/GovAlta/ui-components-docs/assets/120135417/dc11b07c-3855-49b0-b6b1-7049f2bb1d3a)
