### PR TITLE
fix(#2026): Remove mobile h3 CSS

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -101,10 +101,3 @@ code.inline {
     margin: 0;
   }
 }
-
-/*Mobile*/
-@media screen and (max-width: 623px) {
-  h3 {
-    font: var(--goa-typography-body-m);
-  }
-}


### PR DESCRIPTION
`<h3>` tags on the website should now continue to use the proper font style, `--goa-typography-heading-m` even in mobile.