### PR TITLE
chore(#1867): block - add normal to alignment

### DIFF
--- a/src/routes/components/Block.tsx
+++ b/src/routes/components/Block.tsx
@@ -31,7 +31,7 @@ export default function BlockPage() {
       label: "Alignment",
       type: "list",
       name: "alignment",
-      options: ["", "center", "start", "end"],
+      options: ["", "center", "start", "end", "normal"],
       value: "",
       defaultValue: "start",
     },
@@ -52,9 +52,9 @@ export default function BlockPage() {
     },
     {
       name: "alignment",
-      type: "center | start | end",
+      type: "center | start | end | normal",
       description: "Primary axis alignment",
-      defaultValue: "start",
+      defaultValue: "normal",
     },
   ];
 


### PR DESCRIPTION
Following #1983 pull request https://github.com/GovAlta/ui-components/pull/1893
(Will be ready to test once PR 1983 is merged to alpha)

Adding a new alignment value "normal"

<img width="914" alt="image" src="https://github.com/GovAlta/ui-components-docs/assets/120135417/fd649992-a2cc-470a-9f7c-99add3b6cfb9">

<img width="1073" alt="image" src="https://github.com/GovAlta/ui-components-docs/assets/120135417/b5119696-8fab-476c-a1f8-e87ee529460c">
