### PR TITLE
fix(#1605): document additional icon properties

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "code-sandbox",
       "version": "0.0.0",
       "dependencies": {
-        "@abgov/react-components": "4.17.0-alpha.26",
-        "@abgov/web-components": "1.17.0-alpha.53",
+        "@abgov/react-components": "4.17.0-alpha.29",
+        "@abgov/web-components": "1.17.0-alpha.61",
         "@faker-js/faker": "^8.3.1",
         "highlight.js": "^11.8.0",
         "react": "^18.2.0",
@@ -41,9 +41,9 @@
       }
     },
     "node_modules/@abgov/react-components": {
-      "version": "4.17.0-alpha.26",
-      "resolved": "https://registry.npmjs.org/@abgov/react-components/-/react-components-4.17.0-alpha.26.tgz",
-      "integrity": "sha512-oeYY6Lbzpt/cAklP7YXAmo7CY+g7SBgoC0vm2FQ5wb9NKN2zFSIwhh2zdrJF8vramCZ2KDXk2N54pu4yOuB1dw==",
+      "version": "4.17.0-alpha.29",
+      "resolved": "https://registry.npmjs.org/@abgov/react-components/-/react-components-4.17.0-alpha.29.tgz",
+      "integrity": "sha512-0K35mXm63DzcGV9o+4/5zsSF5WNWyycXouTxF93XcId9tdovk2iI5/wC9p7PtkN8cWyvhR5oJJI+MPqyICxNEQ==",
       "peerDependencies": {
         "@types/react": "^17.0.0 || ^18.0.0",
         "react": "^17.0.0 || ^18.0.0",
@@ -51,9 +51,9 @@
       }
     },
     "node_modules/@abgov/web-components": {
-      "version": "1.17.0-alpha.53",
-      "resolved": "https://registry.npmjs.org/@abgov/web-components/-/web-components-1.17.0-alpha.53.tgz",
-      "integrity": "sha512-8RhGhHPeJYhopGOAbgonlLa+etSzIQNbJ9JzHLbcy7YgnNsaju4gvICoaQyIIEEgZ/4Wrz4osl3pwf3DiEt5vQ==",
+      "version": "1.17.0-alpha.61",
+      "resolved": "https://registry.npmjs.org/@abgov/web-components/-/web-components-1.17.0-alpha.61.tgz",
+      "integrity": "sha512-utTXwyoXRWEumhnXjRmjFBJhZ7UyQDZfL/YfRUTHuqTHrSth5auQi/bM4KNaY7F2yjXupOaFfLXbfPbarFRONg==",
       "peerDependencies": {
         "@sveltejs/vite-plugin-svelte": "3.x",
         "glob": "10.x",

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "prettier": "npx prettier . --write"
   },
   "dependencies": {
-    "@abgov/react-components": "4.17.0-alpha.26",
-    "@abgov/web-components": "1.17.0-alpha.53",
+    "@abgov/react-components": "4.17.0-alpha.29",
+    "@abgov/web-components": "1.17.0-alpha.61",
     "@faker-js/faker": "^8.3.1",
     "highlight.js": "^11.8.0",
     "react": "^18.2.0",

--- a/src/routes/components/Icons.tsx
+++ b/src/routes/components/Icons.tsx
@@ -38,26 +38,99 @@ export default function IconsPage() {
       value: "",
       defaultValue: "outline",
     },
+    {
+      label: "Opacity",
+      type: "number",
+      name: "opacity",
+      value: 1,
+    },    
+    {
+      label: "Fill Color",
+      type: "string",
+      name: "fillColor",
+      value: "",
+    },
+    {
+      label: "Inverted",
+      type: "boolean",
+      name: "inverted",
+      value: false,
+    },
+    {
+      label: "Title",
+      type: "string",
+      name: "title",
+      value: "",
+    },    
+    {
+      label: "ARIA Label",
+      type: "string",
+      name: "ariaLabel",
+      value: "",
+    },
   ]);
   const componentProperties: ComponentProperty[] = [
     {
       name: "type",
       type: "GoAIconType",
-      description: "Set the icon",
+      description: "Sets the icon.",
       required: true,
     },
     {
       name: "size",
       type: "small | medium | large",
-      description: "Set the size of icon",
+      description: "Sets the size of icon.",
       defaultValue: "medium",
     },
     {
       name: "theme",
       type: "outline | filled",
-      description: "Style this icon to show outline, or filled",
+      description: "Styles the icon to show outline or filled.",
       defaultValue: "outline",
     },
+    {
+      name: "opacity",
+      type: "number",
+      description: "Sets the opacity of the icon between 0 and 1.",
+      defaultValue: "1",
+    },
+    {
+      name: "fillcolor",
+      type: "string",
+      lang: "angular",
+      description: "Sets the fill colour of the icon.",
+      defaultValue: "false",
+    },
+    {
+      name: "fillColor",
+      type: "string",
+      lang: "react",
+      description: "Sets the fill colour of the icon.",
+      defaultValue: "false",
+    },
+    {
+      name: "inverted",
+      type: "boolean",
+      description: "Colors the icon white for use on dark backgrounds.",
+      defaultValue: "false",
+    },
+    {
+      name: "title",
+      type: "string",
+      description: "Sets the title of the icon.",
+    },
+    {
+      name: "arialabel",
+      type: "string",
+      lang: "angular",
+      description: "Sets the accessible name of the icon.",
+    },
+    {
+      name: "ariaLabel",
+      type: "string",
+      lang: "react",
+      description: "Sets the accessible name of the icon.",
+    },    
   ];
 
   function onSandboxChange(iconsBindings: ComponentBinding[], props: Record<string, unknown>) {


### PR DESCRIPTION
This PR documents the following properties on the `icon` component:
- opacity
- fill colour
- inverted
- title
- aria label

It also adds controls for the above properties to the sandbox:
![image](https://github.com/GovAlta/ui-components-docs/assets/1479091/d0e059bc-af24-4db3-9c82-40af13e042d8)
