### PR TITLE
fix(#1377): make app header collapse when screen size is less than 1140

### DIFF
--- a/src/routes/root.tsx
+++ b/src/routes/root.tsx
@@ -44,7 +44,7 @@ export default function Root() {
             feedbackUrl="https://forms.microsoft.com/r/8Zp7zSJS6W"
             maxContentWidth={MAX_CONTENT_WIDTH}
           />
-          <GoAAppHeader heading="Design system" maxContentWidth={MAX_CONTENT_WIDTH} url={"/"}>
+          <GoAAppHeader heading="Design system" maxContentWidth={MAX_CONTENT_WIDTH} url={"/"} fullMenuBreakpoint={1140}>
             <Link to="/get-started">Get started</Link>
             <Link to="/patterns">Patterns and templates</Link>
             <Link to="/components">Components</Link>


### PR DESCRIPTION
Follow [bug 1377](https://github.com/GovAlta/ui-components/issues/1377) to fix the website. 

https://github.com/GovAlta/ui-components-docs/assets/120135417/2059ff4c-9649-47e9-a683-eb6a983d853a

