### PR TITLE
feat(#1797): document max width on components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "code-sandbox",
       "version": "0.0.0",
       "dependencies": {
-        "@abgov/react-components": "4.22.0",
-        "@abgov/web-components": "1.23.1",
+        "@abgov/react-components": "4.17.0-alpha.34",
+        "@abgov/web-components": "1.17.0-alpha.88",
         "@faker-js/faker": "^8.3.1",
         "highlight.js": "^11.8.0",
         "react": "^18.2.0",
@@ -41,9 +41,9 @@
       }
     },
     "node_modules/@abgov/react-components": {
-      "version": "4.22.0",
-      "resolved": "https://registry.npmjs.org/@abgov/react-components/-/react-components-4.22.0.tgz",
-      "integrity": "sha512-VComCKY+j9kIkKLEUMyMOmdiO4GjBxV3sWuwmMMh9eNuP6Js+CLqg087AHWOzpsNGtcgIZRSAuEXBLQmyWvkcQ==",
+      "version": "4.17.0-alpha.34",
+      "resolved": "https://registry.npmjs.org/@abgov/react-components/-/react-components-4.17.0-alpha.34.tgz",
+      "integrity": "sha512-+xJ/CBRZOiYgCIefwYDO+Y8JFoiz7HFAMSs5yR11ys3H0IOqhF563faizzHFwUvYnXFmEnFFwaUx2InhPbIoLQ==",
       "peerDependencies": {
         "@types/react": "^17.0.0 || ^18.0.0",
         "react": "^17.0.0 || ^18.0.0",
@@ -51,9 +51,9 @@
       }
     },
     "node_modules/@abgov/web-components": {
-      "version": "1.23.1",
-      "resolved": "https://registry.npmjs.org/@abgov/web-components/-/web-components-1.23.1.tgz",
-      "integrity": "sha512-vSVbKqfkZPg6gdSAwuYrT2m4LAKJjaUoOg1RrarSoc65rhWLm4yVC/VQTY7z0hUOn+kjOTdLw25eE6LLmMYFYA==",
+      "version": "1.17.0-alpha.88",
+      "resolved": "https://registry.npmjs.org/@abgov/web-components/-/web-components-1.17.0-alpha.88.tgz",
+      "integrity": "sha512-D0WFuBEZFbuW5zLCooRs9sLbuqky9SbH7hSTWeeNFvmTwzThHPeZA660PWCpruGwjqZHaUO1g4trUYGMS76teg==",
       "peerDependencies": {
         "@sveltejs/vite-plugin-svelte": "3.x",
         "glob": "10.x",

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "prettier": "npx prettier . --write"
   },
   "dependencies": {
-    "@abgov/react-components": "4.22.0",
-    "@abgov/web-components": "1.23.1",
+    "@abgov/react-components": "4.17.0-alpha.34",
+    "@abgov/web-components": "1.17.0-alpha.88",
     "@faker-js/faker": "^8.3.1",
     "highlight.js": "^11.8.0",
     "react": "^18.2.0",

--- a/src/routes/components/Accordion.tsx
+++ b/src/routes/components/Accordion.tsx
@@ -61,8 +61,19 @@ export default function AccordionPage() {
       requirement: "optional",
       value: "",
     },
-
-    { label: "Open", type: "boolean", name: "open", value: false },
+    {
+      label: "Open",
+      type: "boolean",
+      name: "open", 
+      value: false
+    },
+    {
+      label: "Max Width",
+      type: "string",
+      name: "maxWidth",
+      requirement: "optional",
+      value: "",
+    },
   ]);
 
   const componentProperties: ComponentProperty[] = [
@@ -115,6 +126,18 @@ export default function AccordionPage() {
       type: "slot",
       lang: "angular",
       description: "Add components to the accordion container heading such as badges.",
+    },
+    {
+      name: "maxWidth",
+      type: "string",
+      description: "Sets the maximum width of the accordion.",
+      lang: "react",
+    },
+    {
+      name: "maxwidth",
+      type: "string",
+      description: "Sets the maximum width of the accordion.",
+      lang: "angular",
     },
     {
       name: "testId",

--- a/src/routes/components/Callout.tsx
+++ b/src/routes/components/Callout.tsx
@@ -57,6 +57,13 @@ export default function CalloutPage() {
       options: ["", "medium", "large"],
       value: "",
     },
+    {
+      label: "Max Width",
+      type: "string",
+      name: "maxWidth",
+      requirement: "optional",
+      value: "",
+    },    
   ]);
 
   const componentProperties: ComponentProperty[] = [
@@ -77,6 +84,18 @@ export default function CalloutPage() {
       defaultValue: "large",
       description:
         "The medium callout has reduced padding and type size to adjust for a compact area and smaller viewport width when a smaller size is required.",
+    },
+    {
+      name: "maxWidth",
+      type: "string",
+      description: "Sets the maximum width of the callout.",
+      lang: "react",
+    },
+    {
+      name: "maxwidth",
+      type: "string",
+      description: "Sets the maximum width of the callout.",
+      lang: "angular",
     },
     {
       name: "testId",

--- a/src/routes/components/Checkbox.tsx
+++ b/src/routes/components/Checkbox.tsx
@@ -39,6 +39,13 @@ export default function CheckboxPage() {
     { label: "Disabled", type: "boolean", name: "disabled", value: false },
     { label: "Error", type: "boolean", name: "error", value: false },
     { label: "ARIA label", type: "string", name: "ariaLabel", value: "" },
+    {
+      label: "Max Width",
+      type: "string",
+      name: "maxWidth",
+      requirement: "optional",
+      value: "",
+    },
   ]);
   const { formItemBindings, formItemProps, onFormItemChange } = useSandboxFormItem({
     label: "Basic",
@@ -111,6 +118,18 @@ export default function CheckboxPage() {
       type: "(name: string, checked: boolean, value: string) => void",
       description: "Callback function when checkbox value is changed.",
       lang: "react"
+    },
+    {
+      name: "maxWidth",
+      type: "string",
+      description: "Sets the maximum width of the checkbox.",
+      lang: "react",
+    },
+    {
+      name: "maxwidth",
+      type: "string",
+      description: "Sets the maximum width of the checkbox.",
+      lang: "angular",
     },
     {
       name: "testId",

--- a/src/routes/components/Container.tsx
+++ b/src/routes/components/Container.tsx
@@ -63,7 +63,14 @@ export default function ContainerPage() {
       options: ["full", "content"],
       value: "full",
       defaultValue: "full"
-    }
+    },
+    {
+      label: "Max Width",
+      type: "string",
+      name: "maxWidth",
+      requirement: "optional",
+      value: "",
+    },
   ]);
 
   const componentProperties: ComponentProperty[] = [
@@ -103,6 +110,18 @@ export default function ContainerPage() {
       defaultValue: "full",
       description: "Sets the width of the container."
     },
+    {
+      name: "maxWidth",
+      type: "string",
+      description: "Sets the maximum width of the container.",
+      lang: "react",
+    },
+    {
+      name: "maxwidth",
+      type: "string",
+      description: "Sets the maximum width of the container.",
+      lang: "angular",
+    },    
     {
       name: "testId",
       type: "string",

--- a/src/routes/components/Details.tsx
+++ b/src/routes/components/Details.tsx
@@ -29,6 +29,13 @@ export default function DetailsPage() {
       name: "heading",
       value: "Detail Heading",
     },
+    {
+      label: "Max Width",
+      type: "string",
+      name: "maxWidth",
+      requirement: "optional",
+      value: "",
+    },    
   ]);
 
   const componentProperties: ComponentProperty[] = [
@@ -44,6 +51,18 @@ export default function DetailsPage() {
       description: "Controls if details is expanded or not",
       defaultValue: "false",
     },
+    {
+      name: "maxWidth",
+      type: "string",
+      description: "Sets the maximum width of the details.",
+      lang: "react",
+    },
+    {
+      name: "maxwidth",
+      type: "string",
+      description: "Sets the maximum width of the details.",
+      lang: "angular",
+    },    
   ];
 
   function onSandboxChange(bindings: ComponentBinding[], props: Record<string, unknown>) {

--- a/src/routes/components/FormItemPage.tsx
+++ b/src/routes/components/FormItemPage.tsx
@@ -59,7 +59,14 @@ export default function FormItemPage() {
       value: "",
       hidden: true,
       dynamic: true,
-    }
+    },
+    {
+      label: "Max Width",
+      type: "string",
+      name: "maxWidth",
+      requirement: "optional",
+      value: "",
+    },
   ]);
   const componentProps: ComponentProperty[] = [
     {
@@ -116,6 +123,18 @@ export default function FormItemPage() {
       description:
         "The id of the label, necessary for field's aria-labelledby attribute for the screen reader.",
     },
+    {
+      name: "maxWidth",
+      type: "string",
+      description: "Sets the maximum width of the form item.",
+      lang: "react",
+    },
+    {
+      name: "maxwidth",
+      type: "string",
+      description: "Sets the maximum width of the form item.",
+      lang: "angular",
+    },    
     {
       name: "testId",
       type: "string",

--- a/src/routes/components/Popover.tsx
+++ b/src/routes/components/Popover.tsx
@@ -44,27 +44,27 @@ export default function PopoverPage() {
     {
       name: "maxWidth",
       type: "string",
-      description: "The max width of the popover container",
+      description: "Sets the maximum width of the popover container.",
       defaultValue: "320px",
       lang: "react",
     },
     {
       name: "maxwidth",
       type: "string",
-      description: "Sets the max width of the popover container.",
+      description: "Sets the maximum width of the popover container.",
       defaultValue: "320px",
       lang: "angular",
     },
     {
       name: "minWidth",
       type: "string",
-      description: "The min width of the popover container",
+      description: "Sets the minimum width of the popover container.",
       lang: "react",
     },
     {
       name: "minwidth",
       type: "string",
-      description: "The min width of the popover container",
+      description: "Sets the minimum width of the popover container.",
       lang: "angular",
     },
     {

--- a/src/routes/components/Radio.tsx
+++ b/src/routes/components/Radio.tsx
@@ -62,6 +62,13 @@ export default function RadioPage() {
       value: false,
     },
     {
+      label: "Max Width",
+      type: "string",
+      name: "maxWidth",
+      requirement: "optional",
+      value: "",
+    },
+    {
       label: "ARIA Label",
       name: "ariaLabel",
       type: "string",
@@ -159,6 +166,18 @@ export default function RadioPage() {
       type: "string | ReactNode",
       description: "Additional content shown below the label.",
       lang: "react",
+    },
+    {
+      name: "maxWidth",
+      type: "string",
+      description: "Sets the maximum width of the radio.",
+      lang: "react",
+    },
+    {
+      name: "maxwidth",
+      type: "string",
+      description: "Sets the maximum width of the radio.",
+      lang: "angular",
     },
     {
       name: "arialabel",


### PR DESCRIPTION
Documents the `maxwidth` property added to the following components:

- Accordion
- Callout
- Checkbox
- Container
- Details
- Form item
- Radio item

This documents the changes from https://github.com/GovAlta/ui-components/pull/1956.