### PR TITLE
feat(#2053): allow slotted content in microsite header version

### DIFF
--- a/src/examples/microsite-header/MicrositeHeaderExamples.tsx
+++ b/src/examples/microsite-header/MicrositeHeaderExamples.tsx
@@ -1,0 +1,44 @@
+import { GoAMicrositeHeader } from "@abgov/react-components";
+import { Sandbox } from "@components/sandbox";
+import { CodeSnippet } from "@components/code-snippet/CodeSnippet.tsx";
+
+export default function MicrositeHeaderExamples () {
+  return (
+    <>
+      <h2 id="component-examples" className="hidden" aria-hidden="true">Examples</h2>
+      <h3 id="component-example-slotted-microsite-header-version">Slotted version</h3>
+      <Sandbox fullWidth skipRender>
+        {/*Angular*/}
+        <CodeSnippet
+        lang="typescript"
+        tags="angular"
+        allowCopy={true}
+        code={`
+          <goa-microsite-header type="alpha">
+            <div slot="version">
+              <span>Slotted <b>version text</b>.</span>
+              <span>v1.23</span>
+            </div>
+          </goa-microsite-header>
+        `}
+        />
+        {/*React*/}
+        <CodeSnippet
+        lang="typescript"
+        tags="react"
+        allowCopy={true}
+        code={`
+          <GoAMicrositeHeader
+            type="alpha"
+            version={<><span>Slotted <b>version text</b>.</span><span>v1.23</span></>}
+          ></GoAMicrositeHeader>
+        `}
+        />
+        <GoAMicrositeHeader
+          type="alpha"
+          version={<><span>Slotted <b>version text</b>.</span><span>v1.23</span></>}
+        />
+      </Sandbox>
+    </>
+  )
+}

--- a/src/routes/components/MicrositeHeader.tsx
+++ b/src/routes/components/MicrositeHeader.tsx
@@ -14,6 +14,7 @@ import {
 import { ComponentBinding, Sandbox } from "@components/sandbox";
 import { useState } from "react";
 import { ComponentContent } from "@components/component-content/ComponentContent";
+import MicrositeHeaderExamples from "@examples/microsite-header/MicrositeHeaderExamples.tsx";
 
 const componentName = "Microsite header";
 const description =
@@ -82,7 +83,15 @@ export default function MicrositeHeaderPage() {
     },
     {
       name: "version",
-      type: "string",
+      type: "string | ReactNode",
+      lang: "react",
+      description: "Displayed on the right-hand side of the header.",
+    },
+    {
+      name: "version",
+      type: "string | slot",
+      lang: "angular",
+      description: "Displayed on the right-hand side of the header.",
     },
     {
       name: "feedbackUrl",
@@ -134,6 +143,7 @@ export default function MicrositeHeaderPage() {
 
             {/*Component properties table*/}
             <ComponentProperties properties={componentProperties} />
+            <MicrositeHeaderExamples />
           </GoATab>
 
           <GoATab


### PR DESCRIPTION
This PR documents the changes from https://github.com/GovAlta/ui-components/pull/2086.

![image](https://github.com/user-attachments/assets/d7de6937-a815-468b-87a6-4e7026a2350f)
