### PR TITLE
fix(#2069): Updated top margin on modal buttons

### DIFF
--- a/src/examples/modal/ModalExamples.tsx
+++ b/src/examples/modal/ModalExamples.tsx
@@ -249,7 +249,7 @@ export default function ModalExamples() {
           open={warnCalloutModalOpen}
           onClose={() => setWarnCalloutModalOpen(false)}
           actions={
-            <GoAButtonGroup alignment="end" mt="l">
+            <GoAButtonGroup alignment="end">
               <GoAButton type="primary" onClick={() => setWarnCalloutModalOpen(false)}>
                 I understand
               </GoAButton>
@@ -284,7 +284,7 @@ export default function ModalExamples() {
                     (_close)="toggleModal()" heading="Complete submission prior to 1PM">
                       <p>You’ve selected to adjourn a matter that is required to appear today. This Calgary court location does not accept adjournment requests past 1PM MST. Please submit your adjournment request as soon as possible.</p>
                     <div slot="actions">
-                      <goa-button-group alignment="end" mt="l">
+                      <goa-button-group alignment="end">
                         <goa-button type="primary" (_click)="toggleModal()">
                           I understand
                         </goa-button>
@@ -314,7 +314,7 @@ export default function ModalExamples() {
                     role="alertdialog"
                     onClose={() => setOpen(false)}
                     actions={
-                      <GoAButtonGroup alignment="end" mt="l">
+                      <GoAButtonGroup alignment="end">
                         <GoAButton type="primary" onClick={() => setOpen(false)}>I understand</GoAButton>
                       </GoAButtonGroup>
                     }

--- a/src/routes/components/Modal.tsx
+++ b/src/routes/components/Modal.tsx
@@ -263,7 +263,7 @@ export default function ModalPage() {
                   Lorem ipsum dolor sit amet consectetur adipisicing elit. Mollitia obcaecati id
                   molestiae, natus dicta, eaque qui iusto similique, libero explicabo eligendi eius
                   laboriosam! Repellendus ducimus officia asperiores. Eos, eius numquam.
-                  <GoAButtonGroup alignment="end">
+                  <GoAButtonGroup alignment="end" mt="xl">
                     <GoAButton type="tertiary" onClick={() => setOpen(false)}>
                       Cancel
                     </GoAButton>


### PR DESCRIPTION
Updated the top margin on the action buttons for the Modal in the sandbox. And removed top margin from the buttons for example "Warn a user of a deadline"