### PR TITLE
docs(#1783): radio and checkbox slot description and example

### DIFF
--- a/src/examples/checkbox/CheckboxExamples.tsx
+++ b/src/examples/checkbox/CheckboxExamples.tsx
@@ -1,0 +1,57 @@
+import { GoACheckbox, GoAFormItem } from "@abgov/react-components";
+import { Sandbox } from "@components/sandbox";
+import { CodeSnippet } from "@components/code-snippet/CodeSnippet.tsx";
+
+export default function CheckboxExamples () {
+  return (
+    <>      
+      <h2 id="component-examples" className="hidden" aria-hidden="true">Examples</h2>
+      <h3 id="component-example-expand-collapse-form">Use tags in the description</h3>
+      <Sandbox fullWidth skipRender>
+        {/*Angular*/}
+        <CodeSnippet
+        lang="typescript"
+        tags="angular"
+        allowCopy={true}
+        code={`
+              <goa-form-item label="Select one or more options">
+                <goa-checkbox checked="true" name="optionOne" text="Option one">
+                  <span slot="description">Help text with a <a href="#">link</a>.</span>
+                </goa-checkbox>
+                <goa-checkbox checked="false" name="optionTwo" text="Option two" />
+                <goa-checkbox checked="false" name="optionThree" text="Option three" />
+              </goa-form-item>
+            `}
+        />
+        {/*React*/}
+        <CodeSnippet
+        lang="typescript"
+        tags="react"
+        allowCopy={true}
+        code={`
+              <GoAFormItem label="Select one or more options">
+                <GoACheckbox
+                  checked={true}
+                  name="optionOne"
+                  text="Option one"
+                  description={<span>Help text with a <a href="#">link</a>.</span>}
+                  />
+                <GoACheckbox checked={false} name="optionTwo" text="Option two" />
+                <GoACheckbox checked={false} name="optionThree" text="Option three" />
+              </GoAFormItem>
+            `}
+        />
+        <GoAFormItem label="Select one or more options">
+          <GoACheckbox
+            checked={true}
+            name="optionOne"
+            text="Option one"
+            description={<span>Help text with a <a href="#">link</a>.</span>}
+            />
+          <GoACheckbox checked={false} name="optionTwo" text="Option two" />
+          <GoACheckbox checked={false} name="optionThree" text="Option three" />
+        </GoAFormItem>
+      </Sandbox>
+    </>
+  );
+}

--- a/src/examples/radio/RadioExamples.tsx
+++ b/src/examples/radio/RadioExamples.tsx
@@ -1,0 +1,63 @@
+import { GoARadioGroup, GoARadioItem, GoAFormItem } from "@abgov/react-components";
+import { Sandbox } from "@components/sandbox";
+import { CodeSnippet } from "@components/code-snippet/CodeSnippet.tsx";
+
+const noop = () => { };
+
+export default function CheckboxExamples () {
+  return (
+    <>      
+      <h2 id="component-examples" className="hidden" aria-hidden="true">Examples</h2>
+      <h3 id="component-example-expand-collapse-form">Use tags in the description</h3>
+      <Sandbox fullWidth skipRender>
+        {/*Angular*/}
+        <CodeSnippet
+        lang="typescript"
+        tags="angular"
+        allowCopy={true}
+        code={`
+              <goa-form-item label="Select one option">
+              <goa-radio-group name="selectOne" value="1" (_change)="onChange($event)">
+                <goa-radio-item value="1" label="Option one">
+                  <span slot="description">Help text with a <a href="#">link</a>.</span>
+                </goa-radio-item>
+                <goa-radio-item value="2" label="Option two" />
+                <goa-radio-item value="3" label="Option three" />
+              </goa-radio-group>
+            </goa-form-item>     
+            `}
+        />
+        {/*React*/}
+        <CodeSnippet
+        lang="typescript"
+        tags="react"
+        allowCopy={true}
+        code={`
+            <GoAFormItem label="Select one option">
+              <GoARadioGroup name="selectOne" value="1" onChange={onChange}>
+                <GoARadioItem
+                    value="1"
+                    label="Option one"
+                    description={<span>Help text with a <a href="#">link</a>.</span>}
+                    />
+                <GoARadioItem value="2" label="Option two" />
+                <GoARadioItem value="3" label="Option three" />
+              </GoARadioGroup>
+            </GoAFormItem> 
+            `}
+        />
+        <GoAFormItem label="Select one option">
+          <GoARadioGroup name="selectOne" value="1" onChange={noop}>
+            <GoARadioItem
+                value="1"
+                label="Option one"
+                description={<span>Help text with a <a href="#">link</a>.</span>}
+                />
+            <GoARadioItem value="2" label="Option two" />
+            <GoARadioItem value="3" label="Option three" />
+          </GoARadioGroup>
+        </GoAFormItem>        
+      </Sandbox>
+    </>
+  );
+}

--- a/src/routes/components/Checkbox.tsx
+++ b/src/routes/components/Checkbox.tsx
@@ -9,6 +9,7 @@ import {
 import { Category, ComponentHeader } from "@components/component-header/ComponentHeader.tsx";
 import { useSandboxFormItem } from "@hooks/useSandboxFormItem.tsx";
 import { ComponentContent } from "@components/component-content/ComponentContent";
+import CheckboxExamples from "@examples/checkbox/CheckboxExamples.tsx";
 
 // == Page props ==
 const componentName = "Checkbox";
@@ -47,36 +48,43 @@ export default function CheckboxPage() {
     {
       name: "name",
       type: "string",
-      description: "Must match the name assigned to the children",
+      description: "Must match the name assigned to the children.",
       required: true,
     },
     {
       name: "checked",
       type: "boolean",
-      description: "Mark the checkbox item as selected",
+      description: "Mark the checkbox item as selected.",
       required: true,
     },
     {
       name: "text",
       type: "string",
-      description: "Content to display as the label for the Checkbox",
+      description: "Label shown beside the checkbox.",
     },
     {
       name: "value",
       type: "string",
-      description: "The value binding to the checkbox",
+      description: "The value binding.",
     },
     {
       name: "description",
-      type: "string",
-      description: "Additional content added below the content text",
+      type: "string | slot",
+      description: "Additional content shown below the label.",
+      lang: "angular",
+    },
+    {
+      name: "description",
+      type: "string | ReactNode",
+      description: "Additional content shown below the label.",
+      lang: "react",
     },
     {
       name: "disabled",
       type: "boolean",
       defaultValue: "false",
       description:
-        "Disable this control. It will not receive focus or events. Use [attr.disabled] with [formControl]",
+        "Disable this control. It will not receive focus or events. Use [attr.disabled] with [formControl].",
     },
     {
       name: "error",
@@ -152,6 +160,7 @@ export default function CheckboxPage() {
             </Sandbox>
 
             <ComponentProperties properties={componentProperties} />
+            <CheckboxExamples />
           </GoATab>
 
           <GoATab

--- a/src/routes/components/Radio.tsx
+++ b/src/routes/components/Radio.tsx
@@ -16,6 +16,7 @@ import {
 import { CodeSnippet } from "@components/code-snippet/CodeSnippet.tsx";
 import { useSandboxFormItem } from "@hooks/useSandboxFormItem.tsx";
 import { ComponentContent } from "@components/component-content/ComponentContent";
+import RadioExamples from "@examples/radio/RadioExamples.tsx";
 
 // == Page props ==
 const componentName = "Radio";
@@ -74,30 +75,30 @@ export default function RadioPage() {
       name: "name",
       type: "string",
       required: true,
-      description: "Must match the name assigned to the children",
+      description: "Must match the name assigned to the children.",
     },
     {
       name: "value",
       type: "string",
-      description: "The value binding",
+      description: "The value binding.",
     },
     {
       name: "orientation",
       type: "horizontal|vertical",
-      description: "Orientation of the radio items",
+      description: "Orientation of the radio items.",
       defaultValue: "vertical",
     },
     {
       name: "error",
       type: "boolean",
       defaultValue: "false",
-      description: "Set the component to an error state",
+      description: "Set the component to an error state.",
     },
     {
       name: "disabled",
       type: "boolean",
       defaultValue: "false",
-      description: "Set the component to disabled. Use [attr.disabled] with [formControl]",
+      description: "Set the component to disabled. Use [attr.disabled] with [formControl].",
     },
     {
       name: "ariaLabel",
@@ -118,7 +119,7 @@ export default function RadioPage() {
       lang: "react",
       type: "(name: string, value: string[] | string | null) => void",
       required: true,
-      description: "Callback function when radio value is changed",
+      description: "Callback function when radio value is changed.",
     },
   ];
   const radioItemProperties: ComponentProperty[] = [
@@ -131,12 +132,19 @@ export default function RadioPage() {
     {
       name: "label",
       type: "string",
-      description: "Tetx to show to the user",
+      description: "Text shown beside the radio.",
     },
     {
       name: "description",
-      type: "string",
-      description: "Additional text to the bottom of the label",
+      type: "string | slot",
+      description: "Additional content shown below the label.",
+      lang: "angular",
+    },
+    {
+      name: "description",
+      type: "string | ReactNode",
+      description: "Additional content shown below the label.",
+      lang: "react",
     },
   ];
 
@@ -215,6 +223,7 @@ export default function RadioPage() {
             <ComponentProperties heading="Radio group properties" properties={radioGroupProperties} />
             {/*Radio Item properties*/}
             <ComponentProperties heading="Radio Item properties" properties={radioItemProperties} />
+            <RadioExamples />
           </GoATab>
 
           <GoATab


### PR DESCRIPTION
This PR for https://github.com/GovAlta/ui-components/issues/1783 has the following documentation changes to radio and checkbox:
- Adds slot/reactNote type to description property.
- Adds an example of a component as a description. (Based on this [Figma example](https://www.figma.com/file/aIRjvBzpIUH0GbkffjbL04/%E2%9D%96-Patterns-library-%7C-DDD?type=design&node-id=1896-179623&mode=design&t=SirlL7cnXiEtQMJE-4))
- Cleans up the other property descriptions and ensures they all end in a period
