### PR TITLE
chore(#2329): update the guide to install lts version

### DIFF
--- a/src/routes/get-started/developers/DevelopersSetup.tsx
+++ b/src/routes/get-started/developers/DevelopersSetup.tsx
@@ -24,7 +24,7 @@ export default function DevelopersSetupPage() {
           allowCopy={true}
           code={`
           npm i @abgov/web-components
-          npm i @abgov/angular-components
+          npm i @abgov/angular-components@lts
         `}
         />
 
@@ -89,7 +89,7 @@ export default function DevelopersSetupPage() {
           tags="react"
           allowCopy={true}
           code={`
-          npm i @abgov/react-components
+          npm i @abgov/react-components@lts
           npm i @abgov/web-components
         `}
         />


### PR DESCRIPTION
We have `lts` tag for the current production version. I update the Developers Setup guide to make sure ppl install `lts` version, instead of `latest`, so they won't automatically install a breaking change/major version if they don't feel ready. 

This only applies for `angular-components` and `react-components`

![image](https://github.com/user-attachments/assets/2f517538-ca87-4267-9335-a8fd9e93e4a4)

![image](https://github.com/user-attachments/assets/779b4f3a-7dbc-48c9-a0a8-b7ac14f3dc2e)

