### PR TITLE
fix(#1586): fix checkbox docs for angular reactive

### DIFF
--- a/src/components/sandbox/AngularReactiveSerializer.ts
+++ b/src/components/sandbox/AngularReactiveSerializer.ts
@@ -46,7 +46,7 @@ export class AngularReactiveSerializer extends BaseSerializer implements Seriali
 
   stringToProp(name: string, item: string): string {
     if (ReactiveComponents.includes(this.state.element) && name === "value") {
-      return `goaValue [formControl]="${this.state.props.name}FormCtrl" [value]="${this.state.props.name}FormCtrl.value"`;
+      return `goaValue`;
     }
     if (this.isDynamic(name)) {
       return this.#dynamicProp(name);
@@ -69,7 +69,7 @@ export class AngularReactiveSerializer extends BaseSerializer implements Seriali
 
   booleanToProp(propName: string, propValue: boolean): string {
     if (ReactiveComponents.includes(this.state.element) && propName === "checked") {
-      return `goaChecked [formControl]="${this.state.props.name}FormCtrl" [value]="${this.state.props.name}FormCtrl.value"`;
+      return `goaChecked`;
     }
     if (this.isDynamic(propName)) {
       return this.#dynamicProp(propName);
@@ -101,5 +101,32 @@ export class AngularReactiveSerializer extends BaseSerializer implements Seriali
   componentToString(name: string): string {
     name = this.dasherize(name);
     return `<${name} />`;
+  }
+
+  addReactiveProperties(props: string, propName: string): string {
+    const additionalProps = `[formControl]="${propName}FormCtrl" [value]="${propName}FormCtrl.value"`;
+    props = props ? `${props} ${additionalProps}` : additionalProps;
+    return props;
+  }
+
+  modifyProps(props: string, propName: string, elementType: string): string {
+    if (ReactiveComponents.includes(elementType)) {
+      const additionalProps = `[formControl]="${propName}FormCtrl" [value]="${propName}FormCtrl.value"`;
+      props = props ? `${props} ${additionalProps}` : additionalProps;
+    }
+    return props;
+  }
+
+  postProcess (children: string): string {
+    if(children.startsWith('<goa-checkbox')) {
+      if (children.includes('goaChecked') && children.includes('goaValue')) {
+        children = children.replace(/\bgoaValue\b\s?/g, '');
+      }
+
+      if(children.includes('disabled=true')) {
+        children = children.replace(/disabled=true/g, '[attr.disabled]="true"').replace(/\bgoaValue\b\s?/g, ''); 
+      }
+    }
+    return children;
   }
 }

--- a/src/components/sandbox/AngularSerializer.ts
+++ b/src/components/sandbox/AngularSerializer.ts
@@ -83,4 +83,13 @@ export class AngularSerializer extends BaseSerializer implements Serializer {
     name = this.dasherize(name);
     return `<${name} />`;
   }
+  
+  //@ts-ignore
+  modifyProps(props: string, propName: string, elementType: string): string {
+    return props;
+  }
+
+  postProcess (children: string): string {
+    return children;
+  }
 }

--- a/src/components/sandbox/BaseSerializer.ts
+++ b/src/components/sandbox/BaseSerializer.ts
@@ -12,6 +12,8 @@ export interface Serializer {
 
   setIsRoot: (value: boolean) => void;
   setState: (state: SerializerState) => void;
+  modifyProps: (props: string, propName: string, elementType: string) => string;
+  postProcess: (value: string) => string;
 }
 
 export interface SerializerState {
@@ -68,4 +70,6 @@ export class BaseSerializer {
   protected isDynamic(name: string): boolean {
     return this.getProperty(name)?.dynamic || false;
   }
+
+
 }

--- a/src/components/sandbox/ComponentSerializer.ts
+++ b/src/components/sandbox/ComponentSerializer.ts
@@ -85,6 +85,8 @@ export class ComponentSerializer {
       .filter(item => !!item)
       .join(" ");
 
+      props = this.serializer.modifyProps(props, component.props.name, elementType);
+
     // add single space here to ensure only 1 space is added
     if (props.length > 0) {
       props = " " + props;
@@ -113,6 +115,8 @@ export class ComponentSerializer {
     if (component.props["ignore"]) {
       return children;
     }
+
+    children = this.serializer.postProcess(children);
 
     // final output
     return `<${elementType}${props}>\n${indentation}${children}\n${indentation.slice(

--- a/src/components/sandbox/ReactSerializer.ts
+++ b/src/components/sandbox/ReactSerializer.ts
@@ -68,4 +68,13 @@ export class ReactSerializer extends BaseSerializer implements Serializer {
   componentToString(name: string): string {
     return `<${name} />`;
   }
+
+  // @ts-ignore
+  modifyProps(props: string, propName: string, elementType: string): string {
+      return props;
+  }
+
+  postProcess (children: string): string {
+    return children;
+  }
 }

--- a/src/routes/components/Checkbox.tsx
+++ b/src/routes/components/Checkbox.tsx
@@ -102,8 +102,15 @@ export default function CheckboxPage() {
   const noop = () => { };
 
   function onChange(bindings: ComponentBinding[], props: Record<string, unknown>) {
+    const missingProps = {
+      name: "item",
+      checked: false,
+      value: ""
+    };
+    const updatedProps = { ...missingProps, ...props };
+
     setCheckboxBindings(bindings);
-    setCheckboxProps(props as CastingType);
+    setCheckboxProps(updatedProps as CastingType);
   }
 
   return (


### PR DESCRIPTION
For the checkbox documentation, for the code generated for the Reactive Angular section

-Remove the duplication of [formControl] and [value] attributes
-Use [attr.disabled]="true" when disabled is selected
-Prevent disappearing of attributes when properties are changed e.g. description is provided or disabled is selected, etc.


NOTE: (@lizhuomeng71 @ArakTaiRoth  @vanessatran-ddi)
KEEP goaChecked, remove goaValue...Although, the copy code will not work, but based on the discussion with @chrisolsen this is how it should be. 