### PR TITLE
chore/1596:  add value to input elements sandbox code snippet

### DIFF
--- a/src/components/sandbox/AngularReactiveSerializer.ts
+++ b/src/components/sandbox/AngularReactiveSerializer.ts
@@ -75,7 +75,7 @@ export class AngularReactiveSerializer extends BaseSerializer implements Seriali
       return this.#dynamicProp(propName);
     }
     if (!propValue) return "";
-    return `${propName.toLowerCase()}=${propValue}`;
+    return `[${propName.toLowerCase()}]=${propValue}`;
   }
 
   funcToProp(name: string, _item: Object): string {

--- a/src/components/sandbox/AngularSerializer.ts
+++ b/src/components/sandbox/AngularSerializer.ts
@@ -35,6 +35,8 @@ export class AngularSerializer extends BaseSerializer implements Serializer {
     if (this.isDynamic(name)) {
       return this.#dynamicProp(name);
     }
+
+    if (name === "value" && item === "") return `value=""`;
     if (item === "") return "";
     if (name === "className") name = "class";
     return `${name.toLowerCase()}="${item}"`;
@@ -56,7 +58,7 @@ export class AngularSerializer extends BaseSerializer implements Serializer {
       return this.#dynamicProp(name);
     }
     if (!item) return "";
-    return `${name.toLowerCase()}="${item}"`;
+    return `[${name.toLowerCase()}]=${item}`;
   }
 
   funcToProp(name: string, _item: Object): string {

--- a/src/components/sandbox/ComponentBinding.ts
+++ b/src/components/sandbox/ComponentBinding.ts
@@ -14,8 +14,8 @@ interface BaseBinding {
   label: string;
   requirement?: string;
   helpText?: string;
-  dynamic?: boolean;
-  hidden?: boolean;
+  dynamic?: boolean; // If the value is dynamic, it will be displayed to bind with a variable under code snippet
+  hidden?: boolean; // if the value is true, it will hide the property field at sandbox properties
 }
 
 export interface EmptyBinding extends BaseBinding {

--- a/src/components/sandbox/ReactSerializer.ts
+++ b/src/components/sandbox/ReactSerializer.ts
@@ -24,6 +24,8 @@ export class ReactSerializer extends BaseSerializer implements Serializer {
     if (this.isDynamic(name)) {
       return this.dynamicProp(name);
     }
+    if (name === "value" && value === "") return `value=""`;
+
     if (value === "") return "";
     return `${name}="${value}"`;
   }

--- a/src/routes/components/Dropdown.tsx
+++ b/src/routes/components/Dropdown.tsx
@@ -234,9 +234,8 @@ export default function DropdownPage() {
   const [color, setColor] = useState<string>("");
 
   function onChange(_name: string, value: string | string[]) {
-    if (typeof value === "string") {
-      setColor(value);
-    }
+    setColor(value as string);
+    setDropdownProps({ ...dropdownProps, value: value as string } as CastingType);
   }
 
   return (
@@ -276,7 +275,7 @@ export default function DropdownPage() {
                 // reactive code
                 import { FormControl } from "@angular/forms";
                 export class MyComponent {
-                  reactiveFormCtrl = new FormControl("");
+                  itemFormCtrl = new FormControl("");
                 }  
               `}
               />
@@ -286,15 +285,14 @@ export default function DropdownPage() {
                 tags="react"
                 allowCopy={true}
                 code={`
-                const [value, setValue] = useState("");
                 function onChange(name: string, value: string | string[]) {
-                  setValue(value);
+                 console.log("onChange", name, value);
                 }
               `}
               />
 
               <GoAFormItem {...formItemProps}>
-                <GoADropdown name="colors" value={color} {...dropdownProps}>
+                <GoADropdown name="item" value={color} {...dropdownProps}>
                   <GoADropdownItem value="red" label="Red" />
                   <GoADropdownItem value="green" label="Green" />
                   <GoADropdownItem value="blue" label="Blue" />

--- a/src/routes/components/FormItemPage.tsx
+++ b/src/routes/components/FormItemPage.tsx
@@ -7,6 +7,7 @@ import {
 import { Category, ComponentHeader } from "@components/component-header/ComponentHeader.tsx";
 import { GoABadge, GoAFormItem, GoAInput, GoATab, GoATabs } from "@abgov/react-components";
 import { ComponentContent } from "@components/component-content/ComponentContent";
+import { CodeSnippet } from "@components/code-snippet/CodeSnippet.tsx";
 
 export default function FormItemPage() {
   const [formItemProps, setFormItemProps] = useState({
@@ -46,6 +47,14 @@ export default function FormItemPage() {
       options: ["", "optional", "required"],
       value: "",
     },
+    {
+      label: "Value",
+      type: "string",
+      name: "value",
+      value: "",
+      hidden: true,
+      dynamic: true,
+    }
   ]);
   const componentProps: ComponentProperty[] = [
     {
@@ -126,8 +135,48 @@ export default function FormItemPage() {
           <GoATab heading="Code examples">
             <h2 id="component" style={{display: "none"}}>Component</h2>
             <Sandbox properties={formItemBindings} onChange={onSandboxChange} flags={["reactive"]}>
+              <CodeSnippet
+                lang="typescript"
+                tags={["angular"]}
+                allowCopy={true}
+                code={`
+                // non-reactive code
+                export class SomeComponent {
+                  value: string = "";
+                  
+                  onChange(event: Event) {
+                    console.log("Event ", event);
+                    console.log("Value ", (event.target as HTMLInputElement).value);
+                  }
+                }
+              `}
+              />
+              <CodeSnippet
+                lang="typescript"
+                tags={["angular", "reactive"]}
+                allowCopy={true}
+                code={`
+                // reactive code
+                export class SomeComponent {
+                  itemFormCtrl = new FormControl("");
+                }
+              `}
+              />
+
+              <CodeSnippet
+                lang="typescript"
+                tags="react"
+                allowCopy={true}
+                code={`
+                const [value, setValue] = useState<string>("");
+              
+                onChange(name: string, value: string) {
+                  setValue(value);
+                }
+              `}/>
+
               <GoAFormItem {...formItemProps}>
-                <GoAInput onChange={noop} value="" name="firstName" />
+                <GoAInput onChange={noop} value="" name="item" />
               </GoAFormItem>
             </Sandbox>
 

--- a/src/routes/components/Radio.tsx
+++ b/src/routes/components/Radio.tsx
@@ -195,18 +195,17 @@ export default function RadioPage() {
                 tags="react"
                 allowCopy={true}
                 code={`
-              const [item, setItem] = useState("1");
               function onChange(name: string, value: string) {
-                setItem(value);
+                console.log("onChange", name, value);
               }
             `}
               />
 
               <GoAFormItem {...formItemProps}>
-                <GoARadioGroup {...radioProps} value="1" onChange={noop}>
-                  <GoARadioItem value="1" label="Label"></GoARadioItem>
-                  <GoARadioItem value="2" label="Label"></GoARadioItem>
-                  <GoARadioItem value="3" label="Label"></GoARadioItem>
+                <GoARadioGroup {...radioProps} name="item" value="1" onChange={noop}>
+                  <GoARadioItem value="1" label="Label 1"></GoARadioItem>
+                  <GoARadioItem value="2" label="Label 2"></GoARadioItem>
+                  <GoARadioItem value="3" label="Label 3"></GoARadioItem>
                 </GoARadioGroup>
               </GoAFormItem>
             </Sandbox>

--- a/src/routes/components/TextArea.tsx
+++ b/src/routes/components/TextArea.tsx
@@ -98,6 +98,14 @@ export default function TextAreaPage() {
       name: "maxCount",
       type: "number",
     },
+    {
+      name: "value",
+      type: "string",
+      value: "",
+      dynamic: true,
+      hidden: true,
+      label: "Value",
+    },
   ]);
   const { formItemBindings, formItemProps, onFormItemChange } = useSandboxFormItem({ label: "Basic" });
   const componentProperties: ComponentProperty[] = [
@@ -235,6 +243,7 @@ export default function TextAreaPage() {
                 code={`
                 // non-reactive code
                 export class SomeComponent {
+                  value: string = "";
                   onChange(event: Event) {
                     // handle change
                     console.log((event as CustomEvent).detail.value);
@@ -257,7 +266,7 @@ export default function TextAreaPage() {
               />
 
               <GoAFormItem {...formItemProps}>
-                <GoATextarea {...componentProps} value="" onChange={noop} />
+                <GoATextarea {...componentProps} width="60ch" name="item" value="" onChange={noop} />
               </GoAFormItem>
             </Sandbox>
 

--- a/src/routes/components/TextField.tsx
+++ b/src/routes/components/TextField.tsx
@@ -42,6 +42,7 @@ export default function TextFieldPage() {
   const [componentProps, setComponentProps] = useState<ComponentPropsType>({
     name: "item",
     value: "",
+    width: "20ch",
     onChange: () => { },
   });
   const [componentBindings, setComponentBindings] = useState<ComponentBinding[]>([
@@ -96,7 +97,6 @@ export default function TextFieldPage() {
       label: "Max length",
       type: "number",
       name: "maxLength",
-      value: 20,
     },
     {
       label: "Disabled",
@@ -116,6 +116,14 @@ export default function TextFieldPage() {
       value: "",
       name: "ariaLabel",
     },
+    {
+      label: "Value",
+      type: "string",
+      name: "value",
+      value: "",
+      hidden: true,
+      dynamic: true,
+    }
   ]);
   const { formItemBindings, formItemProps, onFormItemChange } = useSandboxFormItem({ label: "Basic" });
   const componentProperties: ComponentProperty[] = [
@@ -386,7 +394,6 @@ export default function TextFieldPage() {
 
   // For sandbox demo function
   const noop = () => { };
-
   return (
     <>
       <ComponentHeader
@@ -415,6 +422,7 @@ export default function TextFieldPage() {
                 code={`
                 // non-reactive code
                 export class SomeComponent {
+                  value: string = "";
                   onChange(event: Event) {
                     // handle change
                     console.log((event as CustomEvent).detail.value);
@@ -447,7 +455,7 @@ export default function TextFieldPage() {
               />
 
               <GoAFormItem {...formItemProps}>
-                <GoAInput {...componentProps} onChange={noop} />
+                <GoAInput {...componentProps} name="item" value="" onChange={noop}/>
               </GoAFormItem>
             </Sandbox>
 


### PR DESCRIPTION
Add `value` to input elements's sandbox. 

**Dropdown:** 
Before: 
![image](https://github.com/GovAlta/ui-components-docs/assets/120135417/9fad9e27-1b9c-43b8-bc5a-bc508f9f7c0b)

After:
![image](https://github.com/GovAlta/ui-components-docs/assets/120135417/4cb020f2-620b-4e32-b74c-bcab6584418f)

**Form Item:**
Before: 
![image](https://github.com/GovAlta/ui-components-docs/assets/120135417/b4a8f789-e0bd-406e-8685-2d7023da4e07)

After: 
![image](https://github.com/GovAlta/ui-components-docs/assets/120135417/b90afd8a-c6a7-422a-a17b-913ce1c25f37)

**Input:**
Before: 
![image](https://github.com/GovAlta/ui-components-docs/assets/120135417/5d8b889c-c628-46a1-9191-36c895d146c0)
After: 
![image](https://github.com/GovAlta/ui-components-docs/assets/120135417/ee6a53f9-eef6-497e-8395-5f1b4cec99f3)

**Textarea:**
Before: 
![image](https://github.com/GovAlta/ui-components-docs/assets/120135417/93856cfb-b77a-40cb-b0d4-a78d989e0f6d)

After: 
![image](https://github.com/GovAlta/ui-components-docs/assets/120135417/e42f113b-9afc-449f-9a16-437920d2bbb8)

