### PR TITLE
fix(#1803): fix do/don't grids and component content grid

### DIFF
--- a/src/components/component-content/ComponentContent.tsx
+++ b/src/components/component-content/ComponentContent.tsx
@@ -11,7 +11,7 @@ export function ComponentContent({tocCssQuery, contentClassName, children}: Prop
 
   return <>
     <div className="component-content--container">
-      <div style={{ maxWidth: tocCssQuery ? "auto" : "54rem" }} className={`component-content--content ${contentClassName}`}>
+      <div style={{ maxWidth: tocCssQuery ? "auto" : "54rem" }} className={`component-content--content ${contentClassName ? contentClassName: ""}`}>
         {children}
       </div>
       {tocCssQuery && <TOC cssQuery={tocCssQuery} />}

--- a/src/components/component-content/component-content.css
+++ b/src/components/component-content/component-content.css
@@ -1,55 +1,60 @@
 .component-example-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 }
 
 h3[id^="component-example"] {
-    margin-bottom: 0;
+  margin-bottom: 0;
 }
 h3[id^="component-example"]:first-of-type,
 .component-example-header:first-of-type {
-    margin-top: 0;
+  margin-top: 0;
 }
 h3[id^="component-example"]:not(:first-of-type),
 .component-example-header:not(:first-of-type) {
-    margin-top: var(--goa-space-3xl);
+  margin-top: var(--goa-space-3xl);
 }
 
 h3[id^="component-example"] + div.sandbox-render,
 .component-example-header + div.sandbox-render {
-    margin-top: var(--goa-space-m);
+  margin-top: var(--goa-space-m);
 }
 
 /*Other toc heading but not inside component examples*/
 h2[id^="toc"] {
-    margin-top: var(--goa-space-3xl);
-    margin-bottom: 0;
+  margin-top: var(--goa-space-3xl);
+  margin-bottom: 0;
 }
 
 h3[id^="toc"] {
-    margin-top: var(--goa-space-2xl);
-    margin-bottom: var(--goa-space-l);
+  margin-top: var(--goa-space-2xl);
+  margin-bottom: var(--goa-space-l);
 }
 
 goa-details + h2[id^="toc"],
 figure + h2[id^="toc"] {
-    margin-top: var(--goa-space-2xl);
+  margin-top: var(--goa-space-2xl);
 }
 
 h2[id^="toc"] + div,
 h2[id^="toc"] + p,
 h3[id^="toc"] + p {
-    margin-top: var(--goa-space-l);
+  margin-top: var(--goa-space-l);
 }
 
 .component-content--container {
-    display: grid;
-    grid-template-columns: 1fr 12rem;
-    grid-gap: var(--goa-space-2xl);
+  display: grid;
+  grid-template-columns: 1fr 12rem;
+  grid-gap: var(--goa-space-2xl);
+
+  @media screen and (max-width: 1230px) {
+    grid-template-columns: 1fr;
+  }
 }
 
 .component-content--content {
-    flex: 1 1 auto;
-    container: inline-size;
+  flex: 1 1 auto;
+  container: inline-size;
+  min-width: 0;
 }

--- a/src/routes/content/Capitalization.tsx
+++ b/src/routes/content/Capitalization.tsx
@@ -2,6 +2,8 @@ import { GoABlock, GoADivider, GoAFormItem, GoAGrid, GoASideMenu } from "@abgov/
 import { DoDont } from "@components/do-dont/DoDont";
 import { ComponentContent } from "@components/component-content/ComponentContent";
 
+const minGridWidth = "36ch";
+
 export default function CapitalizationPage() {
   return (
     <ComponentContent tocCssQuery="h2[id], h3[id]">
@@ -22,7 +24,7 @@ export default function CapitalizationPage() {
       </p>
 
       <div className="dodont-wrapper">
-        <GoAGrid minChildWidth="50ch" gap="2xl">
+        <GoAGrid minChildWidth={minGridWidth} gap="2xl">
           <DoDont
             type="do"
             description="Always capitalize the first word of a heading or new sentence.">
@@ -67,7 +69,7 @@ export default function CapitalizationPage() {
         it.
       </p>
 
-      <GoAGrid minChildWidth="30ch" gap="2xl" mt="xl">
+      <GoAGrid minChildWidth={minGridWidth} gap="2xl" mt="xl">
         <DoDont
           type="do"
           description="Use title case when words are joined by a slash, capitalize the word after the slash if the word before the slash is capitalized.">
@@ -88,7 +90,7 @@ export default function CapitalizationPage() {
         </DoDont>
       </GoAGrid>
 
-      <GoAGrid minChildWidth="30ch" gap="2xl" mt="2xl" mb="3xl">
+      <GoAGrid minChildWidth={minGridWidth} gap="2xl" mt="2xl" mb="3xl">
         <DoDont
           type="dont"
           description="Don’t use internal capitalization (such as AutoScale or e-Book) unless it’s part of a proper noun.">

--- a/src/routes/content/DateFormat.tsx
+++ b/src/routes/content/DateFormat.tsx
@@ -2,6 +2,8 @@ import { GoACallout, GoAContainer, GoADivider, GoAGrid } from "@abgov/react-comp
 import { DoDont } from "@components/do-dont/DoDont";
 import { ComponentContent } from "@components/component-content/ComponentContent";
 
+const minGridWidth = "36ch";
+
 export default function DateFormatPage() {
   return (
     <ComponentContent tocCssQuery="h2[id], h3[id]">
@@ -50,7 +52,7 @@ export default function DateFormatPage() {
       </p>
 
       <div className="dodont-wrapper">
-        <GoAGrid minChildWidth="30ch" gap="2xl">
+        <GoAGrid minChildWidth={minGridWidth} gap="2xl">
           <DoDont type="do" description="Use the format: Month, cardinal date, year.">
             <div className="example">March 14, 2021</div>
             <div className="example"></div>
@@ -61,7 +63,7 @@ export default function DateFormatPage() {
           </DoDont>
         </GoAGrid>
 
-        <GoAGrid minChildWidth="20ch" gap="2xl" mt="2xl">
+        <GoAGrid minChildWidth={minGridWidth} gap="2xl" mt="2xl">
           <DoDont type="dont" description="Don’t use ordinal numbers with written out month.">
             <div className="example">March 14th, 2021</div>
           </DoDont>
@@ -112,7 +114,7 @@ export default function DateFormatPage() {
       </p>
 
       <div className="dodont-wrapper">
-        <GoAGrid minChildWidth="50ch">
+        <GoAGrid minChildWidth={minGridWidth}>
           <DoDont
             type="do"
             description="Use the same format as the long-form: month, cardinal date, year.">
@@ -120,7 +122,7 @@ export default function DateFormatPage() {
           </DoDont>
         </GoAGrid>
 
-        <GoAGrid minChildWidth="30ch" gap="2xl" mt="2xl">
+        <GoAGrid minChildWidth={minGridWidth} gap="2xl" mt="2xl">
           <DoDont
             type="dont"
             description="Don’t use two digit abbreviations for the year, as this adds confusion and ambiguity.">
@@ -134,9 +136,6 @@ export default function DateFormatPage() {
           <DoDont type="dont" description="Don’t use capital letters for the month abbreviation.">
             <div className="example">MAR 12, 21</div>
           </DoDont>
-        </GoAGrid>
-
-        <GoAGrid minChildWidth="30ch" gap="2xl" mt="2xl">
           <DoDont type="dont" description="Don’t use leading zeros for single date numbers.">
             <div className="example">Mar 07, 21</div>
             <div className="example"></div>
@@ -187,14 +186,14 @@ export default function DateFormatPage() {
       </p>
 
       <div className="dodont-wrapper">
-        <GoAGrid minChildWidth="50ch">
+        <GoAGrid minChildWidth={minGridWidth}>
           <DoDont type="do" description="Use the same format: month, cardinal date, year.">
             <div className="example">Monday, March 14, 2021</div>
             <div className="example">Mon, Mar 14, 2021</div>
           </DoDont>
         </GoAGrid>
 
-        <GoAGrid minChildWidth="30ch" gap="2xl" mt="2xl">
+        <GoAGrid minChildWidth={minGridWidth} gap="2xl" mt="2xl">
           <DoDont type="dont" description="Don’t mix long-form and short-form.">
             <div className="example">Monday, Mar 12, 2021</div>
             <div className="example">Mon, March 12, 2021</div>
@@ -241,14 +240,14 @@ export default function DateFormatPage() {
       </p>
       <p>(e.g., Friday, March 14, 2021 at 2:26 pm)</p>
       <div className="dodont-wrapper">
-        <GoAGrid minChildWidth="50ch">
+        <GoAGrid minChildWidth={minGridWidth}>
           <DoDont
             type="do"
             description="Use the same format: day, month cardinal date, year at XX:XX am/pm">
             <div className="example">Monday, March 14, 2021 at 3:30 pm</div>
           </DoDont>
         </GoAGrid>
-        <GoAGrid minChildWidth="30ch" gap="2xl" mt="2xl">
+        <GoAGrid minChildWidth={minGridWidth} gap="2xl" mt="2xl">
           <DoDont type="dont" description="Don't include a leading zero for the time.">
             <div className="example">08:15 am</div>
           </DoDont>
@@ -256,7 +255,7 @@ export default function DateFormatPage() {
             <div className="example">4:43 p.m.</div>
           </DoDont>
         </GoAGrid>
-        <GoAGrid minChildWidth="50ch" mt="2xl">
+        <GoAGrid minChildWidth={minGridWidth} mt="2xl">
           <DoDont type="dont" description="Don’t write the time before the date.">
             <div className="example">7:55 am on Saturday, May 15, 2021</div>
           </DoDont>
@@ -319,7 +318,7 @@ export default function DateFormatPage() {
       </p>
 
       <div className="dodont-wrapper">
-        <GoAGrid minChildWidth="50ch">
+        <GoAGrid minChildWidth={minGridWidth}>
           <DoDont
             type="generic"
             description="12-month timeline highlighting those that pertain to daylight time.">
@@ -340,7 +339,7 @@ export default function DateFormatPage() {
           </DoDont>
         </GoAGrid>
 
-        <GoAGrid minChildWidth="30ch" gap="2xl" mt="2xl">
+        <GoAGrid minChildWidth={minGridWidth} gap="2xl" mt="2xl">
           <DoDont
             type="do"
             description="Use standard time between the months of November and March.">
@@ -352,7 +351,7 @@ export default function DateFormatPage() {
             <img src="/images/date-dst.png" width="80%"></img>
           </DoDont>
         </GoAGrid>
-        <GoAGrid minChildWidth="50ch" mt="2xl">
+        <GoAGrid minChildWidth={minGridWidth} mt="2xl">
           <DoDont
             type="dont"
             description="Don’t wrap the three-letter abbreviation in parentheses.">

--- a/src/routes/content/ErrorMessages.tsx
+++ b/src/routes/content/ErrorMessages.tsx
@@ -11,6 +11,8 @@ import {
 import { Link } from "react-router-dom";
 import { ComponentContent } from "@components/component-content/ComponentContent";
 
+const minGridWidth = "36ch";
+
 export default function ErrorMessagesPage() {
   const noop = () => { };
   return (
@@ -20,7 +22,7 @@ export default function ErrorMessagesPage() {
 
       <GoADivider mb="2xl" mt="2xl"></GoADivider>
 
-      <GoAGrid minChildWidth="40ch" gap="3xl">
+      <GoAGrid minChildWidth={minGridWidth} gap="3xl">
         <GoAFormItem
           label="First name"
           helpText="Enter your legal name."
@@ -79,7 +81,7 @@ export default function ErrorMessagesPage() {
       </p>
 
       <div className="dodont-wrapper">
-        <GoAGrid minChildWidth="50ch" gap="2xl">
+        <GoAGrid minChildWidth={minGridWidth} gap="2xl">
           <DoDont type="do" description="Place error message above helper text.">
             <img src="/images/error-messages/helper-text-do.png" width="80%"></img>
           </DoDont>
@@ -91,7 +93,7 @@ export default function ErrorMessagesPage() {
 
       <h3>Border</h3>
       <div className="dodont-wrapper">
-        <GoAGrid minChildWidth="50ch" gap="2xl">
+        <GoAGrid minChildWidth={minGridWidth} gap="2xl">
           <DoDont type="do" description="Display input field border in red when there is an error.">
             <img src="/images/error-messages/border-do.png" width="80%"></img>
           </DoDont>
@@ -105,7 +107,7 @@ export default function ErrorMessagesPage() {
 
       <h3>Button/upload area</h3>
       <div className="dodont-wrapper">
-        <GoAGrid minChildWidth="50ch" gap="2xl">
+        <GoAGrid minChildWidth={minGridWidth} gap="2xl">
           <DoDont type="do" description="Display an error message below the upload button.">
             <div style={{ textAlign: "center" }}>
               <img src="/images/error-messages/upload-button-do.png" width="100px"></img>
@@ -166,14 +168,14 @@ export default function ErrorMessagesPage() {
       <p>This error appears when user leaves a required field blank.</p>
 
       <div className="dodont-wrapper">
-        <GoAGrid minChildWidth="50ch">
+        <GoAGrid minChildWidth={minGridWidth}>
           <DoDont type="generic">
             <div style={{ textAlign: "center" }}>
               <img src="/images/error-messages/empty-input.png" width="60%"></img>
             </div>
           </DoDont>
         </GoAGrid>
-        <GoAGrid minChildWidth="50ch" mt="2xl" gap="2xl">
+        <GoAGrid minChildWidth={minGridWidth} mt="2xl" gap="2xl">
           <DoDont
             type="do"
             description="Provide a clear solution for the user to correct the error.">
@@ -208,14 +210,14 @@ export default function ErrorMessagesPage() {
       </p>
 
       <div className="dodont-wrapper">
-        <GoAGrid minChildWidth="50ch" gap="2xl">
+        <GoAGrid minChildWidth={minGridWidth} gap="2xl">
           <DoDont type="generic">
             <div style={{ textAlign: "center" }}>
               <img src="/images/error-messages/incorrect-information.png" width="60%"></img>
             </div>
           </DoDont>
         </GoAGrid>
-        <GoAGrid minChildWidth="50ch" gap="2xl" mt="2xl">
+        <GoAGrid minChildWidth={minGridWidth} gap="2xl" mt="2xl">
           <DoDont type="do" description="Provide a clear positive solution with an example.">
             <div className="example">
               Enter a valid postal code,
@@ -253,14 +255,14 @@ export default function ErrorMessagesPage() {
       </p>
 
       <div className="dodont-wrapper">
-        <GoAGrid minChildWidth="50ch">
+        <GoAGrid minChildWidth={minGridWidth}>
           <DoDont type="generic">
             <div style={{ textAlign: "center" }}>
               <img src="/images/error-messages/error-with-date.png" width="70%"></img>
             </div>
           </DoDont>
         </GoAGrid>
-        <GoAGrid minChildWidth="50ch" gap="2xl" mt="2xl">
+        <GoAGrid minChildWidth={minGridWidth} gap="2xl" mt="2xl">
           <DoDont type="do" description="Provide adequate information.">
             <div className="example">
               The student must be 16 years old or older to be eligible for funding.
@@ -291,14 +293,14 @@ export default function ErrorMessagesPage() {
       <p>This error appears when user fails to input a valid/correct amount.</p>
 
       <div className="dodont-wrapper">
-        <GoAGrid minChildWidth="50ch">
+        <GoAGrid minChildWidth={minGridWidth}>
           <DoDont type="generic" description="*Include amount if known">
             <div style={{ textAlign: "center" }}>
               <img src="/images/error-messages/error-with-range.png" width="60%"></img>
             </div>
           </DoDont>
         </GoAGrid>
-        <GoAGrid minChildWidth="30ch" gap="2xl" mt="2xl">
+        <GoAGrid minChildWidth={minGridWidth} gap="2xl" mt="2xl">
           <DoDont type="do" description="Provide a correct value if it is known.">
             <div className="example">Books and Materials cost must be lower than $4,000.</div>
           </DoDont>
@@ -309,14 +311,14 @@ export default function ErrorMessagesPage() {
       </div>
       <div className="dodont-wrapper">
         <h3 id="error-outside-accepted">Input outside accepted values</h3>
-        <GoAGrid minChildWidth="50ch">
+        <GoAGrid minChildWidth={minGridWidth}>
           <DoDont type="generic">
             <div style={{ textAlign: "center" }}>
               <img src="/images/error-messages/input-outside-expected.png" width="60%"></img>
             </div>
           </DoDont>
         </GoAGrid>
-        <GoAGrid minChildWidth="50ch" gap="2xl" mt="2xl">
+        <GoAGrid minChildWidth={minGridWidth} gap="2xl" mt="2xl">
           <DoDont type="do" description="Give a ranged value when possible.">
             <div className="example">PID must be between 10 and 15 digits.</div>
           </DoDont>
@@ -349,14 +351,14 @@ export default function ErrorMessagesPage() {
 
       <h3 id="wrong-file-type">Wrong file type</h3>
       <div className="dodont-wrapper">
-        <GoAGrid minChildWidth="50ch">
+        <GoAGrid minChildWidth={minGridWidth}>
           <DoDont type="generic">
             <div style={{ textAlign: "center" }}>
               <img src="/images/error-messages/wrong-file-types.png" width="60%"></img>
             </div>
           </DoDont>
         </GoAGrid>
-        <GoAGrid minChildWidth="50ch" gap="2xl" mt="2xl">
+        <GoAGrid minChildWidth={minGridWidth} gap="2xl" mt="2xl">
           <DoDont type="do" description="Provide user with the list of accepted formats.">
             <div className="example">The selected file must be a PDF, JPG, PNG, or TIFF.</div>
           </DoDont>
@@ -371,14 +373,14 @@ export default function ErrorMessagesPage() {
 
       <h3 id="file-too-large">File too large</h3>
       <div className="dodont-wrapper">
-        <GoAGrid minChildWidth="50ch">
+        <GoAGrid minChildWidth={minGridWidth}>
           <DoDont type="generic">
             <div style={{ textAlign: "center" }}>
               <img src="/images/error-messages/file-too-large.png" width="60%"></img>
             </div>
           </DoDont>
         </GoAGrid>
-        <GoAGrid minChildWidth="50ch" gap="2xl" mt="2xl">
+        <GoAGrid minChildWidth={minGridWidth} gap="2xl" mt="2xl">
           <DoDont type="do" description="Provide user with the exact file size limit.">
             <div className="example">The selected file must be less than 5MB.</div>
           </DoDont>
@@ -392,14 +394,14 @@ export default function ErrorMessagesPage() {
 
       <h3 id="upload-failed">File upload failed</h3>
       <div className="dodont-wrapper">
-        <GoAGrid minChildWidth="50ch">
+        <GoAGrid minChildWidth={minGridWidth}>
           <DoDont type="generic">
             <div style={{ textAlign: "center" }}>
               <img src="/images/error-messages/file-upload-failed.png" width="70%"></img>
             </div>
           </DoDont>
         </GoAGrid>
-        <GoAGrid minChildWidth="50ch" gap="2xl" mt="2xl">
+        <GoAGrid minChildWidth={minGridWidth} gap="2xl" mt="2xl">
           <DoDont
             type="do"
             description="Use humanized tone when stating the problem. In this example, the service accepts the responsibility for the failed upload and eases the frustration that user might feel.">
@@ -417,14 +419,14 @@ export default function ErrorMessagesPage() {
 
       <h3 id="duplicate-upload">Duplicate file uploaded</h3>
       <div className="dodont-wrapper">
-        <GoAGrid minChildWidth="50ch">
+        <GoAGrid minChildWidth={minGridWidth}>
           <DoDont type="generic">
             <div style={{ textAlign: "center" }}>
               <img src="/images/error-messages/duplicate-file-upload.png" width="70%"></img>
             </div>
           </DoDont>
         </GoAGrid>
-        <GoAGrid minChildWidth="50ch" gap="2xl" mt="2xl">
+        <GoAGrid minChildWidth={minGridWidth} gap="2xl" mt="2xl">
           <DoDont
             type="do"
             description="State the problem in a clear language and provide a solution as to what action should be taken.">
@@ -442,14 +444,14 @@ export default function ErrorMessagesPage() {
 
       <div className="dodont-wrapper">
         <h3 id="no-file-selected">No file selected</h3>
-        <GoAGrid minChildWidth="50ch">
+        <GoAGrid minChildWidth={minGridWidth}>
           <DoDont type="generic">
             <div style={{ textAlign: "center" }}>
               <img src="/images/error-messages/no-file-selected.png" width="60%"></img>
             </div>
           </DoDont>
         </GoAGrid>
-        <GoAGrid minChildWidth="50ch" gap="2xl" mt="2xl">
+        <GoAGrid minChildWidth={minGridWidth} gap="2xl" mt="2xl">
           <DoDont type="do" description="Provide a clear solution as to what user should do.">
             <div className="example">Upload a work permit.</div>
           </DoDont>
@@ -468,14 +470,14 @@ export default function ErrorMessagesPage() {
       </p>
 
       <div className="dodont-wrapper">
-        <GoAGrid minChildWidth="50ch">
+        <GoAGrid minChildWidth={minGridWidth}>
           <DoDont type="generic">
             <div style={{ textAlign: "center" }}>
               <img src="/images/error-messages/invalid-characters.png" width="60%"></img>
             </div>
           </DoDont>
         </GoAGrid>
-        <GoAGrid minChildWidth="50ch" gap="2xl" mt="2xl">
+        <GoAGrid minChildWidth={minGridWidth} gap="2xl" mt="2xl">
           <DoDont
             type="do"
             description="Display valid characters when possible. This example also conveys the accepted letters case to the users.">
@@ -494,14 +496,14 @@ export default function ErrorMessagesPage() {
 
       <p>When the accepted characters are known, include an example in the error message.</p>
       <div className="dodont-wrapper">
-        <GoAGrid minChildWidth="50ch">
+        <GoAGrid minChildWidth={minGridWidth}>
           <DoDont type="generic" description="*Use “only” when relevant.">
             <div style={{ textAlign: "center" }}>
               <img src="/images/error-messages/invalid-characters-2.png" width="80%"></img>
             </div>
           </DoDont>
         </GoAGrid>
-        <GoAGrid minChildWidth="50ch" gap="2xl" mt="2xl">
+        <GoAGrid minChildWidth={minGridWidth} gap="2xl" mt="2xl">
           <DoDont type="do" description="Provide clear guided solution.">
             <div className="example">
               Alberta Bar ID must include numbers only, such as “12345.”
@@ -517,14 +519,14 @@ export default function ErrorMessagesPage() {
 
       <h3 id="incorrect-number-of-characters">Incorrect number of characters</h3>
       <div className="dodont-wrapper">
-        <GoAGrid minChildWidth="50ch">
+        <GoAGrid minChildWidth={minGridWidth}>
           <DoDont type="generic">
             <div style={{ textAlign: "center" }}>
               <img src="/images/error-messages/invalid-number-of-characters.png" width="60%"></img>
             </div>
           </DoDont>
         </GoAGrid>
-        <GoAGrid minChildWidth="50ch" gap="2xl" mt="2xl">
+        <GoAGrid minChildWidth={minGridWidth} gap="2xl" mt="2xl">
           <DoDont type="do" description="Provide a clear guided solution with context.">
             <div className="example">The Mobius reference number must be 10 digits.</div>
           </DoDont>

--- a/src/routes/content/HelperText.tsx
+++ b/src/routes/content/HelperText.tsx
@@ -12,6 +12,8 @@ import { DoDont } from "@components/do-dont/DoDont";
 import { Link } from "react-router-dom";
 import { ComponentContent } from "@components/component-content/ComponentContent";
 
+const minGridWidth = "36ch";
+
 export default function HelperTextPage() {
   return (
     <ComponentContent tocCssQuery="h2[id], h3[id]">
@@ -45,7 +47,7 @@ export default function HelperTextPage() {
       </GoAContainer>
       <GoADivider mb="2xl" mt="2xl"></GoADivider>
       <h2 id="considerations">Considerations</h2>
-      <p>Consider the following ways to convey more information:</p>
+      <p>Consider the following ways to convey more information:</p>      
       <GoATable width="100%" mb="xl">
         <thead>
           <tr>
@@ -255,7 +257,7 @@ export default function HelperTextPage() {
         </ul>
       </p>
       <div className="dodont-wrapper">
-        <GoAGrid minChildWidth="50ch" gap="2xl">
+        <GoAGrid minChildWidth={minGridWidth} gap="2xl">
           <DoDont
             type="do"
             description="Refer directly to the content in the Text field using words such as This, These, and The when possible.">
@@ -306,7 +308,7 @@ export default function HelperTextPage() {
         </ul>
       </p>
       <div className="dodont-wrapper">
-        <GoAGrid minChildWidth="50ch" gap="2xl">
+        <GoAGrid minChildWidth={minGridWidth} gap="2xl">
           <DoDont
             type="do"
             description="Begin with an Action (Directive Verb) e.g. Search, Start, Select, Find, Deposit; phrasing that follows should briefly describe or summarize directions.">
@@ -351,7 +353,7 @@ export default function HelperTextPage() {
         </ul>
       </p>
       <div className="dodont-wrapper">
-        <GoAGrid minChildWidth="50ch" gap="2xl">
+        <GoAGrid minChildWidth={minGridWidth} gap="2xl">
           <DoDont type="do" description="Be specific about the information you are asking for.">
             <div style={{ textAlign: "center" }}>
               <img src="/images/helper-text/restrictive-do-1.png" width="80%"></img>
@@ -385,7 +387,7 @@ export default function HelperTextPage() {
         punctuation.
       </p>
       <div className="dodont-wrapper">
-        <GoAGrid gap="2xl" minChildWidth="50ch">
+        <GoAGrid gap="2xl" minChildWidth={minGridWidth}>
           <DoDont
             type="do"
             description="Use sentence case with no punctuation at the end of the helper text.">


### PR DESCRIPTION
This PR addresses the issues identified in https://github.com/GovAlta/ui-components/issues/1803. It makes the following changes:

- Reduces the minimum grid width of the "Do &  Don't" columns from `50ch` to `36ch`
- Swiches the `ComponentContent` grid to a single column when the table of contents disappears below `1230px` width.
- Adds a `min-width` of 0 to `.component-content--content`. This prevents wider content from [growing the column width past the available space](https://css-tricks.com/preventing-a-grid-blowout/).
- Fixes an `undefined` class name in `ComponentContent`

I determined that `36ch` is the maximum width at `642px` without overflowing the content area.

<img width="653" alt="image" src="https://github.com/GovAlta/ui-components-docs/assets/1479091/f75a1fec-8fef-4bda-8614-1180f6e77360">

The header-related issues are captured in this other ticket: https://github.com/GovAlta/ui-components/issues/1438

Checklist:
- [x] I have run a build locally.
- [x] I have tested the functionality.