### PR TITLE
feat(#1816): width property for container

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "code-sandbox",
       "version": "0.0.0",
       "dependencies": {
-        "@abgov/react-components": "4.17.0-alpha.25",
-        "@abgov/web-components": "1.17.0-alpha.51",
+        "@abgov/react-components": "4.17.0-alpha.26",
+        "@abgov/web-components": "1.17.0-alpha.53",
         "@faker-js/faker": "^8.3.1",
         "highlight.js": "^11.8.0",
         "react": "^18.2.0",
@@ -41,9 +41,9 @@
       }
     },
     "node_modules/@abgov/react-components": {
-      "version": "4.17.0-alpha.25",
-      "resolved": "https://registry.npmjs.org/@abgov/react-components/-/react-components-4.17.0-alpha.25.tgz",
-      "integrity": "sha512-mpWGjXjHxQe78JzxDu7Z134P+RTMZkuLGZo132ayKJUU+vdxHivJ7Szan8/OA9dOvxoeQhzEURjM+e3MXVFODQ==",
+      "version": "4.17.0-alpha.26",
+      "resolved": "https://registry.npmjs.org/@abgov/react-components/-/react-components-4.17.0-alpha.26.tgz",
+      "integrity": "sha512-oeYY6Lbzpt/cAklP7YXAmo7CY+g7SBgoC0vm2FQ5wb9NKN2zFSIwhh2zdrJF8vramCZ2KDXk2N54pu4yOuB1dw==",
       "peerDependencies": {
         "@types/react": "^17.0.0 || ^18.0.0",
         "react": "^17.0.0 || ^18.0.0",
@@ -51,9 +51,9 @@
       }
     },
     "node_modules/@abgov/web-components": {
-      "version": "1.17.0-alpha.51",
-      "resolved": "https://registry.npmjs.org/@abgov/web-components/-/web-components-1.17.0-alpha.51.tgz",
-      "integrity": "sha512-A1/T4uAyq2GVfsLRHiS/aau39nPcViZ3/DeuyV96elTRHdlXq7BUOLGA/hDQAW1rmTSeu+TyNjzz2qqfzgymuQ==",
+      "version": "1.17.0-alpha.53",
+      "resolved": "https://registry.npmjs.org/@abgov/web-components/-/web-components-1.17.0-alpha.53.tgz",
+      "integrity": "sha512-8RhGhHPeJYhopGOAbgonlLa+etSzIQNbJ9JzHLbcy7YgnNsaju4gvICoaQyIIEEgZ/4Wrz4osl3pwf3DiEt5vQ==",
       "peerDependencies": {
         "@sveltejs/vite-plugin-svelte": "3.x",
         "glob": "10.x",

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "prettier": "npx prettier . --write"
   },
   "dependencies": {
-    "@abgov/react-components": "4.17.0-alpha.25",
-    "@abgov/web-components": "1.17.0-alpha.51",
+    "@abgov/react-components": "4.17.0-alpha.26",
+    "@abgov/web-components": "1.17.0-alpha.53",
     "@faker-js/faker": "^8.3.1",
     "highlight.js": "^11.8.0",
     "react": "^18.2.0",

--- a/src/routes/components/Container.tsx
+++ b/src/routes/components/Container.tsx
@@ -56,39 +56,53 @@ export default function ContainerPage() {
       value: "relaxed",
       defaultValue: "relaxed",
     },
+    {
+      label: "Width",
+      type: "radio",
+      name: "width",
+      options: ["full", "content"],
+      value: "full",
+      defaultValue: "full"
+    }
   ]);
 
   const componentProperties: ComponentProperty[] = [
     {
       name: "type",
       type: "interactive | info | error | success | important | non-interactive",
-      description: "Choose the type of container the type of the accent bar",
+      description: "Sets the container and accent bar styling.",
       defaultValue: "interactive",
     },
     {
       name: "accent",
       type: "thick | thin | filled",
       defaultValue: "filled",
-      description: "Sets the style of accent on the container",
+      description: "Sets the style of accent on the container.",
     },
     {
       name: "padding",
       type: "relaxed | compact",
       defaultValue: "relaxed",
-      description: "Sets the amount of white space in the container",
+      description: "Sets the amount of white space in the container.",
     },
     {
       name: "title",
       type: "slot",
       description:
-        "Sets the content in the left of the accent bar. To only beused along with accent=thick.",
+        "Sets the content in the left of the accent bar. Can only be used with accent=thick.",
     },
     {
       name: "actions",
       type: "slot",
       description:
-        "Sets the content in the right of the accent bar. To only be used along with accent=thick.",
+        "Sets the content in the right of the accent bar. Can only be used with accent=thick.",
     },
+    {
+      name: "width",
+      type: "full | content",
+      defaultValue: "full",
+      description: "Sets the width of the container."
+    }
   ];
 
   function onSandboxChange(bindings: ComponentBinding[], props: Record<string, unknown>) {


### PR DESCRIPTION
This PR documents the change from PR https://github.com/GovAlta/ui-components/pull/1851 for issue https://github.com/GovAlta/ui-components/issues/1816. It includes the following changes:

- Adds `Width` property to container playground
- Adds `Width` property description
- Fixes punctuation and spelling for other container property descriptions.

![container-width](https://github.com/GovAlta/ui-components-docs/assets/1479091/e0108eb3-e187-4c92-bd5c-0add605d3dad)