### PR TITLE
chore(#1713): add maxWidth to Popover properties table

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "code-sandbox",
       "version": "0.0.0",
       "dependencies": {
-        "@abgov/react-components": "4.21.0",
-        "@abgov/web-components": "1.21.0",
+        "@abgov/react-components": "4.17.0-alpha.31",
+        "@abgov/web-components": "1.17.0-alpha.68",
         "@faker-js/faker": "^8.3.1",
         "highlight.js": "^11.8.0",
         "react": "^18.2.0",
@@ -41,9 +41,9 @@
       }
     },
     "node_modules/@abgov/react-components": {
-      "version": "4.21.0",
-      "resolved": "https://registry.npmjs.org/@abgov/react-components/-/react-components-4.21.0.tgz",
-      "integrity": "sha512-3+PK0DD0MFHo12yubDXXHoEIp6CDOsvf75VXu/+pvAUujmaN7EZ5NVZoRskK0aN/X+T4XkswJhlp1rWShrNBrg==",
+      "version": "4.17.0-alpha.31",
+      "resolved": "https://registry.npmjs.org/@abgov/react-components/-/react-components-4.17.0-alpha.31.tgz",
+      "integrity": "sha512-bUVYZb1tDzIwlSApeuCh2NSpW51IRE2GUYeK6tUTwD4y8k41HW0mB3wfF9IclG/cY/UMDqPFyFupuG8nWWGeAg==",
       "peerDependencies": {
         "@types/react": "^17.0.0 || ^18.0.0",
         "react": "^17.0.0 || ^18.0.0",
@@ -51,9 +51,9 @@
       }
     },
     "node_modules/@abgov/web-components": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/@abgov/web-components/-/web-components-1.21.0.tgz",
-      "integrity": "sha512-dDQDU1dF8AKeKIZvH4NJkSK1uSC+CSjwVZaeg8n4j9yzg0vQjknbArc0wATR4I2xImATmcu2gM4IjTOEk/B7FQ==",
+      "version": "1.17.0-alpha.68",
+      "resolved": "https://registry.npmjs.org/@abgov/web-components/-/web-components-1.17.0-alpha.68.tgz",
+      "integrity": "sha512-zedbWLEyZaNsBSQDUeIB0L6KL/a9bOjYuzrPJ/zcXEceaNBhYiYvzL4o6o/Hx3xFftPOImID32fZq1HUDMWZAA==",
       "peerDependencies": {
         "@sveltejs/vite-plugin-svelte": "3.x",
         "glob": "10.x",

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "prettier": "npx prettier . --write"
   },
   "dependencies": {
-    "@abgov/react-components": "4.21.0",
-    "@abgov/web-components": "1.21.0",
+    "@abgov/react-components": "4.17.0-alpha.31",
+    "@abgov/web-components": "1.17.0-alpha.68",
     "@faker-js/faker": "^8.3.1",
     "highlight.js": "^11.8.0",
     "react": "^18.2.0",

--- a/src/routes/components/Popover.tsx
+++ b/src/routes/components/Popover.tsx
@@ -20,6 +20,12 @@ export default function PopoverPage() {
       value: "",
     },
     {
+      label: "Min Width",
+      type: "string",
+      name: "minWidth",
+      value: "",
+    },
+    {
       label: "Position",
       type: "list",
       name: "position",
@@ -38,7 +44,7 @@ export default function PopoverPage() {
     {
       name: "maxWidth",
       type: "string",
-      description: "The maxwidth of the popover container",
+      description: "The max width of the popover container",
       defaultValue: "320px",
       lang: "react",
     },
@@ -47,6 +53,18 @@ export default function PopoverPage() {
       type: "string",
       description: "The maxwidth of the popover container",
       defaultValue: "320px",
+      lang: "angular",
+    },
+    {
+      name: "minWidth",
+      type: "string",
+      description: "The min width of the popover container",
+      lang: "react",
+    },
+    {
+      name: "minwidth",
+      type: "string",
+      description: "The min width of the popover container",
       lang: "angular",
     },
     {


### PR DESCRIPTION
Following issue #1713 https://github.com/GovAlta/ui-components/issues/1713 and document it, add `minWidth` for Popover component.