### PR TITLE
fix(#1797): remove radio maxwidth sandbox and add example

### DIFF
--- a/src/examples/radio/RadioExamples.tsx
+++ b/src/examples/radio/RadioExamples.tsx
@@ -4,11 +4,11 @@ import { CodeSnippet } from "@components/code-snippet/CodeSnippet.tsx";
 
 const noop = () => { };
 
-export default function CheckboxExamples () {
+export default function RadioExamples () {
   return (
     <>      
       <h2 id="component-examples" className="hidden" aria-hidden="true">Examples</h2>
-      <h3 id="component-example-expand-collapse-form">Use tags in the description</h3>
+      <h3 id="component-example-use-tags-in-description">Use tags in the description</h3>
       <Sandbox fullWidth skipRender>
         {/*Angular*/}
         <CodeSnippet
@@ -52,6 +52,58 @@ export default function CheckboxExamples () {
                 value="1"
                 label="Option one"
                 description={<span>Help text with a <a href="#">link</a>.</span>}
+                />
+            <GoARadioItem value="2" label="Option two" />
+            <GoARadioItem value="3" label="Option three" />
+          </GoARadioGroup>
+        </GoAFormItem>        
+      </Sandbox>
+      <h3 id="component-example-max-width">Radio item with max width</h3>
+      <Sandbox fullWidth skipRender>
+         {/*Angular*/}
+         <CodeSnippet
+        lang="typescript"
+        tags="angular"
+        allowCopy={true}
+        code={`
+              <goa-form-item label="Select one option">
+              <goa-radio-group name="selectOne" value="1" (_change)="onChange($event)">
+                <goa-radio-item
+                  value="1"
+                  label="Option one which has a very long label with lots of text"
+                  maxwidth="300px"
+                />
+                <goa-radio-item value="2" label="Option two" />
+                <goa-radio-item value="3" label="Option three" />
+              </goa-radio-group>
+            </goa-form-item>     
+            `}
+        />
+        {/*React*/}
+        <CodeSnippet
+        lang="typescript"
+        tags="react"
+        allowCopy={true}
+        code={`
+            <GoAFormItem label="Select one option">
+              <GoARadioGroup name="selectOne" value="1" onChange={onChange}>
+                <GoARadioItem
+                    value="1"
+                    label="Option one which has a very long label with lots of text"
+                    maxWidth="300px"
+                    />
+                <GoARadioItem value="2" label="Option two" />
+                <GoARadioItem value="3" label="Option three" />
+              </GoARadioGroup>
+            </GoAFormItem> 
+            `}
+        />
+        <GoAFormItem label="Select one option">
+          <GoARadioGroup name="selectOne" value="1" onChange={noop}>
+            <GoARadioItem
+                value="1"
+                label="Option one which has a very long label with lots of text"
+                maxWidth="300px"
                 />
             <GoARadioItem value="2" label="Option two" />
             <GoARadioItem value="3" label="Option three" />

--- a/src/routes/components/Radio.tsx
+++ b/src/routes/components/Radio.tsx
@@ -62,13 +62,6 @@ export default function RadioPage() {
       value: false,
     },
     {
-      label: "Max Width",
-      type: "string",
-      name: "maxWidth",
-      requirement: "optional",
-      value: "",
-    },
-    {
       label: "ARIA Label",
       name: "ariaLabel",
       type: "string",


### PR DESCRIPTION
This PR makes the following changes:
1. Removes the `maxwidth` from the sandbox. The sandbox is for the radio group, not individual radio items.
2. Adds an example with `maxwidth` on a radio item.
  ![image](https://github.com/user-attachments/assets/773d8188-3499-4b68-8034-5c4f8b4d6edb)
