### PR TITLE
feat(#2080): Added icon theme prop to Chip component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "code-sandbox",
       "version": "0.0.0",
       "dependencies": {
-        "@abgov/react-components": "4.17.0-alpha.37",
-        "@abgov/web-components": "1.17.0-alpha.96",
+        "@abgov/react-components": "4.17.0-alpha.38",
+        "@abgov/web-components": "1.17.0-alpha.100",
         "@faker-js/faker": "^8.3.1",
         "highlight.js": "^11.8.0",
         "react": "^18.2.0",
@@ -41,9 +41,9 @@
       }
     },
     "node_modules/@abgov/react-components": {
-      "version": "4.17.0-alpha.37",
-      "resolved": "https://registry.npmjs.org/@abgov/react-components/-/react-components-4.17.0-alpha.37.tgz",
-      "integrity": "sha512-QOF2mVZhHc//rx71FkmeaYcQxg0/FGUaaz6fJWsNSPyTM9zIpE3gh7QQKoAL5QY6j0CoJYkq6lgvRKAd8ZiBwQ==",
+      "version": "4.17.0-alpha.38",
+      "resolved": "https://registry.npmjs.org/@abgov/react-components/-/react-components-4.17.0-alpha.38.tgz",
+      "integrity": "sha512-WYfTi5ABrg3BsthPVfjQ3AgDCHIS8PUfeZyW5XKPZh/cdvBaJ7ikJhczAYnYe9Bd6XBbjaCLrBKElV40lsf6ww==",
       "peerDependencies": {
         "@types/react": "^17.0.0 || ^18.0.0",
         "react": "^17.0.0 || ^18.0.0",
@@ -51,9 +51,9 @@
       }
     },
     "node_modules/@abgov/web-components": {
-      "version": "1.17.0-alpha.96",
-      "resolved": "https://registry.npmjs.org/@abgov/web-components/-/web-components-1.17.0-alpha.96.tgz",
-      "integrity": "sha512-Fjg5wGTdS3mzOSWr2EA0zKwYHERMLERQRBK2bfRcz/Y6R6u5b1E5I/k/eJeQLw1WGkCb7K+pyoGVlzepH7Ykxw==",
+      "version": "1.17.0-alpha.100",
+      "resolved": "https://registry.npmjs.org/@abgov/web-components/-/web-components-1.17.0-alpha.100.tgz",
+      "integrity": "sha512-NbBBzR3FMqwh9ufbd/R+fqzOvq2f/SW+dSJAGjOgtMrrPtKqnujdAAP0fAZB2EXEIofRQ57gqX3McA0PJql55g==",
       "peerDependencies": {
         "@sveltejs/vite-plugin-svelte": "3.x",
         "glob": "10.x",

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "prettier": "npx prettier . --write"
   },
   "dependencies": {
-    "@abgov/react-components": "4.17.0-alpha.37",
-    "@abgov/web-components": "1.17.0-alpha.96",
+    "@abgov/react-components": "4.17.0-alpha.38",
+    "@abgov/web-components": "1.17.0-alpha.100",
     "@faker-js/faker": "^8.3.1",
     "highlight.js": "^11.8.0",
     "react": "^18.2.0",

--- a/src/routes/components/Chip.tsx
+++ b/src/routes/components/Chip.tsx
@@ -40,6 +40,14 @@ export default function ChipPage() {
       value: "",
     },
     {
+      label: "Icon Theme",
+      type: "list",
+      name: "iconTheme",
+      options: ["", "outline", "filled", "sharp"],
+      defaultValue: "outline",
+      value: ""
+    },
+    {
       label: "Deletable",
       type: "boolean",
       name: "deletable",
@@ -71,6 +79,20 @@ export default function ChipPage() {
       type: "GoAIconType",
       description: "Shows an icon to the left of the text.",
       lang: "react",
+    },
+    {
+      name: "icontheme",
+      type: "outline | filled | sharp",
+      description: "The style of the leading icon",
+      defaultValue: "outline",
+      lang: "angular"
+    },
+    {
+      name: "iconTheme",
+      type: "outline | filled | sharp",
+      description: "The style of the leading icon",
+      defaultValue: "outline",
+      lang: "react"
     },
     {
       name: "error",


### PR DESCRIPTION
There should be a new property called `icontheme` or `iconTheme` added to the Chip component sandbox and Property Accordion.