### PR TITLE
fix(#2161): Update Angular DatePicker sandbox code

### DIFF
--- a/src/routes/components/DatePicker.tsx
+++ b/src/routes/components/DatePicker.tsx
@@ -186,7 +186,7 @@ export default function DatePickerPage() {
                 // reactive code
                 import { FormControl } from "@angular/forms";
                 export class MyComponent {
-                  reactiveFormCtrl = new FormControl(new Date());
+                  itemFormCtrl = new FormControl(new Date());
                 }  
               `}
               />


### PR DESCRIPTION
## Before

Code under Date Picker Reactive Forms example:
```javascript
import { FormControl } from "@angular/forms";
export class MyComponent {
  reactiveFormCtrl = new FormControl(new Date());
}
```

## After

Code under Date Picker Reactive Forms example:
```javascript
import { FormControl } from "@angular/forms";
export class MyComponent {
  itemFormCtrl = new FormControl(new Date());
}
```