### PR TITLE
fix(#2055): Removed width option from TextArea sandbox

### DIFF
--- a/src/routes/components/TextArea.tsx
+++ b/src/routes/components/TextArea.tsx
@@ -51,12 +51,6 @@ export default function TextAreaPage() {
       type: "number",
     },
     {
-      label: "Width",
-      name: "width",
-      type: "string",
-      value: "60ch",
-    },
-    {
       label: "Placeholder",
       type: "string",
       name: "placeholder",


### PR DESCRIPTION
Text Area sandbox should no longer have the `width` option