### PR TITLE
feat(#20): update to component doc page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@abgov/react-components": "5.4.0",
         "@abgov/web-components": "1.29.0",
         "@faker-js/faker": "^8.3.1",
+        "date-fns": "^3.6.0",
         "highlight.js": "^11.8.0",
         "octokit": "^4.0.2",
         "react": "^18.2.0",
@@ -1929,6 +1930,16 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+    },
+    "node_modules/date-fns": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
+      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
     },
     "node_modules/debug": {
       "version": "4.3.4",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@abgov/web-components": "1.29.0",
     "@faker-js/faker": "^8.3.1",
     "highlight.js": "^11.8.0",
+    "date-fns": "^3.6.0",
     "octokit": "^4.0.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/components/accessibility-empty/AccessibilityEmpty.css
+++ b/src/components/accessibility-empty/AccessibilityEmpty.css
@@ -1,2 +1,0 @@
-.accessibility-empty {
-}

--- a/src/components/accessibility-empty/AccessibilityEmpty.css
+++ b/src/components/accessibility-empty/AccessibilityEmpty.css
@@ -1,0 +1,2 @@
+.accessibility-empty {
+}

--- a/src/components/accessibility-empty/AccessibilityEmpty.tsx
+++ b/src/components/accessibility-empty/AccessibilityEmpty.tsx
@@ -1,0 +1,23 @@
+import { GoAContainer, GoAText } from "@abgov/react-components";
+import "./AccessibilityEmpty.css";
+
+  export interface Props {
+    figmaLink: string;
+  }
+  export function AccessibilityEmpty(props: Props) {
+    return (
+    <div className="accessibility-empty">
+      <GoAContainer type="non-interactive" accent="filled" padding="relaxed" width="content">
+        <GoAText size="body-m" mt="none">
+          Accessibility documentation for this component can be found on it's {" "}
+          <a href={props.figmaLink} target="_blank" rel="noreferrer">
+            component&nbsp;page&nbsp;in&nbsp;Figma.
+          </a>{" "}
+        </GoAText>
+        <GoAText size="body-m" mb="none">
+          More accessibility guidance for design and development is coming soon.
+        </GoAText>
+      </GoAContainer>
+    </div>
+  );
+};

--- a/src/components/accessibility-empty/AccessibilityEmpty.tsx
+++ b/src/components/accessibility-empty/AccessibilityEmpty.tsx
@@ -20,4 +20,4 @@ import "./AccessibilityEmpty.css";
       </GoAContainer>
     </div>
   );
-};
+}

--- a/src/components/accessibility-empty/AccessibilityEmpty.tsx
+++ b/src/components/accessibility-empty/AccessibilityEmpty.tsx
@@ -1,5 +1,4 @@
 import { GoAContainer, GoAText } from "@abgov/react-components";
-import "./AccessibilityEmpty.css";
 
   export interface Props {
     figmaLink: string;

--- a/src/components/code-snippet/CodeSnippet.css
+++ b/src/components/code-snippet/CodeSnippet.css
@@ -3,7 +3,7 @@
   border-radius: 4px;
   margin-top: var(--goa-space-m);
   overflow: hidden;
-  max-height: 25rem;
+  max-height: 20rem;
   position: relative;
 }
 
@@ -11,11 +11,15 @@
   margin: 0;
   white-space: pre-wrap;
   word-wrap: break-word;
+  padding-right: var(--goa-space-2xl); /** to not overlap with copy button **/
+  background-color: var(--goa-color-greyscale-100);
+
+
 }
 
 .goa-code-snippet.overflow pre {
   padding-bottom: var(--goa-space-xl); /** to not overlap with show more/less button **/
-  padding-right: var(--goa-space-2xl); /** to not overlap with copy button **/
+  padding-right: var(--goa-space-3xl); /** to not overlap with copy button **/
   background-color: var(--goa-color-greyscale-100);
 }
 

--- a/src/components/code-snippet/CodeSnippet.css
+++ b/src/components/code-snippet/CodeSnippet.css
@@ -13,8 +13,6 @@
   word-wrap: break-word;
   padding-right: var(--goa-space-2xl); /** to not overlap with copy button **/
   background-color: var(--goa-color-greyscale-100);
-
-
 }
 
 .goa-code-snippet.overflow pre {

--- a/src/components/component-content/ComponentContent.tsx
+++ b/src/components/component-content/ComponentContent.tsx
@@ -1,5 +1,6 @@
 import TOC from "@components/table-of-contents/TOC";
 import "./component-content.css";
+import { GoADivider } from "@abgov/react-components";
 
 type Props = {
   children: React.ReactNode;
@@ -11,10 +12,16 @@ export function ComponentContent({tocCssQuery, contentClassName, children}: Prop
 
   return <>
     <div className="component-content--container">
-      <div style={{ maxWidth: tocCssQuery ? "auto" : "54rem" }} className={`component-content--content ${contentClassName ? contentClassName: ""}`}>
+      <div style={{ maxWidth: tocCssQuery ? "auto" : "54rem" }}
+           className={`component-content--content ${contentClassName ? contentClassName : ""}`}>
         {children}
+        <GoADivider mt="3xl"></GoADivider>
+
       </div>
       {tocCssQuery && <TOC cssQuery={tocCssQuery} />}
+    </div>
+
+    <div >
     </div>
   </>
 }

--- a/src/components/component-header/ComponentHeader.css
+++ b/src/components/component-header/ComponentHeader.css
@@ -1,11 +1,26 @@
 .component-header {
-  margin-bottom: 3rem;
-  margin-top: 2rem;
+  margin-bottom: var(--goa-space-l);
+  margin-top: var(--goa-space-xl);
 }
 
 .component-header h1 {
-  margin-bottom: 1rem;
-  margin-top: 1.5rem;
+  margin-bottom: var(--goa-space-m);
+  margin-top: var(--goa-space-l);
+}
+
+.component-header h3 {
+  margin-bottom: var(--goa-space-xs);
+}
+
+.component-header span.small,
+.component-header a.small {
+  font: var(--goa-typography-body-s);
+  margin-bottom: var(--goa-space-xs);
+}
+
+.component-header span.x-small,
+.component-header a.x-small {
+  font: var(--goa-typography-body-xs);
 }
 
 @media screen and (max-width: 623px) {

--- a/src/components/component-header/ComponentHeader.tsx
+++ b/src/components/component-header/ComponentHeader.tsx
@@ -1,4 +1,4 @@
-import {GoABadge, GoABlock, GoAHeroBanner, GoAText, } from "@abgov/react-components";
+import {GoABadge, GoABlock, GoAText, } from "@abgov/react-components";
 import "./ComponentHeader.css";
 import { Link } from "react-router-dom";
 

--- a/src/components/component-header/ComponentHeader.tsx
+++ b/src/components/component-header/ComponentHeader.tsx
@@ -1,42 +1,74 @@
-import { GoABadge } from "@abgov/react-components";
+import { GoABadge, GoABlock, GoAText } from "@abgov/react-components";
 import "./ComponentHeader.css";
 import { Link } from "react-router-dom";
-
+import { format } from 'date-fns';
+import { useEffect, useState } from "react";
 
 interface Props {
-  category?: Category;
-  name: string;
-  description?: string;
-  relatedComponents?: { link: string; name: string }[];
+    category?: Category;
+    name: string;
+    description?: string;
+    relatedComponents?: { link: string; name: string }[];
+    githubLink?: string;
 }
 
 export enum Category {
-  CONTENT_AND_LAYOUT = "Content and layout",
-  FEEDBACK_AND_ALERTS = "Feedback and alerts",
-  STRUCTURE_AND_NAVIGATION = "Structure and navigation",
-  INPUTS_AND_ACTIONS = "Inputs and actions",
-  UTILITIES = "Utilities",
+    CONTENT_AND_LAYOUT = "Content and layout",
+    FEEDBACK_AND_ALERTS = "Feedback and alerts",
+    STRUCTURE_AND_NAVIGATION = "Structure and navigation",
+    INPUTS_AND_ACTIONS = "Inputs and actions",
+    UTILITIES = "Utilities",
 }
 
 export const ComponentHeader: React.FC<Props> = (props: Props) => {
-  return (
-    <div className="component-header">
-      <GoABadge type="information" content={props.category} />
-      <h1>{props.name}</h1>
-      <h2 id="component" className="hidden" aria-hidden="true">Component</h2>
-      <h3 dangerouslySetInnerHTML={{__html: props.description || ''}}></h3>
+    const GITHUB_BASE = "https://github.com/GovAlta/ui-components-docs/blob/main/src/";
+    const [lastUpdateTime, setLastUpdateTime] = useState<Date | null>(null);
+    useEffect(() => {
+        if (props.githubLink) {
+            const fetchLastUpdateTime = async () => {
+                try {
+                    const url = `https://api.github.com/repos/GovAlta/ui-components-docs/commits?path=src/${props.githubLink}`;
+                    const response = await fetch(url);
+                    if (!response.ok) {
+                        return;
+                    }
+                    const commits = await response.json();
+                    if (commits.length === 0) {
+                        return;
+                    }
+                    const lastCommit = commits[0];
+                    const lastUpdateTime = new Date(lastCommit.commit.committer.date);
+                    setLastUpdateTime(lastUpdateTime);
+                } catch (error) {
+                    console.error((error as Error).message);
+                }
+            };
 
-      {props.relatedComponents?.length && (
-        <>
-          <span>Related components: </span>
-          {props.relatedComponents.map((relatedComponent, index, array) => (
-            <span key={index}>
+            fetchLastUpdateTime();
+        }
+    }, [props.githubLink]);
+
+    return (
+        <div className="component-header">
+            <GoABadge type="information" content={props.category} />
+            <GoAText size="heading-xl" mt="s">{props.name}</GoAText>
+            <h2 id="component" className="hidden" aria-hidden="true">
+                Component
+            </h2>
+            <h3 dangerouslySetInnerHTML={{ __html: props.description || "" }}></h3>
+
+            {props.relatedComponents?.length && (
+                <GoABlock mb={"xl"} gap={"xs"}>
+                    <span className="small">Related: </span>
+                    {props.relatedComponents.map((relatedComponent, index, array) => (
+                        <span className="small" key={index}>
               <Link to={relatedComponent.link}>{relatedComponent.name}</Link>
-              {index < array.length - 1 && ", "}
+                            {index < array.length - 1 && ", "}
             </span>
-          ))}
-        </>
-      )}
-    </div>
-  );
+                    ))}
+                </GoABlock>
+            )}
+
+        </div>
+    );
 };

--- a/src/components/component-header/ComponentHeader.tsx
+++ b/src/components/component-header/ComponentHeader.tsx
@@ -61,11 +61,9 @@ export const ComponentHeader: React.FC<Props> = (props) => {
                 )}
             </GoABlock>
 
-            <h2 id="component" className="hidden" aria-hidden="true">
-                Component
-            </h2>
-
-            <h3 dangerouslySetInnerHTML={{ __html: props.description || "" }} />
+          <GoAText size="heading-m" mt="none">
+            {props.description}
+          </GoAText>
 
             {props.relatedComponents?.length && (
                 <GoABlock mt="m" mb="xl" gap="xs">

--- a/src/components/component-header/ComponentHeader.tsx
+++ b/src/components/component-header/ComponentHeader.tsx
@@ -1,17 +1,8 @@
-import { GoABadge, GoABlock, GoAText } from "@abgov/react-components";
+import {GoABadge, GoABlock, GoAHeroBanner, GoAText, } from "@abgov/react-components";
 import "./ComponentHeader.css";
 import { Link } from "react-router-dom";
-import { format } from 'date-fns';
-import { useEffect, useState } from "react";
 
-interface Props {
-    category?: Category;
-    name: string;
-    description?: string;
-    relatedComponents?: { link: string; name: string }[];
-    githubLink?: string;
-}
-
+// If you have an enum for categories:
 export enum Category {
     CONTENT_AND_LAYOUT = "Content and layout",
     FEEDBACK_AND_ALERTS = "Feedback and alerts",
@@ -20,54 +11,74 @@ export enum Category {
     UTILITIES = "Utilities",
 }
 
-export const ComponentHeader: React.FC<Props> = (props: Props) => {
-    const GITHUB_BASE = "https://github.com/GovAlta/ui-components-docs/blob/main/src/";
-    const [lastUpdateTime, setLastUpdateTime] = useState<Date | null>(null);
-    useEffect(() => {
-        if (props.githubLink) {
-            const fetchLastUpdateTime = async () => {
-                try {
-                    const url = `https://api.github.com/repos/GovAlta/ui-components-docs/commits?path=src/${props.githubLink}`;
-                    const response = await fetch(url);
-                    if (!response.ok) {
-                        return;
-                    }
-                    const commits = await response.json();
-                    if (commits.length === 0) {
-                        return;
-                    }
-                    const lastCommit = commits[0];
-                    const lastUpdateTime = new Date(lastCommit.commit.committer.date);
-                    setLastUpdateTime(lastUpdateTime);
-                } catch (error) {
-                    console.error((error as Error).message);
-                }
-            };
+interface Props {
+    category?: Category;
+    name: string;
+    description?: string;
+    relatedComponents?: { link: string; name: string }[];
+    githubLink?: string;
+    figmaLink?: string;
+}
 
-            fetchLastUpdateTime();
-        }
-    }, [props.githubLink]);
+export const ComponentHeader: React.FC<Props> = (props) => {
+    // Helper to transform "button" -> "Button" for GitHub label
+    function toSentenceCase(str: string): string {
+        return str.charAt(0).toUpperCase() + str.slice(1).toLowerCase();
+    }
 
     return (
-        <div className="component-header">
+
+        <div className="component-header" >
             <GoABadge type="information" content={props.category} />
-            <GoAText size="heading-xl" mt="s">{props.name}</GoAText>
+
+            <GoABlock gap="2xl" alignment="center">
+                <GoAText size="heading-xl" mt="xs">
+                    {props.name}
+                </GoAText>
+                {(props.githubLink || props.figmaLink) && (
+                    <GoABlock gap="l" direction="row" mt="l">
+                        {/* GitHub Issues link, if we have a "githubLink" */}
+                        {props.githubLink && (
+                            <a className="small"
+                               href={`https://github.com/GovAlta/ui-components/issues?q=is%3Aissue+is%3Aopen+label%3A${encodeURIComponent(
+                                   toSentenceCase(props.githubLink)
+                               )}`}
+                               target="_blank"
+                               rel="noopener noreferrer"
+                            >
+                                GitHub issues
+                            </a>
+                        )}
+
+                        {/* Figma link, if we have a "figmaLink" */}
+                        {props.figmaLink && (
+                            <a className="small"
+                               href={props.figmaLink} target="_blank" rel="noopener noreferrer">
+                                Figma
+                            </a>
+                        )}
+                    </GoABlock>
+                )}
+            </GoABlock>
+
             <h2 id="component" className="hidden" aria-hidden="true">
                 Component
             </h2>
-            <h3 dangerouslySetInnerHTML={{ __html: props.description || "" }}></h3>
+
+            <h3 dangerouslySetInnerHTML={{ __html: props.description || "" }} />
 
             {props.relatedComponents?.length && (
-                <GoABlock mb={"xl"} gap={"xs"}>
-                    <span className="small">Related: </span>
-                    {props.relatedComponents.map((relatedComponent, index, array) => (
+                <GoABlock mt="m" mb="xl" gap="xs">
+                    <span className="small">Related:</span>
+                    {props.relatedComponents.map((rc, index, array) => (
                         <span className="small" key={index}>
-              <Link to={relatedComponent.link}>{relatedComponent.name}</Link>
+              <Link to={rc.link}>{rc.name}</Link>
                             {index < array.length - 1 && ", "}
             </span>
                     ))}
                 </GoABlock>
             )}
+
 
         </div>
     );

--- a/src/components/component-properties/ComponentProperties.tsx
+++ b/src/components/component-properties/ComponentProperties.tsx
@@ -70,7 +70,9 @@ interface ComponentPropertyProps {
 
 function ComponentProperty({ props }: ComponentPropertyProps) {
   return (
+
     <div className={css["component-props"]}>
+
       <div className={css.details}>
         <code className={`${css.code} ${css.name}`}>{props.name}</code>
 
@@ -86,7 +88,9 @@ function ComponentProperty({ props }: ComponentPropertyProps) {
       <div className={css.description}>
         {props.description}
         {props.defaultValue && (
+
           <span>
+            <br/>
             {" "}
             Defaults to <code className={css.code}>{props.defaultValue}</code>.
           </span>

--- a/src/components/component-properties/ComponentProperties.tsx
+++ b/src/components/component-properties/ComponentProperties.tsx
@@ -46,7 +46,7 @@ export const ComponentProperties = (props: Props) => {
       >
         {props.heading || "Properties"}
       </h3>
-      <GoAAccordion heading={props.heading || "Properties"} mt="l" mb="none">
+      <GoAAccordion heading={props.heading || "Component properties"} mt="l" mb="none">
         <div>
           {filteredProperties.map((props, index) => (
             <ComponentProperty key={index} props={props} />

--- a/src/components/component-properties/ComponentProperties.tsx
+++ b/src/components/component-properties/ComponentProperties.tsx
@@ -1,4 +1,4 @@
-import { GoAAccordion, GoABadge } from "@abgov/react-components";
+import {  GoABadge, GoAText, GoAContainer } from "@abgov/react-components";
 import { useContext, useEffect, useState } from "react";
 import { LanguageContext } from "@components/sandbox";
 
@@ -39,20 +39,27 @@ export const ComponentProperties = (props: Props) => {
 
   return (
     <>
-      <h3 
+      <h2
         id={props.heading ? `components-${dasherize(props.heading)}` : "component-properties"} 
         className="hidden" 
         aria-hidden="true"
       >
         {props.heading || "Properties"}
-      </h3>
-      <GoAAccordion heading={props.heading || "Component properties"} mt="l" mb="none">
+      </h2>
+
+      <GoAText size="heading-m" mb="l" mt="2xl">
+        {props.heading || "Properties"}
+      </GoAText>
+      <GoAContainer
+        type="interactive"
+        >
         <div>
           {filteredProperties.map((props, index) => (
             <ComponentProperty key={index} props={props} />
           ))}
         </div>
-      </GoAAccordion>
+      </GoAContainer>
+
     </>
   );
 };

--- a/src/components/design-empty/DesignEmpty.css
+++ b/src/components/design-empty/DesignEmpty.css
@@ -1,2 +1,0 @@
-.accessibility-empty {
-}

--- a/src/components/design-empty/DesignEmpty.css
+++ b/src/components/design-empty/DesignEmpty.css
@@ -1,0 +1,2 @@
+.accessibility-empty {
+}

--- a/src/components/design-empty/DesignEmpty.tsx
+++ b/src/components/design-empty/DesignEmpty.tsx
@@ -18,4 +18,4 @@ import "./DesignEmpty.css";
       </GoAContainer>
     </div>
   );
-};
+}

--- a/src/components/design-empty/DesignEmpty.tsx
+++ b/src/components/design-empty/DesignEmpty.tsx
@@ -1,5 +1,4 @@
 import { GoAContainer, GoAText } from "@abgov/react-components";
-import "./DesignEmpty.css";
 
   export interface Props {
     figmaLink: string;

--- a/src/components/design-empty/DesignEmpty.tsx
+++ b/src/components/design-empty/DesignEmpty.tsx
@@ -1,0 +1,21 @@
+import { GoAContainer, GoAText } from "@abgov/react-components";
+import "./DesignEmpty.css";
+
+  export interface Props {
+    figmaLink: string;
+  }
+  export function DesignEmpty(props: Props) {
+    return (
+    <div className="design-empty">
+
+      <GoAContainer type="non-interactive" accent="filled" padding="relaxed" width="content">
+        <GoAText size="body-m" mb="none">
+          Detailed design documentation for this component can be found on it's {" "}
+        <a href={props.figmaLink} target="_blank" rel="noreferrer">
+          component&nbsp;page&nbsp;in&nbsp;Figma.
+        </a>{" "}
+        </GoAText>
+      </GoAContainer>
+    </div>
+  );
+};

--- a/src/components/examples-empty/ExamplesEmpty.css
+++ b/src/components/examples-empty/ExamplesEmpty.css
@@ -1,0 +1,2 @@
+.examples-empty {
+}

--- a/src/components/examples-empty/ExamplesEmpty.css
+++ b/src/components/examples-empty/ExamplesEmpty.css
@@ -1,2 +1,0 @@
-.examples-empty {
-}

--- a/src/components/examples-empty/ExamplesEmpty.tsx
+++ b/src/components/examples-empty/ExamplesEmpty.tsx
@@ -17,4 +17,4 @@ import "./ExamplesEmpty.css";
       </GoAContainer>
     </div>
   );
-};
+}

--- a/src/components/examples-empty/ExamplesEmpty.tsx
+++ b/src/components/examples-empty/ExamplesEmpty.tsx
@@ -1,5 +1,4 @@
 import { GoAContainer, GoAText } from "@abgov/react-components";
-import "./ExamplesEmpty.css";
 
   export interface Props {
     figmaLink?: string;

--- a/src/components/examples-empty/ExamplesEmpty.tsx
+++ b/src/components/examples-empty/ExamplesEmpty.tsx
@@ -1,0 +1,20 @@
+import { GoAContainer, GoAText } from "@abgov/react-components";
+import "./ExamplesEmpty.css";
+
+  export interface Props {
+    figmaLink?: string;
+  }
+  export function ExamplesEmpty( ) {
+    return (
+    <div className="examples-empty">
+      <GoAContainer type="non-interactive" accent="filled" padding="relaxed" width="content">
+        <GoAText size="body-m" mt="none" mb="none">
+          We are currently collecting contextual service examples for this component to provide as a starting point in both Figma and code libraries. To contribute examples from your service {" "}
+          <a href="/get-started/support" rel="noreferrer">
+            talk&nbsp;to&nbsp;the&nbsp;design&nbsp;system&nbsp;team.
+          </a>{" "}
+        </GoAText>
+      </GoAContainer>
+    </div>
+  );
+};

--- a/src/components/icon-snippet/IconSnippet.css
+++ b/src/components/icon-snippet/IconSnippet.css
@@ -3,7 +3,7 @@ div.icon-snippet {
   border: 1px var(--goa-color-greyscale-200) solid;
   border-radius: 4px;
   padding: var(--goa-space-m);
-  color: var(--goa-color-text-secondary);
+  color: var(--goa-color-greyscale-black);
   cursor: pointer;
   /*Below to make icons and text on the same row*/
   display: inline-flex;
@@ -24,20 +24,26 @@ div.icon-snippet span {
 
 div.icon-snippet:hover,
 div.icon-snippet:focus {
-  border-color: var(--goa-color-greyscale-black);
-  color: var(--goa-color-greyscale-black);
+  border-color: var(--goa-color-interactive-hover);
+  color: var(--goa-color-interactive-hover);
+  background-color: var(--goa-color-greyscale-100);
+}
+
+div.icon-snippet:active{
+  border-color: var(--goa-color-interactive-hover);
+  color: var(--goa-color-greyscale-white);
+  background-color: var(--goa-color-interactive-hover);
 }
 
 /*Will remove when we have temporary notification component*/
 div.icon-snippet div.copy-feedback {
   color: white;
   background-color: var(--goa-color-greyscale-black);
-  border: 1px solid var(--goa-color-greyscale-200);
   border-radius: var(--goa-border-radius-m);
   padding: var(--goa-space-m) var(--goa-space-l) var(--goa-space-m) var(--goa-space-l);
   z-index: 10000;
   position: absolute;
-  margin-top: 100px;
+  margin-top: 120px;
 }
 
 div.icon-snippet div.copy-feedback span {

--- a/src/components/icon-snippet/IconSnippet.tsx
+++ b/src/components/icon-snippet/IconSnippet.tsx
@@ -12,7 +12,7 @@ export const IconSnippet: FC<Props> = ({ type }) => {
   function copyIcon() {
     navigator.clipboard.writeText(type).then(() => {
       setCopied(true);
-      setTimeout(() => setCopied(false), 1000);
+      setTimeout(() => setCopied(false), 2300);
     });
   }
 

--- a/src/components/sandbox/Sandbox.css
+++ b/src/components/sandbox/Sandbox.css
@@ -7,7 +7,6 @@
   border: var(--goa-border-width-s) solid var(--goa-color-greyscale-200);
   background: var(--goa-color-greyscale-white);
   padding: var(--goa-space-3xl);
-  margin: var(--goa-space-xs) 0 0;
   display: flex;
   justify-content: space-around;
 }
@@ -20,7 +19,6 @@
   display: flex;
   gap: 1rem 2rem;
   flex-flow: wrap;
-  margin-top: var(--goa-space-m);
 }
 
 .sandbox-render-centered {

--- a/src/components/sandbox/Sandbox.css
+++ b/src/components/sandbox/Sandbox.css
@@ -20,7 +20,7 @@
   display: flex;
   gap: 1rem 2rem;
   flex-flow: wrap;
-  margin-top: var(--goa-space-l);
+  margin-top: var(--goa-space-m);
 }
 
 .sandbox-render-centered {
@@ -31,10 +31,6 @@
   .sandbox-render {
     /*make sure preview element will inherit component width*/
     display: block;
-    padding: var(--goa-space-xs);
-  }
-  .sandbox-container {
-    gap: 0;
-    display: block;
-  }
+    padding: var(--goa-space-xl);
+  } 
 }

--- a/src/components/sandbox/Sandbox.tsx
+++ b/src/components/sandbox/Sandbox.tsx
@@ -1,5 +1,5 @@
 import { ReactElement, ReactNode, useContext, useEffect, useState } from "react";
-
+import { GoAAccordion } from "@abgov/react-components";
 import SandboxProperties from "./SandboxProperties";
 import { CodeSnippet } from "@components/code-snippet/CodeSnippet";
 import { ComponentBinding } from "./ComponentBinding";
@@ -93,7 +93,10 @@ export const Sandbox = (props: SandboxProps) => {
 
   function SandboxView(props: SandboxViewProps): ReactElement {
     return <div className="sandbox-render">
+
+
       <div className={props.fullWidth ? "sandbox-render-fullwidth" : "sandbox-render-centered"}>
+
         <ComponentList type="goa" sandboxProps={props.sandboxProps} />
       </div>
     </div>
@@ -102,17 +105,33 @@ export const Sandbox = (props: SandboxProps) => {
   return (
     <>
       <SandboxView fullWidth={props.fullWidth} sandboxProps={props} />
-      {props.formItemProperties && props.formItemProperties.length > 0 && (
-        <SandboxProperties
-          onChange={onChangeFormItemBindings}
-          properties={props.formItemProperties}
-        />
-      )}
+
+      {/* Only render the GoAAccordion if props.properties is provided */}
       {props.properties && props.properties.length > 0 && (
-        <SandboxProperties properties={props.properties} onChange={onChange} />
+        <GoAAccordion
+          heading="Playground controls"
+          secondaryText="(Copy code below)"
+          headingSize="small"
+          mt="m"
+          open={true}
+        >
+          {props.formItemProperties && props.formItemProperties.length > 0 && (
+            <SandboxProperties
+              onChange={onChangeFormItemBindings}
+              properties={props.formItemProperties}
+            />
+          )}
+
+          <SandboxProperties
+            properties={props.properties}
+            onChange={onChange}
+          />
+        </GoAAccordion>
       )}
+
       <SandboxCode props={props} formatLang={formatLang} lang={lang} serializers={serializers} />
-      {props.note && (<div className="sandbox-note">{props.note}</div>)}
+
+      {props.note && <div className="sandbox-note">{props.note}</div>}
     </>
   );
 };
@@ -199,7 +218,7 @@ function ComponentList(props: ComponentListProps): ReactElement[] {
   const isValidGOAComponent = (el: ReactElement) =>
     typeof el.type === "function" && el.type.name.toLowerCase().startsWith(props.type);
   const isAllowedInSandbox = (el: ReactElement) =>
-    typeof el.type === "string" && props.sandboxProps.allow?.includes(el.type) || 
+    typeof el.type === "string" && props.sandboxProps.allow?.includes(el.type) ||
     typeof el.type === "function" && props.sandboxProps.allow?.includes(el.type.name);
   return children.filter(
     el => React.isValidElement(el) && (isValidGOAComponent(el) || isAllowedInSandbox(el))

--- a/src/components/sandbox/Sandbox.tsx
+++ b/src/components/sandbox/Sandbox.tsx
@@ -17,9 +17,9 @@ type ComponentType = "goa" | "codesnippet";
 type Serializer = (el: any, properties: ComponentBinding[]) => string;
 
 interface SandboxProps {
-  properties?: ComponentBinding[];
-  formItemProperties?: ComponentBinding[];
-  note?: string;
+  properties?: ComponentBinding[]; // show property controls for the rendered component
+  formItemProperties?: ComponentBinding[]; // show property controls for the form item in the rendered component
+  note?: string; // show text below (description or other)
   fullWidth?: boolean;
   onChange?: (bindings: ComponentBinding[], props: Record<string, unknown>) => void;
   onChangeFormItemBindings?: (bindings: ComponentBinding[], props: Record<string, unknown>) => void;
@@ -28,11 +28,14 @@ interface SandboxProps {
   allow?: string[];     // Be default the Sandbox is selective to what it renders out. This adds
                         // additional elements to what is allowed to be rendered out
   children: ReactNode;
+  background?: string; // Add custom background for SandboxView
+
 }
 
 type SandboxViewProps = {
   fullWidth?: boolean;
   sandboxProps: SandboxProps;
+  background?: string; // set custom background colour
 }
 
 export const Sandbox = (props: SandboxProps) => {
@@ -92,8 +95,9 @@ export const Sandbox = (props: SandboxProps) => {
   }
 
   function SandboxView(props: SandboxViewProps): ReactElement {
-    return <div className="sandbox-render">
+    const { background } = props;
 
+    return <div className="sandbox-render" style={{ background }}>
 
       <div className={props.fullWidth ? "sandbox-render-fullwidth" : "sandbox-render-centered"}>
 
@@ -104,7 +108,7 @@ export const Sandbox = (props: SandboxProps) => {
 
   return (
     <>
-      <SandboxView fullWidth={props.fullWidth} sandboxProps={props} />
+      <SandboxView fullWidth={props.fullWidth} sandboxProps={props} background={props.background} />
 
       {/* Only render the GoAAccordion if props.properties is provided */}
       {props.properties && props.properties.length > 0 && (

--- a/src/components/sandbox/Sandbox.tsx
+++ b/src/components/sandbox/Sandbox.tsx
@@ -114,7 +114,7 @@ export const Sandbox = (props: SandboxProps) => {
       {props.properties && props.properties.length > 0 && (
         <GoAAccordion
           heading="Playground controls"
-          secondaryText="(Copy code below)"
+          secondaryText="Change properties to update code below"
           headingSize="small"
           mt="m"
           open={true}

--- a/src/components/support-info/SupportInfo.css
+++ b/src/components/support-info/SupportInfo.css
@@ -1,11 +1,4 @@
 .support-info {
-  margin-right: var(--goa-space-3xl);
   max-width: 700px;
   margin-top: var(--goa-space-3xl);
-}
-
-@media screen and (max-width: 623px) {
-  .support-info {
-    margin-right: var(--goa-space-m);
-  }
 }

--- a/src/examples/accordion/AccordionExamples.tsx
+++ b/src/examples/accordion/AccordionExamples.tsx
@@ -14,7 +14,6 @@ export default function AccordionExamples() {
   }
   return (
     <>
-      <h2 id="component-examples" className="hidden" aria-hidden="true">Examples</h2>
       <h3 id="component-example-expand-collapse-form">Expand or collapse part of a form</h3>
       <Sandbox fullWidth skipRender allow={["h3"]}>
         <CodeSnippet

--- a/src/examples/badge/BadgeExamples.tsx
+++ b/src/examples/badge/BadgeExamples.tsx
@@ -40,7 +40,6 @@ export default function CheckboxExamples () {
     return (
         <> 
         {/* Examples*/}
-        <h2 id="component-examples" className="hidden" aria-hidden="true">Examples</h2>
 
         <h3 id="component-example-show-status-table">Show status in a table</h3>
         <Sandbox fullWidth skipRender>

--- a/src/examples/checkbox/CheckboxExamples.tsx
+++ b/src/examples/checkbox/CheckboxExamples.tsx
@@ -5,7 +5,6 @@ import { CodeSnippet } from "@components/code-snippet/CodeSnippet.tsx";
 export default function CheckboxExamples () {
   return (
     <>      
-      <h2 id="component-examples" className="hidden" aria-hidden="true">Examples</h2>
       <h3 id="component-example-expand-collapse-form">Use tags in the description</h3>
       <Sandbox fullWidth skipRender>
         {/*Angular*/}

--- a/src/examples/container/ContainerExamples.tsx
+++ b/src/examples/container/ContainerExamples.tsx
@@ -14,7 +14,6 @@ export default function ContainerExamples() {
   return (
     <>
       {/*Container examples*/}
-      <h2 id="component-examples" className="hidden" aria-hidden="true">Examples</h2>
       <h3 id="component-example-1">User information</h3>
       <Sandbox fullWidth skipRender>
         {/*CSS Code Snippet*/}

--- a/src/examples/microsite-header/MicrositeHeaderExamples.tsx
+++ b/src/examples/microsite-header/MicrositeHeaderExamples.tsx
@@ -10,7 +10,6 @@ const onClick = () => {
 export default function MicrositeHeaderExamples () {
   return (
     <>
-      <h2 id="component-examples" className="hidden" aria-hidden="true">Examples</h2>
       <h3 id="component-example-feedbackclick">Custom click event handler (for feedback)</h3>
             <Sandbox skipRender fullWidth>
               <GoAMicrositeHeader type="alpha" onFeedbackClick={onClick} />

--- a/src/examples/modal/ModalExamples.tsx
+++ b/src/examples/modal/ModalExamples.tsx
@@ -53,9 +53,6 @@ export default function ModalExamples() {
 
   return (
     <>
-      <h2 id="component-examples" className="hidden" aria-hidden="true">
-        Examples
-      </h2>
       <h3 id="component-example-basic">Basic Modal</h3>
       <Sandbox skipRender>
         <GoAButton onClick={() => setBasicModalOpen(true)}>Open Basic Modal</GoAButton>

--- a/src/examples/radio/RadioExamples.tsx
+++ b/src/examples/radio/RadioExamples.tsx
@@ -7,7 +7,6 @@ const noop = () => { };
 export default function RadioExamples () {
   return (
     <>      
-      <h2 id="component-examples" className="hidden" aria-hidden="true">Examples</h2>
       <h3 id="component-example-use-tags-in-description">Use tags in the description</h3>
       <Sandbox fullWidth skipRender>
         {/*Angular*/}

--- a/src/examples/text-field/TextFieldExamples.tsx
+++ b/src/examples/text-field/TextFieldExamples.tsx
@@ -14,9 +14,6 @@ export default function TextFieldExamples() {
   return (
     <>
       {/*Examples*/}
-      <h2 id="component-examples" className="hidden" aria-hidden="true">
-        Examples
-      </h2>
 
       <h3 id="component-example-ask-user-for-an-address">Ask a user for an address </h3>
       <Sandbox flags={["reactive"]}>

--- a/src/routes/components/Accordion.tsx
+++ b/src/routes/components/Accordion.tsx
@@ -1,13 +1,13 @@
 import {
   GoAAccordion,
   GoAAccordionProps,
-  GoABadge, GoACallout,
+  GoABadge,
   GoATab,
   GoATabs
 } from "@abgov/react-components";
 import {
   ComponentProperties,
-  ComponentProperty,
+  ComponentProperty
 } from "@components/component-properties/ComponentProperties";
 import { ComponentBinding, Sandbox } from "@components/sandbox";
 import { Category, ComponentHeader } from "@components/component-header/ComponentHeader.tsx";
@@ -15,8 +15,10 @@ import { useState } from "react";
 import AccordionExamples from "@examples/accordion/AccordionExamples.tsx";
 import { GoAHeadingSize } from "@abgov/react-components";
 import { ComponentContent } from "@components/component-content/ComponentContent";
+import { DesignEmpty } from "@components/design-empty/DesignEmpty.tsx";
+import { AccessibilityEmpty } from "@components/accessibility-empty/AccessibilityEmpty.tsx";
 
-const FIGMA_LINK = "https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=15931-553576;"
+const FIGMA_LINK = "https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=15931-553576;";
 
 // == Page props ==
 const componentName = "Accordion";
@@ -24,7 +26,7 @@ const description = "Let users show and hide sections of related content on a pa
 const category = Category.CONTENT_AND_LAYOUT;
 const relatedComponents = [
   { link: "/components/details", name: "Details" },
-  { link: "/components/tabs", name: "Tabs" },
+  { link: "/components/tabs", name: "Tabs" }
 ];
 
 type ComponentPropsType = GoAAccordionProps;
@@ -37,44 +39,44 @@ type CastingType = {
 
 export default function AccordionPage() {
   const [accordionProps, setAccordionProps] = useState<ComponentPropsType>({
-    heading: "Heading",
+    heading: "Accordion",
     headingSize: "medium",
-    children: <></>,
+    children: <></>
   });
 
   const [accordionBindings, setAccordionBindings] = useState<ComponentBinding[]>([
-    {
-      label: "Heading",
-      type: "string",
-      name: "heading",
-      value: "Accordion heading",
-    },
     {
       label: "Heading Size",
       type: "radio",
       name: "headingSize",
       options: ["small", "medium"],
-      value: "medium",
+      value: "medium"
+    },
+    {
+      label: "Heading",
+      type: "string",
+      name: "heading",
+      value: "Accordion"
     },
     {
       label: "Secondary Text",
       type: "string",
       name: "secondaryText",
       requirement: "optional",
-      value: "",
-    },
-    {
-      label: "Open",
-      type: "boolean",
-      name: "open",
-      value: false
+      value: ""
     },
     {
       label: "Max Width",
       type: "string",
       name: "maxWidth",
       requirement: "optional",
-      value: "",
+      value: ""
+    },
+    {
+      label: "Open",
+      type: "boolean",
+      name: "open",
+      value: false
     },
   ]);
 
@@ -83,92 +85,92 @@ export default function AccordionPage() {
       name: "heading",
       type: "string",
       required: true,
-      description: "Sets the heading text.",
+      description: "Sets the heading text."
     },
     {
       name: "secondaryText",
       type: "string",
       lang: "react",
-      description: "Sets secondary text.",
+      description: "Sets secondary text."
     },
     {
       name: "secondarytext",
       type: "string",
       lang: "angular",
-      description: "Sets secondary text.",
+      description: "Sets secondary text."
     },
     {
       name: "open",
       type: "boolean",
       defaultValue: "false",
-      description: "Sets the state of the accordion container open or closed.",
+      description: "Sets the state of the accordion container open or closed."
     },
     {
       name: "headingSize",
       type: "small | medium",
       defaultValue: "small",
       lang: "react",
-      description: "Sets the heading size of the accordion container heading.",
+      description: "Sets the heading size of the accordion container heading."
     },
     {
       name: "headingsize",
       type: "small | medium",
       defaultValue: "small",
       lang: "angular",
-      description: "Sets the heading size of the accordion container heading.",
+      description: "Sets the heading size of the accordion container heading."
     },
     {
       name: "headingContent",
       type: "ReactNode",
       lang: "react",
-      description: "Add components to the accordion container heading such as badges.",
+      description: "Add components to the accordion container heading such as badges."
     },
     {
       name: "headingcontent",
       type: "slot",
       lang: "angular",
-      description: "Add components to the accordion container heading such as badges.",
+      description: "Add components to the accordion container heading such as badges."
     },
     {
       name: "maxWidth",
       type: "string",
       description: "Sets the maximum width of the accordion.",
-      lang: "react",
+      lang: "react"
     },
     {
       name: "maxwidth",
       type: "string",
       description: "Sets the maximum width of the accordion.",
-      lang: "angular",
+      lang: "angular"
     },
     {
       name: "testId",
       type: "string",
       lang: "react",
-      description: "Sets the data-testid attribute. Used with ByTestId queries in tests.",
+      description: "Sets the data-testid attribute. Used with ByTestId queries in tests."
     },
     {
       name: "testid",
       type: "string",
       lang: "angular",
-      description: "Sets the data-testid attribute. Used with ByTestId queries in tests.",
+      description: "Sets the data-testid attribute. Used with ByTestId queries in tests."
     },
     {
       name: "mt,mr,mb,ml",
       type: "none | 3xs | 2xs | xs | s | m | l | xl | 2xl | 3xl | 4xl",
-      description: "Apply margin to the top, right, bottom, and/or left of the component.",
+      description: "Apply margin to the top, right, bottom, and/or left of the component."
     },
     {
       name: "_change",
       lang: "angular",
       type: "CustomEvent",
-      description: "Callback function when accordion heading is clicked.",
+      description: "Callback function when accordion heading is clicked."
     },
     {
       name: "onChange",
       lang: "react",
       type: "(open: boolean) => void",
-      description: "Callback function when accordion heading is clicked.",
+      description: "Callback function when accordion heading is clicked."
     }
   ];
 
@@ -191,12 +193,11 @@ export default function AccordionPage() {
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
         <GoATabs>
           <GoATab heading="Code playground">
-            <h2 id="component" style={{display: "none"}}>Playground</h2>
+            <h2 id="component" style={{ display: "none" }}>Playground</h2>
             <Sandbox properties={accordionBindings} onChange={onSandboxChange} fullWidth>
               <GoAAccordion {...accordionProps}>
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
-                incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
-                exercitation ullamco laboris nisi
+                This is the content in an accordion item. This content can be anything that you want including rich
+                text, components, and more.
               </GoAAccordion>
             </Sandbox>
             <ComponentProperties properties={componentProperties} />
@@ -208,28 +209,15 @@ export default function AccordionPage() {
               <GoABadge type="information" content="2" />
             </>}
           >
-            <AccordionExamples></AccordionExamples>
+            <AccordionExamples />
           </GoATab>
 
           <GoATab heading="Design">
-            <GoACallout heading="Design documentation in Figma" type="important" size="medium" maxWidth="540px">
-              Detailed design documentation for this component can be found on the associated{" "}
-              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
-                component page
-              </a>{" "}
-              in the Component library in Figma.
-            </GoACallout>
+            <DesignEmpty figmaLink={FIGMA_LINK} />
           </GoATab>
           <GoATab heading="Accessibility">
-            <GoACallout heading="Accessibility documentation in Figma" type="important" size="medium" maxWidth="550px">
-              Detailed accessibility documentation for this component can be found on the associated{" "}
-              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
-                component page
-              </a>{" "}
-              in the Component library in Figma.
-            </GoACallout>
+            <AccessibilityEmpty figmaLink={FIGMA_LINK} />
           </GoATab>
-
 
         </GoATabs>
       </ComponentContent>

--- a/src/routes/components/Accordion.tsx
+++ b/src/routes/components/Accordion.tsx
@@ -1,7 +1,7 @@
 import {
   GoAAccordion,
   GoAAccordionProps,
-  GoABadge,
+  GoABadge, GoACallout,
   GoATab,
   GoATabs
 } from "@abgov/react-components";
@@ -15,6 +15,8 @@ import { useState } from "react";
 import AccordionExamples from "@examples/accordion/AccordionExamples.tsx";
 import { GoAHeadingSize } from "@abgov/react-components";
 import { ComponentContent } from "@components/component-content/ComponentContent";
+
+const FIGMA_LINK = "https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=15931-553576;"
 
 // == Page props ==
 const componentName = "Accordion";
@@ -33,7 +35,7 @@ type CastingType = {
   [key: string]: unknown;
 };
 
-export default function AccordionPage() {  
+export default function AccordionPage() {
   const [accordionProps, setAccordionProps] = useState<ComponentPropsType>({
     heading: "Heading",
     headingSize: "medium",
@@ -64,7 +66,7 @@ export default function AccordionPage() {
     {
       label: "Open",
       type: "boolean",
-      name: "open", 
+      name: "open",
       value: false
     },
     {
@@ -177,12 +179,19 @@ export default function AccordionPage() {
 
   return (
     <div className="accordion-page">
-      <ComponentHeader name={componentName} category={category} description={description} relatedComponents={relatedComponents} />
+      <ComponentHeader
+        name={componentName}
+        category={category}
+        description={description}
+        relatedComponents={relatedComponents}
+        githubLink="Accordion"
+        figmaLink={FIGMA_LINK}
+      />
 
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
         <GoATabs>
-          <GoATab heading="Code examples">
-            <h2 id="component" style={{display: "none"}}>Component</h2>
+          <GoATab heading="Code playground">
+            <h2 id="component" style={{display: "none"}}>Playground</h2>
             <Sandbox properties={accordionBindings} onChange={onSandboxChange} fullWidth>
               <GoAAccordion {...accordionProps}>
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
@@ -191,16 +200,37 @@ export default function AccordionPage() {
               </GoAAccordion>
             </Sandbox>
             <ComponentProperties properties={componentProperties} />
-            <AccordionExamples />
-          </GoATab>
 
+          </GoATab>
           <GoATab
             heading={<>
-              Design guidelines
-              <GoABadge type="information" content="In progress" />
+              Examples
+              <GoABadge type="information" content="2" />
             </>}
           >
-            </GoATab>
+            <AccordionExamples></AccordionExamples>
+          </GoATab>
+
+          <GoATab heading="Design">
+            <GoACallout heading="Design documentation in Figma" type="important" size="medium" maxWidth="540px">
+              Detailed design documentation for this component can be found on the associated{" "}
+              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
+                component page
+              </a>{" "}
+              in the Component library in Figma.
+            </GoACallout>
+          </GoATab>
+          <GoATab heading="Accessibility">
+            <GoACallout heading="Accessibility documentation in Figma" type="important" size="medium" maxWidth="550px">
+              Detailed accessibility documentation for this component can be found on the associated{" "}
+              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
+                component page
+              </a>{" "}
+              in the Component library in Figma.
+            </GoACallout>
+          </GoATab>
+
+
         </GoATabs>
       </ComponentContent>
     </div>

--- a/src/routes/components/AppFooter.tsx
+++ b/src/routes/components/AppFooter.tsx
@@ -14,12 +14,13 @@ import {
   GoAAppFooterProps,
   GoATab,
   GoATabs,
-  GoACallout,
 } from "@abgov/react-components";
 import { ComponentContent } from "@components/component-content/ComponentContent";
 import { CodeSnippet } from "@components/code-snippet/CodeSnippet.tsx";
 import Sandbox from "@components/sandbox/Sandbox.tsx";
 import "./AllComponents.css";
+import { DesignEmpty } from "@components/design-empty/DesignEmpty.tsx";
+import { AccessibilityEmpty } from "@components/accessibility-empty/AccessibilityEmpty.tsx";
 
 // == Page props ==
 
@@ -368,34 +369,13 @@ export default function AppFooterPage() {
           </GoATab>
 
           <GoATab heading="Design">
-            <GoACallout
-              heading="Design documentation in Figma"
-              type="important"
-              size="medium"
-              maxWidth="540px"
-            >
-              Detailed design documentation for this component can be found on the associated{" "}
-              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
-                component page
-              </a>{" "}
-              in the Component library in Figma.
-            </GoACallout>
+            <DesignEmpty figmaLink={FIGMA_LINK} />
           </GoATab>
-          <GoATab heading="Accessibility">
 
-          <GoACallout
-              heading="Accessibility documentation in Figma"
-              type="important"
-              size="medium"
-              maxWidth="550px"
-            >
-              Detailed accessibility documentation for this component can be found on the associated{" "}
-              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
-                component page
-              </a>{" "}
-              in the Component library in Figma.
-            </GoACallout>
+          <GoATab heading="Accessibility">
+            <AccessibilityEmpty figmaLink={FIGMA_LINK} />
           </GoATab>
+
         </GoATabs>
       </ComponentContent>
     </>

--- a/src/routes/components/AppFooter.tsx
+++ b/src/routes/components/AppFooter.tsx
@@ -1,29 +1,33 @@
+import { useContext, useState } from "react";
+import { ComponentBinding, LanguageContext } from "@components/sandbox";
 import {
+  ComponentProperties,
+  ComponentProperty,
+} from "@components/component-properties/ComponentProperties.tsx";
+import { Category, ComponentHeader } from "@components/component-header/ComponentHeader.tsx";
+import {
+  GoABadge,
   GoAAppFooter,
   GoAAppFooterMetaSection,
   GoAFooterNavSectionProps,
   GoAAppFooterNavSection,
   GoAAppFooterProps,
-  GoABadge,
   GoATab,
   GoATabs,
+  GoACallout,
 } from "@abgov/react-components";
-import { Category, ComponentHeader } from "@components/component-header/ComponentHeader.tsx";
-import {
-  ComponentProperties,
-  ComponentProperty,
-} from "@components/component-properties/ComponentProperties.tsx";
-import { ComponentBinding, Sandbox } from "@components/sandbox";
 import { ComponentContent } from "@components/component-content/ComponentContent";
-import { useState, useContext } from "react";
-import { CodeSnippet } from "@components/code-snippet/CodeSnippet";
-import { LanguageContext } from "@components/sandbox";
+import { CodeSnippet } from "@components/code-snippet/CodeSnippet.tsx";
+import Sandbox from "@components/sandbox/Sandbox.tsx";
+import "./AllComponents.css";
 
 // == Page props ==
 
+const FIGMA_LINK =
+  "https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=582-5939";
 const componentName = "Footer";
 const description = "Provides information related your service at the bottom of every page.";
-const componentCategory = Category.STRUCTURE_AND_NAVIGATION;
+const category = Category.STRUCTURE_AND_NAVIGATION;
 const relatedComponents = [
   { link: "/components/header", name: "Header" },
   { link: "/patterns", name: "Layout" },
@@ -126,17 +130,19 @@ export default function AppFooterPage() {
     <>
       <ComponentHeader
         name={componentName}
-        category={componentCategory}
+        category={category}
         description={description}
         relatedComponents={relatedComponents}
+        githubLink={componentName}
+        figmaLink={FIGMA_LINK}
       />
+
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
         <GoATabs>
-          <GoATab heading="Code examples">
+          <GoATab heading="Code playground">
             <h2 id="component" style={{ display: "none" }}>
-              Component
+              Playground
             </h2>
-            <h3>Basic Footer</h3>
             <Sandbox properties={appFooterBindings} onChange={onSandbox1Change} fullWidth>
               <GoAAppFooter {...appFooterProps} />
             </Sandbox>
@@ -144,7 +150,7 @@ export default function AppFooterPage() {
             {/*Component properties table*/}
             <ComponentProperties properties={componentProperties} />
             <ComponentProperties
-              heading="App Footer Nav Section"
+              heading="Nav section properties"
               properties={secondaryNavProperties}
             />
 
@@ -154,11 +160,9 @@ export default function AppFooterPage() {
                 properties={metaLinkProperties}
               />
             )}
+          </GoATab>
 
-            {/* Examples*/}
-            <h2 id="component-examples" className="hidden" aria-hidden="true">
-              Examples
-            </h2>
+          <GoATab heading={<>Examples<GoABadge type="information" content="2" /></>}>
 
             <h3 id="component-example-footer-meta">Show quick links</h3>
             <Sandbox skipRender fullWidth>
@@ -363,14 +367,34 @@ export default function AppFooterPage() {
             </Sandbox>
           </GoATab>
 
-          <GoATab
-            heading={
-              <>
-                Design guidelines
-                <GoABadge type="information" content="In progress" />
-              </>
-            }>
-            <p>Coming Soon</p>
+          <GoATab heading="Design">
+            <GoACallout
+              heading="Design documentation in Figma"
+              type="important"
+              size="medium"
+              maxWidth="540px"
+            >
+              Detailed design documentation for this component can be found on the associated{" "}
+              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
+                component page
+              </a>{" "}
+              in the Component library in Figma.
+            </GoACallout>
+          </GoATab>
+          <GoATab heading="Accessibility">
+
+          <GoACallout
+              heading="Accessibility documentation in Figma"
+              type="important"
+              size="medium"
+              maxWidth="550px"
+            >
+              Detailed accessibility documentation for this component can be found on the associated{" "}
+              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
+                component page
+              </a>{" "}
+              in the Component library in Figma.
+            </GoACallout>
           </GoATab>
         </GoATabs>
       </ComponentContent>

--- a/src/routes/components/AppHeader.tsx
+++ b/src/routes/components/AppHeader.tsx
@@ -6,7 +6,7 @@ import {
   GoATabs,
   GoARadioGroup,
   GoARadioItem,
-  GoACallout, GoABadge
+  GoABadge,
 } from "@abgov/react-components";
 import { Category, ComponentHeader } from "@components/component-header/ComponentHeader.tsx";
 import {
@@ -17,6 +17,8 @@ import { CodeSnippet } from "@components/code-snippet/CodeSnippet";
 import { ComponentBinding, Sandbox } from "@components/sandbox";
 import { useState } from "react";
 import { ComponentContent } from "@components/component-content/ComponentContent";
+import { DesignEmpty } from "@components/design-empty/DesignEmpty.tsx";
+import { AccessibilityEmpty } from "@components/accessibility-empty/AccessibilityEmpty.tsx";
 
 // == Page props ==
 
@@ -320,34 +322,13 @@ export default function AppHeaderPage() {
           </GoATab>
 
           <GoATab heading="Design">
-            <GoACallout
-              heading="Design documentation in Figma"
-              type="important"
-              size="medium"
-              maxWidth="540px"
-            >
-              Detailed design documentation for this component can be found on the associated{" "}
-              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
-                component page
-              </a>{" "}
-              in the Component library in Figma.
-            </GoACallout>
+            <DesignEmpty figmaLink={FIGMA_LINK} />
           </GoATab>
 
           <GoATab heading="Accessibility">
-            <GoACallout
-              heading="Accessibility documentation in Figma"
-              type="important"
-              size="medium"
-              maxWidth="550px"
-            >
-              Detailed accessibility documentation for this component can be found on the associated{" "}
-              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
-                component page
-              </a>{" "}
-              in the Component library in Figma.
-            </GoACallout>
+            <AccessibilityEmpty figmaLink={FIGMA_LINK} />
           </GoATab>
+
         </GoATabs>
       </ComponentContent>
     </>

--- a/src/routes/components/AppHeader.tsx
+++ b/src/routes/components/AppHeader.tsx
@@ -2,9 +2,11 @@ import {
   GoAAppHeader,
   GoAAppHeaderMenu,
   GoAAppHeaderProps,
-  GoABadge, GoARadioGroup, GoARadioItem,
   GoATab,
-  GoATabs
+  GoATabs,
+  GoARadioGroup,
+  GoARadioItem,
+  GoACallout, GoABadge
 } from "@abgov/react-components";
 import { Category, ComponentHeader } from "@components/component-header/ComponentHeader.tsx";
 import {
@@ -16,10 +18,14 @@ import { ComponentBinding, Sandbox } from "@components/sandbox";
 import { useState } from "react";
 import { ComponentContent } from "@components/component-content/ComponentContent";
 
+// == Page props ==
+
+const FIGMA_LINK =
+  "https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=4576-224884";
 const componentName = "Header";
 const description =
   "Provide structure to help users find their way around the service.";
-const componentCategory = Category.STRUCTURE_AND_NAVIGATION;
+const category = Category.STRUCTURE_AND_NAVIGATION;
 const relatedComponents = [
   { link: "/components/footer", name: "Footer" },
   { link: "/patterns", name: "Layout" },
@@ -138,29 +144,32 @@ export default function AppHeaderPage() {
     <>
       <ComponentHeader
         name={componentName}
-        category={componentCategory}
+        category={category}
         description={description}
         relatedComponents={relatedComponents}
+        githubLink={componentName}
+        figmaLink={FIGMA_LINK}
       />
 
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
         <GoATabs>
-          <GoATab heading="Code examples">
+          <GoATab heading="Code playground">
             <h2 id="component" style={{ display: "none" }}>
-              Component
+              Playground
             </h2>
             <Sandbox properties={appHeaderBindings} onChange={onSandboxChange} fullWidth>
               <GoAAppHeader {...appHeaderProps} />
             </Sandbox>
 
-            {/*Component properties*/}
+            {/* Component properties */}
             <ComponentProperties properties={componentProperties} />
+          </GoATab>
 
-            {/*Examples*/}
-            <h2 id="component-examples" className="hidden" aria-hidden="true">
-              Examples
-            </h2>
+          <GoATab heading={<>Examples<GoABadge type="information" content="2" /></>}>
 
+            {/* Examples */}
+
+            {/* Example 1 */}
             <h3 id="component-example-header-navigation">Header with navigation</h3>
             <Sandbox fullWidth skipRender>
               <CodeSnippet
@@ -208,6 +217,7 @@ export default function AppHeaderPage() {
               </GoAAppHeader>
             </Sandbox>
 
+            {/* Example 2 */}
             <h3 id="component-example-with-menu-click">Header with menu click event</h3>
             <Sandbox fullWidth skipRender>
               <GoARadioGroup name="device" value={deviceWidth} onChange={(_, value) => setDeviceWidth(value)}>
@@ -306,16 +316,37 @@ export default function AppHeaderPage() {
               `}
               />
             </Sandbox>
+
           </GoATab>
 
-          <GoATab
-            heading={
-              <>
-                Design guidelines
-                <GoABadge type="information" content="In progress" />
-              </>
-            }>
-            <p>Coming Soon</p>
+          <GoATab heading="Design">
+            <GoACallout
+              heading="Design documentation in Figma"
+              type="important"
+              size="medium"
+              maxWidth="540px"
+            >
+              Detailed design documentation for this component can be found on the associated{" "}
+              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
+                component page
+              </a>{" "}
+              in the Component library in Figma.
+            </GoACallout>
+          </GoATab>
+
+          <GoATab heading="Accessibility">
+            <GoACallout
+              heading="Accessibility documentation in Figma"
+              type="important"
+              size="medium"
+              maxWidth="550px"
+            >
+              Detailed accessibility documentation for this component can be found on the associated{" "}
+              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
+                component page
+              </a>{" "}
+              in the Component library in Figma.
+            </GoACallout>
           </GoATab>
         </GoATabs>
       </ComponentContent>

--- a/src/routes/components/Badge.tsx
+++ b/src/routes/components/Badge.tsx
@@ -1,5 +1,5 @@
 import { Category, ComponentHeader } from "@components/component-header/ComponentHeader.tsx";
-import { GoABadge, GoATab, GoATabs, GoABadgeType, GoABadgeProps } from "@abgov/react-components";
+import { GoABadge, GoATab, GoATabs, GoABadgeType, GoABadgeProps, GoACallout } from "@abgov/react-components";
 import { ComponentBinding, Sandbox } from "@components/sandbox";
 import { useState } from "react";
 import {
@@ -9,22 +9,17 @@ import {
 import { ComponentContent } from "@components/component-content/ComponentContent";
 
 // == Page props ==
-
 const componentName = "Badge";
 const description =
   "Small labels which hold small amounts of information, system feedback, or states.";
 const category = Category.FEEDBACK_AND_ALERTS;
 const relatedComponents = [
-  {
-    link: "/components/chip", name: "Chip"
-  },
-  {
-    link: "/components/Icons", name: "Icons"
-  },
-  {
-    link: "/components/Table", name: "Table"
-  }
+  { link: "/components/chip", name: "Chip" },
+  { link: "/components/Icons", name: "Icons" },
+  { link: "/components/Table", name: "Table" }
 ];
+const FIGMA_LINK = "https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=458-16984";
+
 
 type ComponentPropsType = GoABadgeProps;
 type CastingType = {
@@ -124,12 +119,18 @@ export default function BadgePage() {
 
   return (
     <>
-      <ComponentHeader name={componentName} category={category} description={description} relatedComponents={relatedComponents} />
+      <ComponentHeader name={componentName}
+                       category={category}
+                       description={description}
+                       relatedComponents={relatedComponents}
+                       githubLink={componentName}
+                       figmaLink={FIGMA_LINK}
+      />
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
 
         <GoATabs>
-          <GoATab heading="Code examples">
-            <h2 id="component" style={{display: "none"}}>Component</h2>
+          <GoATab heading="Code playground">
+            <h2 id="component" style={{display: "none"}}>Playground</h2>
             <Sandbox properties={badgeBindings} onChange={onSandboxChange}>
               <GoABadge {...badgeProps} />
             </Sandbox>
@@ -139,11 +140,39 @@ export default function BadgePage() {
           <GoATab
             heading={
               <>
-                Design guidelines
-                <GoABadge type="information" content="In progress" />
+                Examples
+                <GoABadge type="information" content="0" />
               </>
             }
-          ></GoATab>
+          >
+            <GoACallout heading="We are currently collecting design examples for this component" type="important" size="medium" maxWidth="540px">
+              {" "}
+              <a href="https://design.alberta.ca/get-started/support#:~:text=Raise%20an%20issue-,Talk%20to%20us,-Slack" target="_blank" rel="noreferrer">
+                Talk to the design system team
+              </a>{" "}
+              to contribute examples from your service.
+            </GoACallout>
+          </GoATab>
+
+          <GoATab heading="Design">
+            <GoACallout heading="Design documentation in Figma" type="important" size="medium" maxWidth="540px">
+              Detailed design documentation for this component can be found on the associated{" "}
+              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
+                component page
+              </a>{" "}
+              in the Component library in Figma.
+            </GoACallout>
+          </GoATab>
+          <GoATab heading="Accessibility">
+            <GoACallout heading="Accessibility documentation in Figma" type="important" size="medium" maxWidth="550px">
+              Detailed accessibility documentation for this component can be found on the associated{" "}
+              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
+                component page
+              </a>{" "}
+              in the Component library in Figma.
+            </GoACallout>
+          </GoATab>
+
         </GoATabs>
       </ComponentContent>
     </>

--- a/src/routes/components/Badge.tsx
+++ b/src/routes/components/Badge.tsx
@@ -7,7 +7,6 @@ import {
   ComponentProperty
 } from "@components/component-properties/ComponentProperties.tsx";
 import { ComponentContent } from "@components/component-content/ComponentContent";
-import { ExamplesEmpty } from "@components/examples-empty/ExamplesEmpty.tsx";
 import { DesignEmpty } from "@components/design-empty/DesignEmpty.tsx";
 import { AccessibilityEmpty } from "@components/accessibility-empty/AccessibilityEmpty.tsx";
 import BadgeExamples from "@examples/badge/BadgeExamples.tsx";
@@ -139,7 +138,7 @@ export default function BadgePage() {
               <GoABadge {...badgeProps} />
             </Sandbox>
             <ComponentProperties properties={componentProperties} />
-            <BadgeExamples />
+
 
           </GoATab>
 
@@ -147,11 +146,11 @@ export default function BadgePage() {
             heading={
               <>
                 Examples
-                <GoABadge type="information" content="0" />
+                <GoABadge type="information" content="3" />
               </>
             }
           >
-            <ExamplesEmpty/>
+            <BadgeExamples />
           </GoATab>
 
           <GoATab heading="Design">

--- a/src/routes/components/Badge.tsx
+++ b/src/routes/components/Badge.tsx
@@ -1,12 +1,15 @@
 import { Category, ComponentHeader } from "@components/component-header/ComponentHeader.tsx";
-import { GoABadge, GoATab, GoATabs, GoABadgeType, GoABadgeProps, GoACallout } from "@abgov/react-components";
+import { GoABadge, GoATab, GoATabs, GoABadgeType, GoABadgeProps, } from "@abgov/react-components";
 import { ComponentBinding, Sandbox } from "@components/sandbox";
 import { useState } from "react";
 import {
   ComponentProperties,
-  ComponentProperty,
+  ComponentProperty
 } from "@components/component-properties/ComponentProperties.tsx";
 import { ComponentContent } from "@components/component-content/ComponentContent";
+import { ExamplesEmpty } from "@components/examples-empty/ExamplesEmpty.tsx";
+import { DesignEmpty } from "@components/design-empty/DesignEmpty.tsx";
+import { AccessibilityEmpty } from "@components/accessibility-empty/AccessibilityEmpty.tsx";
 
 // == Page props ==
 const componentName = "Badge";
@@ -31,8 +34,8 @@ type CastingType = {
 
 export default function BadgePage() {
   const [badgeProps, setBadgeProps] = useState<ComponentPropsType>({
-    type: "information",
-    content: "Information",
+    type: "important",
+    content: "Badge"
   });
 
   const [badgeBindings, setBadgeBindings] = useState<ComponentBinding[]>([
@@ -41,26 +44,26 @@ export default function BadgePage() {
       type: "list",
       name: "type",
       options: ["success", "important", "information", "emergency", "dark", "midtone", "light"],
-      value: "information",
+      value: "important"
     },
     {
       label: "Icon",
       type: "boolean",
       name: "icon",
-      value: false,
+      value: false
     },
     {
       label: "Content",
       type: "string",
       name: "content",
-      value: "Information",
+      value: "Badge"
     },
     {
       label: "AriaLabel",
       type: "string",
       name: "ariaLabel",
-      value: "",
-    },
+      value: ""
+    }
   ]);
 
   const componentProperties: ComponentProperty[] = [
@@ -68,48 +71,48 @@ export default function BadgePage() {
       name: "type",
       type: "success | important | information | emergency | dark | midtone | light",
       description: "Define the context and colour of the badge",
-      required: true,
+      required: true
     },
     {
       name: "icon",
       type: "boolean",
       description: "Includes an icon in the badge.",
-      defaultValue: "false",
+      defaultValue: "false"
     },
     {
       name: "content",
       type: "string",
-      description: "Text label of the badge.",
+      description: "Text label of the badge."
     },
     {
       name: "ariaLabel",
       type: "string",
       description: "Accessible label.",
-      lang: "react",
+      lang: "react"
     },
     {
       name: "arialabel",
       type: "string",
       description: "Accessible label.",
-      lang: "angular",
+      lang: "angular"
     },
     {
       name: "testId",
       type: "string",
       lang: "react",
-      description: "Sets the data-testid attribute. Used with ByTestId queries in tests.",
+      description: "Sets the data-testid attribute. Used with ByTestId queries in tests."
     },
     {
       name: "testid",
       type: "string",
       lang: "angular",
-      description: "Sets the data-testid attribute. Used with ByTestId queries in tests.",
+      description: "Sets the data-testid attribute. Used with ByTestId queries in tests."
     },
     {
       name: "mt,mr,mb,ml",
       type: "none | 3xs | 2xs | xs | s | m | l | xl | 2xl | 3xl | 4xl",
-      description: "Apply margin to the top, right, bottom, and/or left of the component.",
-    },
+      description: "Apply margin to the top, right, bottom, and/or left of the component."
+    }
   ];
 
   function onSandboxChange(badgeBindings: ComponentBinding[], props: Record<string, unknown>) {
@@ -130,7 +133,7 @@ export default function BadgePage() {
 
         <GoATabs>
           <GoATab heading="Code playground">
-            <h2 id="component" style={{display: "none"}}>Playground</h2>
+            <h2 id="component" style={{ display: "none" }}>Playground</h2>
             <Sandbox properties={badgeBindings} onChange={onSandboxChange}>
               <GoABadge {...badgeProps} />
             </Sandbox>
@@ -145,32 +148,15 @@ export default function BadgePage() {
               </>
             }
           >
-            <GoACallout heading="We are currently collecting design examples for this component" type="important" size="medium" maxWidth="540px">
-              {" "}
-              <a href="https://design.alberta.ca/get-started/support#:~:text=Raise%20an%20issue-,Talk%20to%20us,-Slack" target="_blank" rel="noreferrer">
-                Talk to the design system team
-              </a>{" "}
-              to contribute examples from your service.
-            </GoACallout>
+            <ExamplesEmpty/>
           </GoATab>
 
           <GoATab heading="Design">
-            <GoACallout heading="Design documentation in Figma" type="important" size="medium" maxWidth="540px">
-              Detailed design documentation for this component can be found on the associated{" "}
-              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
-                component page
-              </a>{" "}
-              in the Component library in Figma.
-            </GoACallout>
+            <DesignEmpty figmaLink={FIGMA_LINK} />
           </GoATab>
+
           <GoATab heading="Accessibility">
-            <GoACallout heading="Accessibility documentation in Figma" type="important" size="medium" maxWidth="550px">
-              Detailed accessibility documentation for this component can be found on the associated{" "}
-              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
-                component page
-              </a>{" "}
-              in the Component library in Figma.
-            </GoACallout>
+            <AccessibilityEmpty figmaLink={FIGMA_LINK} />
           </GoATab>
 
         </GoATabs>

--- a/src/routes/components/Block.tsx
+++ b/src/routes/components/Block.tsx
@@ -9,7 +9,8 @@ import {
   GoABlock,
   GoATab,
   GoATabs,
-  GoACallout,
+  GoAText,
+  GoAContainer,
 } from "@abgov/react-components";
 import { ComponentContent } from "@components/component-content/ComponentContent";
 
@@ -139,13 +140,15 @@ export default function BlockPage() {
           </GoATab>
 
           <GoATab heading="Design">
-            <GoACallout heading="Using Block in design" type="important" size="medium" maxWidth="540px">
-              The block component is accomplished in design by using{" "}
-              <a href="https://help.figma.com/hc/en-us/articles/360040451373-Explore-auto-layout-properties" target="_blank" rel="noreferrer">
-                auto layout
-              </a>{" "}
-              in Figma, our design tool.
-            </GoACallout>
+            <GoAContainer type="non-interactive" accent="filled" padding="relaxed" width="content">
+              <GoAText size="body-m" mt="none" mb="none">
+                In design, use Figma's built-in{" "}
+                <a href="https://help.figma.com/hc/en-us/articles/360040451373-Explore-auto-layout-properties" target="_blank" rel="noreferrer">
+                  auto layout
+                </a>{" "}
+                feature to group multiple things with consistent spacing between them instead of a <i>Block</i> component.
+              </GoAText>
+            </GoAContainer>
           </GoATab>
 
         </GoATabs>

--- a/src/routes/components/Block.tsx
+++ b/src/routes/components/Block.tsx
@@ -5,8 +5,16 @@ import {
   ComponentProperty,
 } from "@components/component-properties/ComponentProperties.tsx";
 import { Category, ComponentHeader } from "@components/component-header/ComponentHeader.tsx";
-import { GoABadge, GoABlock, GoATab, GoATabs } from "@abgov/react-components";
+import {
+  GoABlock,
+  GoATab,
+  GoATabs,
+  GoACallout,
+} from "@abgov/react-components";
 import { ComponentContent } from "@components/component-content/ComponentContent";
+
+
+const componentName = "Block";
 
 export default function BlockPage() {
   const [blockProps, setBlockProps] = useState({});
@@ -60,7 +68,7 @@ export default function BlockPage() {
       name: "mt,mr,mb,ml",
       type: "none | 3xs | 2xs | xs | s | m | l | xl | 2xl | 3xl | 4xl",
       description: "Apply margin to the top, right, bottom, and/or left of the component.",
-    },  
+    },
   ];
 
   useEffect(() => {
@@ -76,7 +84,7 @@ export default function BlockPage() {
   return (
     <>
       <ComponentHeader
-        name="Block"
+        name={componentName}
         category={Category.UTILITIES}
         description="Used when grouping components into a block with consistent space between."
         relatedComponents={[
@@ -85,13 +93,14 @@ export default function BlockPage() {
           { link: "/patterns", name: "Layout" },
           { link: "/component/spacer", name: "Spacer" },
         ]}
+        githubLink={componentName}
       />
 
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
 
         <GoATabs>
-          <GoATab heading="Code examples">
-            <h2 id="component" style={{display: "none"}}>Component</h2>
+          <GoATab heading="Code playground">
+            <h2 id="component" style={{ display: "none" }}>Playground</h2>
             <Sandbox properties={blockBindings} onChange={onSandboxChange} fullWidth={sandboxFullWidth}>
               <GoABlock {...blockProps}>
                 <div
@@ -126,18 +135,19 @@ export default function BlockPage() {
                 </div>
               </GoABlock>
             </Sandbox>
-            {/*Block table properties*/}
             <ComponentProperties properties={componentProperties} />
           </GoATab>
 
-          <GoATab
-            heading={
-              <>
-                Design guidelines
-                <GoABadge type="information" content="In progress" />
-              </>
-            }
-          ></GoATab>
+          <GoATab heading="Design">
+            <GoACallout heading="Using Block in design" type="important" size="medium" maxWidth="540px">
+              The block component is accomplished in design by using{" "}
+              <a href="https://help.figma.com/hc/en-us/articles/360040451373-Explore-auto-layout-properties" target="_blank" rel="noreferrer">
+                auto layout
+              </a>{" "}
+              in Figma, our design tool.
+            </GoACallout>
+          </GoATab>
+
         </GoATabs>
       </ComponentContent>
     </>

--- a/src/routes/components/Button.tsx
+++ b/src/routes/components/Button.tsx
@@ -10,7 +10,6 @@ import {
   GoAInput,
   GoATab,
   GoATabs,
-  GoAText,
 } from "@abgov/react-components";
 import { Sandbox, ComponentBinding } from "@components/sandbox";
 import { CodeSnippet } from "@components/code-snippet/CodeSnippet";
@@ -30,7 +29,7 @@ export default function ButtonPage() {
       label: "Type",
       type: "list",
       name: "type",
-      options: ["primary", "secondary", "tertiary", "start"],
+      options: ["primary", "submit", "secondary", "tertiary", "start"],
       value: "",
       defaultValue: "primary",
     },
@@ -62,6 +61,7 @@ export default function ButtonPage() {
       options: [""].concat(ICONS),
       value: "",
     },
+    {label: "Width", type: "string", name: "width", value: ""},
     { label: "Disabled", type: "boolean", name: "disabled", value: false },
   ]);
   const componentProperties: ComponentProperty[] = [
@@ -114,6 +114,11 @@ export default function ButtonPage() {
       description: "Shows an icon to the right of the text.",
     },
     {
+      name: "width",
+      type: "string",
+      description: "Sets the width of the button.",
+    },
+    {
       name: "_click",
       lang: "angular",
       type: "CustomEvent",
@@ -154,17 +159,16 @@ export default function ButtonPage() {
       <ComponentHeader
         name="Button"
         category={Category.INPUTS_AND_ACTIONS}
-        description="Carry out an important action or navigate to another page."
+        description="Carry out an important action or to navigate to another page."
         relatedComponents={[
-          { link: "/components/button-group", name: "Button group" },
+          { link: "/components/buttonGroup", name: "Button group" },
           { link: "/components/icon-button", name: "Icon button" },
         ]}
-        githubLink="routes/components/Button.tsx"
       />
 
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
         <GoATabs>
-          <GoATab heading="Code">
+          <GoATab heading="Code examples">
             {/*Button Sandbox*/}
             <h2 id="component" style={{display: "none"}}>Component</h2>
             <Sandbox properties={buttonBindings} onChange={SandboxOnChange}>
@@ -181,22 +185,21 @@ export default function ButtonPage() {
                 `}
               />
               <GoAButton {...buttonProps} onClick={noop}>
-                Button
+                Primary Button
               </GoAButton>
             </Sandbox>
 
             {/*Button Table Properties*/}
             <ComponentProperties properties={componentProperties} />
-          </GoATab>
-          
-          <GoATab heading="Examples">
+
             {/*Button Examples*/}
-      
+            <h2 id="component-examples" className="hidden" aria-hidden="true">Examples</h2>
+
+
             {/*Button Example 1*/}
             <h3 id="component-example-ask-address">Ask a user for an address</h3>
             <Sandbox flags={["reactive"]}>
-              
-              
+
             <GoABlock gap="xl" direction="column">
               <GoAFormItem label="Street Address">
                 <GoAInput name="address" type="text" value="" onChange={noop} width="100%" />
@@ -228,9 +231,9 @@ export default function ButtonPage() {
                   <GoAInput name="postalCode" type="text" value="" onChange={noop} width="100%" />
                 </GoAFormItem>
               </GoABlock>
-              
+
              </GoABlock>
-              
+
               <GoAButtonGroup alignment="start" mt="2xl">
                 <GoAButton type="primary" onClick={noop}>
                   Submit and continue
@@ -276,13 +279,14 @@ export default function ButtonPage() {
             </Sandbox>
           </GoATab>
 
-          <GoATab heading="Design">
-            
-            
-          </GoATab>
-          <GoATab heading="Accessibility">
-            
-            
+          <GoATab
+            heading={
+              <>
+                Design guidelines
+                <GoABadge type="information" content="In progress" />
+              </>
+            }>
+            <p>Coming Soon</p>
           </GoATab>
         </GoATabs>
       </ComponentContent>

--- a/src/routes/components/Button.tsx
+++ b/src/routes/components/Button.tsx
@@ -10,6 +10,7 @@ import {
   GoAInput,
   GoATab,
   GoATabs,
+  GoAText,
 } from "@abgov/react-components";
 import { Sandbox, ComponentBinding } from "@components/sandbox";
 import { CodeSnippet } from "@components/code-snippet/CodeSnippet";
@@ -29,7 +30,7 @@ export default function ButtonPage() {
       label: "Type",
       type: "list",
       name: "type",
-      options: ["primary", "submit", "secondary", "tertiary", "start"],
+      options: ["primary", "secondary", "tertiary", "start"],
       value: "",
       defaultValue: "primary",
     },
@@ -61,7 +62,6 @@ export default function ButtonPage() {
       options: [""].concat(ICONS),
       value: "",
     },
-    {label: "Width", type: "string", name: "width", value: ""},
     { label: "Disabled", type: "boolean", name: "disabled", value: false },
   ]);
   const componentProperties: ComponentProperty[] = [
@@ -114,11 +114,6 @@ export default function ButtonPage() {
       description: "Shows an icon to the right of the text.",
     },
     {
-      name: "width",
-      type: "string",
-      description: "Sets the width of the button.",
-    },
-    {
       name: "_click",
       lang: "angular",
       type: "CustomEvent",
@@ -159,16 +154,16 @@ export default function ButtonPage() {
       <ComponentHeader
         name="Button"
         category={Category.INPUTS_AND_ACTIONS}
-        description="Carry out an important action or to navigate to another page."
+        description="Carry out an important action or navigate to another page."
         relatedComponents={[
-          { link: "/components/buttonGroup", name: "Button group" },
+          { link: "/components/button-group", name: "Button group" },
           { link: "/components/icon-button", name: "Icon button" },
         ]}
       />
 
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
         <GoATabs>
-          <GoATab heading="Code examples">
+          <GoATab heading="Code">
             {/*Button Sandbox*/}
             <h2 id="component" style={{display: "none"}}>Component</h2>
             <Sandbox properties={buttonBindings} onChange={SandboxOnChange}>
@@ -185,20 +180,21 @@ export default function ButtonPage() {
                 `}
               />
               <GoAButton {...buttonProps} onClick={noop}>
-                Primary Button
+                Button
               </GoAButton>
             </Sandbox>
 
             {/*Button Table Properties*/}
             <ComponentProperties properties={componentProperties} />
-
+          </GoATab>
+          
+          <GoATab heading="Examples">
             {/*Button Examples*/}
-            <h2 id="component-examples" className="hidden" aria-hidden="true">Examples</h2>
-
-
+      
             {/*Button Example 1*/}
             <h3 id="component-example-ask-address">Ask a user for an address</h3>
             <Sandbox flags={["reactive"]}>
+              
               
             <GoABlock gap="xl" direction="column">
               <GoAFormItem label="Street Address">
@@ -279,14 +275,13 @@ export default function ButtonPage() {
             </Sandbox>
           </GoATab>
 
-          <GoATab
-            heading={
-              <>
-                Design guidelines
-                <GoABadge type="information" content="In progress" />
-              </>
-            }>
-            <p>Coming Soon</p>
+          <GoATab heading="Design">
+            
+            
+          </GoATab>
+          <GoATab heading="Accessibility">
+            
+            
           </GoATab>
         </GoATabs>
       </ComponentContent>

--- a/src/routes/components/Button.tsx
+++ b/src/routes/components/Button.tsx
@@ -159,6 +159,7 @@ export default function ButtonPage() {
           { link: "/components/button-group", name: "Button group" },
           { link: "/components/icon-button", name: "Icon button" },
         ]}
+        githubLink="routes/components/Button.tsx"
       />
 
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">

--- a/src/routes/components/Button.tsx
+++ b/src/routes/components/Button.tsx
@@ -4,7 +4,6 @@ import {
   GoABlock,
   GoAButton,
   GoAButtonGroup,
-  GoACallout,
   GoADropdown,
   GoADropdownItem,
   GoAFormItem,
@@ -22,6 +21,8 @@ import {
 } from "@components/component-properties/ComponentProperties";
 import ICONS from "@routes/components/icons.json";
 import { ComponentContent } from "@components/component-content/ComponentContent";
+import { DesignEmpty } from "@components/design-empty/DesignEmpty.tsx";
+import { AccessibilityEmpty } from "@components/accessibility-empty/AccessibilityEmpty.tsx";
 
 const FIGMA_LINK = "https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=420-6810";
 
@@ -254,7 +255,7 @@ export default function ButtonPage() {
 
             {/*Button example 2*/}
             <h3 id="component-example-confirm-action">Confirm a destructive action</h3>
-            <Sandbox flags={["reactive"]}>
+            <Sandbox flags={["reactive"]} /*background="#33333380"*/>
               <GoAModal heading="Are you sure you want to delete this record?">
                 <p>You cannot undo this action.</p>
 
@@ -288,24 +289,13 @@ export default function ButtonPage() {
           </GoATab>
 
           <GoATab heading="Design">
-            <GoACallout heading="Design documentation in Figma" type="important" size="medium" maxWidth="540px">
-              Detailed design documentation for this component can be found on the associated{" "}
-              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
-                component page
-              </a>{" "}
-              in the Component library in Figma.
-            </GoACallout>
+            <DesignEmpty figmaLink={FIGMA_LINK} />
           </GoATab>
 
           <GoATab heading="Accessibility">
-            <GoACallout heading="Accessibility documentation in Figma" type="important" size="medium" maxWidth="550px">
-              Detailed accessibility documentation for this component can be found on the associated{" "}
-              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
-                component page
-              </a>{" "}
-              in the Component library in Figma.
-            </GoACallout>
+            <AccessibilityEmpty figmaLink={FIGMA_LINK} />
           </GoATab>
+
         </GoATabs>
       </ComponentContent>
     </>

--- a/src/routes/components/Button.tsx
+++ b/src/routes/components/Button.tsx
@@ -4,6 +4,7 @@ import {
   GoABlock,
   GoAButton,
   GoAButtonGroup,
+  GoACallout,
   GoADropdown,
   GoADropdownItem,
   GoAFormItem,
@@ -21,6 +22,9 @@ import {
 } from "@components/component-properties/ComponentProperties";
 import ICONS from "@routes/components/icons.json";
 import { ComponentContent } from "@components/component-content/ComponentContent";
+
+const FIGMA_LINK = "https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=420-6810";
+
 
 export default function ButtonPage() {
   const [buttonProps, setButtonProps] = useState({});
@@ -164,13 +168,15 @@ export default function ButtonPage() {
           { link: "/components/buttonGroup", name: "Button group" },
           { link: "/components/icon-button", name: "Icon button" },
         ]}
+        githubLink="Button"
+        figmaLink={FIGMA_LINK}
       />
 
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
         <GoATabs>
-          <GoATab heading="Code examples">
+          <GoATab heading="Code playground">
             {/*Button Sandbox*/}
-            <h2 id="component" style={{display: "none"}}>Component</h2>
+            <h2 id="component" style={{display: "none"}}>Playground</h2>
             <Sandbox properties={buttonBindings} onChange={SandboxOnChange}>
               <CodeSnippet
                 lang="typescript"
@@ -190,10 +196,12 @@ export default function ButtonPage() {
             </Sandbox>
 
             {/*Button Table Properties*/}
-            <ComponentProperties properties={componentProperties} />
 
+            <ComponentProperties properties={componentProperties} />
+          </GoATab>
+          <GoATab heading={<>Examples<GoABadge type="information" content="3" /></>}>
             {/*Button Examples*/}
-            <h2 id="component-examples" className="hidden" aria-hidden="true">Examples</h2>
+            <h2 className="hidden" aria-hidden="true">Examples</h2>
 
 
             {/*Button Example 1*/}
@@ -279,14 +287,24 @@ export default function ButtonPage() {
             </Sandbox>
           </GoATab>
 
-          <GoATab
-            heading={
-              <>
-                Design guidelines
-                <GoABadge type="information" content="In progress" />
-              </>
-            }>
-            <p>Coming Soon</p>
+          <GoATab heading="Design">
+            <GoACallout heading="Design documentation in Figma" type="important" size="medium" maxWidth="540px">
+              Detailed design documentation for this component can be found on the associated{" "}
+              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
+                component page
+              </a>{" "}
+              in the Component library in Figma.
+            </GoACallout>
+          </GoATab>
+
+          <GoATab heading="Accessibility">
+            <GoACallout heading="Accessibility documentation in Figma" type="important" size="medium" maxWidth="550px">
+              Detailed accessibility documentation for this component can be found on the associated{" "}
+              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
+                component page
+              </a>{" "}
+              in the Component library in Figma.
+            </GoACallout>
           </GoATab>
         </GoATabs>
       </ComponentContent>

--- a/src/routes/components/ButtonGroup.tsx
+++ b/src/routes/components/ButtonGroup.tsx
@@ -5,9 +5,19 @@ import {
   ComponentProperty,
 } from "@components/component-properties/ComponentProperties.tsx";
 import { Category, ComponentHeader } from "@components/component-header/ComponentHeader.tsx";
-import { GoABadge, GoAButton, GoAButtonGroup, GoATab, GoATabs } from "@abgov/react-components";
+import {
+  GoABadge,
+  GoAButton,
+  GoAButtonGroup,
+  GoATab,
+  GoATabs,
+  GoACallout,
+} from "@abgov/react-components";
 import { GoAButtonGroupAlignment } from "@abgov/react-components";
 import { ComponentContent } from "@components/component-content/ComponentContent";
+
+const FIGMA_LINK =
+  "https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=27301-302108";
 
 export default function ButtonGroupPage() {
   const [buttonGroupProps, setButtonGroupProps] = useState({
@@ -62,13 +72,13 @@ export default function ButtonGroupPage() {
       type: "none | 3xs | 2xs | xs | s | m | l | xl | 2xl | 3xl | 4xl",
       description: "Apply margin to the top, right, bottom, and/or left of the component.",
     },
-  ]; 
+  ];
 
-  const noop = () => { };
+  const noop = () => {};
 
   function onSandboxChange(bindings: ComponentBinding[], props: Record<string, unknown>) {
     setButtonGroupBindings(bindings);
-    setButtonGroupProps(props as { alignment: GoAButtonGroupAlignment;[key: string]: unknown });
+    setButtonGroupProps(props as { alignment: GoAButtonGroupAlignment; [key: string]: unknown });
   }
 
   return (
@@ -76,24 +86,20 @@ export default function ButtonGroupPage() {
       <ComponentHeader
         name="Button Group"
         category={Category.INPUTS_AND_ACTIONS}
-        description={
-          "Display multiple related actions stacked or in a horizontal row to help with arrangement and spacing."
-        }
+        description="Display multiple related actions stacked or in a horizontal row to help with arrangement and spacing."
         relatedComponents={[
           { link: "/components/button", name: "Button" },
-          /* 
-          { link: "/components/icon-button", name: "Icon button" },
-          { link: "/components/link", name: "Link" }, 
-          */
         ]}
+        githubLink="ButtonGroup"
+        figmaLink={FIGMA_LINK}
       />
 
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
-
         <GoATabs>
-          <GoATab heading="Code examples">
-            {/*Button Group Sandbox*/}
-            <h2 id="component" style={{display: "none"}}>Component</h2>
+          <GoATab heading="Code playground">
+            <h2 id="component" style={{ display: "none" }}>
+              Playground
+            </h2>
             <Sandbox properties={buttonGroupBindings} onChange={onSandboxChange} fullWidth>
               <GoAButtonGroup {...buttonGroupProps}>
                 <GoAButton type="primary" onClick={noop}>
@@ -107,17 +113,36 @@ export default function ButtonGroupPage() {
                 </GoAButton>
               </GoAButtonGroup>
             </Sandbox>
-
             <ComponentProperties properties={componentProperties} />
           </GoATab>
-          <GoATab
-            heading={
-              <>
-                Design guidelines
-                <GoABadge type="information" content="In progress" />
-              </>
-            }
-          ></GoATab>
+          <GoATab heading={<>Examples<GoABadge type="information" content="0" /></>}>
+            <GoACallout heading="We are currently collecting design examples for this component" type="important" size="medium" maxWidth="540px">
+              {" "}
+              <a href="https://design.alberta.ca/get-started/support#:~:text=Raise%20an%20issue-,Talk%20to%20us,-Slack" target="_blank" rel="noreferrer">
+                Talk to the design system team
+              </a>{" "}
+              to contribute examples from your service.
+            </GoACallout>
+
+          </GoATab>
+          <GoATab heading="Design">
+            <GoACallout heading="Design documentation in Figma" type="important" size="medium" maxWidth="540px">
+              Detailed design documentation for this component can be found on the associated{" "}
+              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
+                component page
+              </a>{" "}
+              in the Component library in Figma.
+            </GoACallout>
+          </GoATab>
+          <GoATab heading="Accessibility">
+            <GoACallout heading="Accessibility documentation in Figma" type="important" size="medium" maxWidth="550px">
+              Detailed accessibility documentation for this component can be found on the associated{" "}
+              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
+                component page
+              </a>{" "}
+              in the Component library in Figma.
+            </GoACallout>
+          </GoATab>
         </GoATabs>
       </ComponentContent>
     </>

--- a/src/routes/components/ButtonGroup.tsx
+++ b/src/routes/components/ButtonGroup.tsx
@@ -11,10 +11,12 @@ import {
   GoAButtonGroup,
   GoATab,
   GoATabs,
-  GoACallout,
 } from "@abgov/react-components";
 import { GoAButtonGroupAlignment } from "@abgov/react-components";
 import { ComponentContent } from "@components/component-content/ComponentContent";
+import { ExamplesEmpty } from "@components/examples-empty/ExamplesEmpty.tsx";
+import { AccessibilityEmpty } from "@components/accessibility-empty/AccessibilityEmpty.tsx";
+import { DesignEmpty } from "@components/design-empty/DesignEmpty.tsx";
 
 const FIGMA_LINK =
   "https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=27301-302108";
@@ -115,34 +117,19 @@ export default function ButtonGroupPage() {
             </Sandbox>
             <ComponentProperties properties={componentProperties} />
           </GoATab>
-          <GoATab heading={<>Examples<GoABadge type="information" content="0" /></>}>
-            <GoACallout heading="We are currently collecting design examples for this component" type="important" size="medium" maxWidth="540px">
-              {" "}
-              <a href="https://design.alberta.ca/get-started/support#:~:text=Raise%20an%20issue-,Talk%20to%20us,-Slack" target="_blank" rel="noreferrer">
-                Talk to the design system team
-              </a>{" "}
-              to contribute examples from your service.
-            </GoACallout>
 
+          <GoATab heading={<>Examples<GoABadge type="information" content="0" /></>}>
+            <ExamplesEmpty/>
           </GoATab>
+
           <GoATab heading="Design">
-            <GoACallout heading="Design documentation in Figma" type="important" size="medium" maxWidth="540px">
-              Detailed design documentation for this component can be found on the associated{" "}
-              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
-                component page
-              </a>{" "}
-              in the Component library in Figma.
-            </GoACallout>
+            <DesignEmpty figmaLink={FIGMA_LINK} />
           </GoATab>
+
           <GoATab heading="Accessibility">
-            <GoACallout heading="Accessibility documentation in Figma" type="important" size="medium" maxWidth="550px">
-              Detailed accessibility documentation for this component can be found on the associated{" "}
-              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
-                component page
-              </a>{" "}
-              in the Component library in Figma.
-            </GoACallout>
+            <AccessibilityEmpty figmaLink={FIGMA_LINK} />
           </GoATab>
+
         </GoATabs>
       </ComponentContent>
     </>

--- a/src/routes/components/Callout.tsx
+++ b/src/routes/components/Callout.tsx
@@ -9,20 +9,16 @@ import {
 } from "@abgov/react-components";
 import { ComponentBinding, Sandbox } from "@components/sandbox";
 import { useState } from "react";
-
-import {
-  ComponentProperties,
-  ComponentProperty,
-} from "@components/component-properties/ComponentProperties.tsx";
+import { ComponentProperties, ComponentProperty } from "@components/component-properties/ComponentProperties.tsx";
 import { ComponentContent } from "@components/component-content/ComponentContent";
 
-// == Page props ==
-
+const FIGMA_LINK =
+  "https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=434-14122";
 const componentName = "Callout";
 const description = "Communicate important information through a strong visual emphasis.";
 const category = Category.FEEDBACK_AND_ALERTS;
 const relatedComponents = [
-  { link: "/components/Notification-banner", name: "Notification banner" },
+  { link: "/components/notification-banner", name: "Notification banner" },
 ];
 type ComponentPropsType = GoACalloutProps;
 type CastingType = {
@@ -141,14 +137,14 @@ export default function CalloutPage() {
         category={category}
         description={description}
         relatedComponents={relatedComponents}
+        githubLink={componentName}
+        figmaLink={FIGMA_LINK}
       />
 
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
         <GoATabs>
-          <GoATab heading="Code examples">
-            <h2 id="component" style={{ display: "none" }}>
-              Component
-            </h2>
+          <GoATab heading="Code playground">
+            <h2 id="component" style={{ display: "none" }}>Playground</h2>
             <Sandbox properties={componentBindings} onChange={onSandboxChange}>
               <GoACallout {...componentProps}>
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit.
@@ -156,14 +152,32 @@ export default function CalloutPage() {
             </Sandbox>
             <ComponentProperties properties={componentProperties} />
           </GoATab>
-
-          <GoATab
-            heading={
-              <>
-                Design guidelines
-                <GoABadge type="information" content="In progress" />
-              </>
-            }></GoATab>
+          <GoATab heading={<>Examples<GoABadge type="information" content="0" /></>}>
+            <GoACallout heading="We are currently working on design examples for this component" type="important" size="medium" maxWidth="540px">
+              <a href="https://design.alberta.ca/get-started/support#:~:text=Raise%20an%20issue-,Talk%20to%20us,-Slack" target="_blank" rel="noreferrer">
+                Talk to the design system team
+              </a>{" "}
+              to contribute examples from your service.
+            </GoACallout>
+          </GoATab>
+          <GoATab heading="Design">
+            <GoACallout heading="Design documentation in Figma" type="important" size="medium" maxWidth="540px">
+              Detailed design documentation for this component can be found on the associated{" "}
+              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
+                component page
+              </a>{" "}
+              in the Component library in Figma.
+            </GoACallout>
+          </GoATab>
+          <GoATab heading="Accessibility">
+            <GoACallout heading="Accessibility documentation in Figma" type="important" size="medium" maxWidth="550px">
+              Detailed accessibility documentation for this component can be found on the associated{" "}
+              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
+                component page
+              </a>{" "}
+              in the Component library in Figma.
+            </GoACallout>
+          </GoATab>
         </GoATabs>
       </ComponentContent>
     </>

--- a/src/routes/components/Callout.tsx
+++ b/src/routes/components/Callout.tsx
@@ -14,7 +14,6 @@ import { ComponentBinding, Sandbox } from "@components/sandbox";
 import { useState } from "react";
 import { ComponentProperties, ComponentProperty } from "@components/component-properties/ComponentProperties.tsx";
 import { ComponentContent } from "@components/component-content/ComponentContent";
-import { ExamplesEmpty } from "@components/examples-empty/ExamplesEmpty.tsx";
 import { DesignEmpty } from "@components/design-empty/DesignEmpty.tsx";
 import { AccessibilityEmpty } from "@components/accessibility-empty/AccessibilityEmpty.tsx";
 import { CodeSnippet } from "@components/code-snippet/CodeSnippet.tsx";
@@ -158,8 +157,10 @@ export default function CalloutPage() {
               </GoACallout>
             </Sandbox>
             <ComponentProperties properties={componentProperties} />
-            
-            <h2 id="component-examples" className="hidden" aria-hidden="true">Examples</h2>
+
+          </GoATab>
+
+          <GoATab heading={<>Examples<GoABadge type="information" content="1" /></>}>
 
             <h3 id="component-example-confirm-application-submitted">Confirm that an application was submitted</h3>
             <Sandbox fullWidth allow={['h2', 'h3', 'p']} skipRender>
@@ -232,10 +233,6 @@ export default function CalloutPage() {
                 <GoAButton type="secondary">Back to dashboard</GoAButton>
               </GoAButtonGroup>
             </Sandbox>
-          </GoATab>
-
-          <GoATab heading={<>Examples<GoABadge type="information" content="0" /></>}>
-            <ExamplesEmpty/>
           </GoATab>
 
           <GoATab heading="Design">

--- a/src/routes/components/Callout.tsx
+++ b/src/routes/components/Callout.tsx
@@ -11,6 +11,9 @@ import { ComponentBinding, Sandbox } from "@components/sandbox";
 import { useState } from "react";
 import { ComponentProperties, ComponentProperty } from "@components/component-properties/ComponentProperties.tsx";
 import { ComponentContent } from "@components/component-content/ComponentContent";
+import { ExamplesEmpty } from "@components/examples-empty/ExamplesEmpty.tsx";
+import { DesignEmpty } from "@components/design-empty/DesignEmpty.tsx";
+import { AccessibilityEmpty } from "@components/accessibility-empty/AccessibilityEmpty.tsx";
 
 const FIGMA_LINK =
   "https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=434-14122";
@@ -152,32 +155,19 @@ export default function CalloutPage() {
             </Sandbox>
             <ComponentProperties properties={componentProperties} />
           </GoATab>
+
           <GoATab heading={<>Examples<GoABadge type="information" content="0" /></>}>
-            <GoACallout heading="We are currently working on design examples for this component" type="important" size="medium" maxWidth="540px">
-              <a href="https://design.alberta.ca/get-started/support#:~:text=Raise%20an%20issue-,Talk%20to%20us,-Slack" target="_blank" rel="noreferrer">
-                Talk to the design system team
-              </a>{" "}
-              to contribute examples from your service.
-            </GoACallout>
+            <ExamplesEmpty/>
           </GoATab>
+
           <GoATab heading="Design">
-            <GoACallout heading="Design documentation in Figma" type="important" size="medium" maxWidth="540px">
-              Detailed design documentation for this component can be found on the associated{" "}
-              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
-                component page
-              </a>{" "}
-              in the Component library in Figma.
-            </GoACallout>
+            <DesignEmpty figmaLink={FIGMA_LINK} />
           </GoATab>
+
           <GoATab heading="Accessibility">
-            <GoACallout heading="Accessibility documentation in Figma" type="important" size="medium" maxWidth="550px">
-              Detailed accessibility documentation for this component can be found on the associated{" "}
-              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
-                component page
-              </a>{" "}
-              in the Component library in Figma.
-            </GoACallout>
+            <AccessibilityEmpty figmaLink={FIGMA_LINK} />
           </GoATab>
+
         </GoATabs>
       </ComponentContent>
     </>

--- a/src/routes/components/Checkbox.tsx
+++ b/src/routes/components/Checkbox.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { GoABadge, GoACheckbox, GoACheckboxProps, GoAFormItem, GoATab, GoATabs, GoACallout } from "@abgov/react-components";
+import { GoABadge, GoACheckbox, GoACheckboxProps, GoAFormItem, GoATab, GoATabs, } from "@abgov/react-components";
 import { Sandbox, ComponentBinding } from "@components/sandbox";
 import { CodeSnippet } from "@components/code-snippet/CodeSnippet";
 import {
@@ -10,6 +10,8 @@ import { Category, ComponentHeader } from "@components/component-header/Componen
 import { useSandboxFormItem } from "@hooks/useSandboxFormItem.tsx";
 import { ComponentContent } from "@components/component-content/ComponentContent";
 import CheckboxExamples from "@examples/checkbox/CheckboxExamples.tsx";
+import { DesignEmpty } from "@components/design-empty/DesignEmpty.tsx";
+import { AccessibilityEmpty } from "@components/accessibility-empty/AccessibilityEmpty.tsx";
 
 const FIGMA_LINK =
   "https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=183-219";
@@ -177,6 +179,7 @@ export default function CheckboxPage() {
       />
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
         <GoATabs>
+
           <GoATab heading="Code playground">
             <h2 id="component" style={{ display: "none" }}>Playground</h2>
             <Sandbox
@@ -217,29 +220,19 @@ export default function CheckboxPage() {
             </Sandbox>
             <ComponentProperties properties={componentProperties} />
           </GoATab>
+
           <GoATab heading={<>Examples<GoABadge type="information" content="1" /></>}>
             <CheckboxExamples />
-
-
           </GoATab>
+
           <GoATab heading="Design">
-            <GoACallout heading="Design documentation in Figma" type="important" size="medium" maxWidth="540px">
-              Detailed design documentation for this component can be found on the associated{" "}
-              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
-                component page
-              </a>{" "}
-              in the Component library in Figma.
-            </GoACallout>
+            <DesignEmpty figmaLink={FIGMA_LINK} />
           </GoATab>
+
           <GoATab heading="Accessibility">
-            <GoACallout heading="Accessibility documentation in Figma" type="important" size="medium" maxWidth="550px">
-              Detailed accessibility documentation for this component can be found on the associated{" "}
-              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
-                component page
-              </a>{" "}
-              in the Component library in Figma.
-            </GoACallout>
+            <AccessibilityEmpty figmaLink={FIGMA_LINK} />
           </GoATab>
+
         </GoATabs>
       </ComponentContent>
     </>

--- a/src/routes/components/Checkbox.tsx
+++ b/src/routes/components/Checkbox.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { GoABadge, GoACheckbox, GoACheckboxProps, GoAFormItem, GoATab, GoATabs } from "@abgov/react-components";
+import { GoABadge, GoACheckbox, GoACheckboxProps, GoAFormItem, GoATab, GoATabs, GoACallout } from "@abgov/react-components";
 import { Sandbox, ComponentBinding } from "@components/sandbox";
 import { CodeSnippet } from "@components/code-snippet/CodeSnippet";
 import {
@@ -11,7 +11,8 @@ import { useSandboxFormItem } from "@hooks/useSandboxFormItem.tsx";
 import { ComponentContent } from "@components/component-content/ComponentContent";
 import CheckboxExamples from "@examples/checkbox/CheckboxExamples.tsx";
 
-// == Page props ==
+const FIGMA_LINK =
+  "https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=183-219";
 const componentName = "Checkbox";
 const description = "Let the user select one or more options.";
 const category = Category.INPUTS_AND_ACTIONS;
@@ -26,6 +27,7 @@ type CastingType = {
   checked: boolean;
   [key: string]: unknown;
 };
+
 export default function CheckboxPage() {
   const [checkboxProps, setCheckboxProps] = useState<ComponentPropsType>({
     name: "item",
@@ -165,12 +167,18 @@ export default function CheckboxPage() {
 
   return (
     <>
-      <ComponentHeader name={componentName} category={category} description={description} relatedComponents={relatedComponents} />
+      <ComponentHeader
+        name={componentName}
+        category={category}
+        description={description}
+        relatedComponents={relatedComponents}
+        githubLink={componentName}
+        figmaLink={FIGMA_LINK}
+      />
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
-
         <GoATabs>
-          <GoATab heading="Code examples">
-            <h2 id="component" style={{display: "none"}}>Component</h2>
+          <GoATab heading="Code playground">
+            <h2 id="component" style={{ display: "none" }}>Playground</h2>
             <Sandbox
               properties={checkboxBindings}
               formItemProperties={formItemBindings}
@@ -207,18 +215,31 @@ export default function CheckboxPage() {
                 <GoACheckbox {...checkboxProps} onChange={noop} />
               </GoAFormItem>
             </Sandbox>
-
             <ComponentProperties properties={componentProperties} />
-            <CheckboxExamples />
           </GoATab>
+          <GoATab heading={<>Examples<GoABadge type="information" content="1" /></>}>
+            <CheckboxExamples />
 
-          <GoATab
-            heading={
-              <>
-                Design guidelines
-                <GoABadge type="information" content="In progress" />
-              </>
-            }></GoATab>
+
+          </GoATab>
+          <GoATab heading="Design">
+            <GoACallout heading="Design documentation in Figma" type="important" size="medium" maxWidth="540px">
+              Detailed design documentation for this component can be found on the associated{" "}
+              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
+                component page
+              </a>{" "}
+              in the Component library in Figma.
+            </GoACallout>
+          </GoATab>
+          <GoATab heading="Accessibility">
+            <GoACallout heading="Accessibility documentation in Figma" type="important" size="medium" maxWidth="550px">
+              Detailed accessibility documentation for this component can be found on the associated{" "}
+              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
+                component page
+              </a>{" "}
+              in the Component library in Figma.
+            </GoACallout>
+          </GoATab>
         </GoATabs>
       </ComponentContent>
     </>

--- a/src/routes/components/Container.tsx
+++ b/src/routes/components/Container.tsx
@@ -7,14 +7,17 @@ import {
 import { Category, ComponentHeader } from "@components/component-header/ComponentHeader";
 import {
   GoABadge,
-  GoAContainer, GoAContainerProps,
+  GoAContainer,
+  GoAContainerProps,
   GoATab,
-  GoATabs
+  GoATabs,
+  GoACallout,
 } from "@abgov/react-components";
 import ContainerExamples from "@examples/container/ContainerExamples.tsx";
 import { ComponentContent } from "@components/component-content/ComponentContent";
 
-// == Page props ==
+const FIGMA_LINK =
+  "https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=1789-12623";
 const componentName = "Container";
 const description = "Group information, create hierarchy, and show related information.";
 const category = Category.FEEDBACK_AND_ALERTS;
@@ -121,7 +124,7 @@ export default function ContainerPage() {
       type: "string",
       description: "Sets the maximum width of the container.",
       lang: "angular",
-    },    
+    },
     {
       name: "testId",
       type: "string",
@@ -153,13 +156,15 @@ export default function ContainerPage() {
         category={category}
         description={description}
         relatedComponents={relatedComponents}
+        githubLink={componentName}
+        figmaLink={FIGMA_LINK}
       />
 
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
 
         <GoATabs>
-          <GoATab heading={"Code examples"}>
-            <h2 id="component" style={{display: "none"}}>Component</h2>
+          <GoATab heading="Code playground">
+            <h2 id="component" style={{ display: "none" }}>Playground</h2>
             <Sandbox properties={containerBindings} onChange={onSandboxChange} fullWidth>
               <GoAContainer {...containerProps}>
                 <h2>Detach to use</h2>
@@ -169,18 +174,29 @@ export default function ContainerPage() {
 
             {/*Container Table Properties*/}
             <ComponentProperties properties={componentProperties} />
-            <ContainerExamples />
-
           </GoATab>
 
-          <GoATab
-            heading={
-              <>
-                Design guidelines
-                <GoABadge type="information" content="In progress" />
-              </>
-            }>
-            <p>Coming Soon</p>
+          <GoATab heading={<>Examples<GoABadge type="information" content="4" /></>}>
+            <ContainerExamples />
+          </GoATab>
+
+          <GoATab heading="Design">
+            <GoACallout heading="Design documentation in Figma" type="important" size="medium" maxWidth="540px">
+              Detailed design documentation for this component can be found on the associated{" "}
+              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
+                component page
+              </a>{" "}
+              in the Component library in Figma.
+            </GoACallout>
+          </GoATab>
+          <GoATab heading="Accessibility">
+            <GoACallout heading="Accessibility documentation in Figma" type="important" size="medium" maxWidth="550px">
+              Detailed accessibility documentation for this component can be found on the associated{" "}
+              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
+                component page
+              </a>{" "}
+              in the Component library in Figma.
+            </GoACallout>
           </GoATab>
         </GoATabs>
       </ComponentContent>

--- a/src/routes/components/Container.tsx
+++ b/src/routes/components/Container.tsx
@@ -11,10 +11,11 @@ import {
   GoAContainerProps,
   GoATab,
   GoATabs,
-  GoACallout,
 } from "@abgov/react-components";
 import ContainerExamples from "@examples/container/ContainerExamples.tsx";
 import { ComponentContent } from "@components/component-content/ComponentContent";
+import { DesignEmpty } from "@components/design-empty/DesignEmpty.tsx";
+import { AccessibilityEmpty } from "@components/accessibility-empty/AccessibilityEmpty.tsx";
 
 const FIGMA_LINK =
   "https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=1789-12623";
@@ -181,23 +182,13 @@ export default function ContainerPage() {
           </GoATab>
 
           <GoATab heading="Design">
-            <GoACallout heading="Design documentation in Figma" type="important" size="medium" maxWidth="540px">
-              Detailed design documentation for this component can be found on the associated{" "}
-              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
-                component page
-              </a>{" "}
-              in the Component library in Figma.
-            </GoACallout>
+            <DesignEmpty figmaLink={FIGMA_LINK} />
           </GoATab>
+
           <GoATab heading="Accessibility">
-            <GoACallout heading="Accessibility documentation in Figma" type="important" size="medium" maxWidth="550px">
-              Detailed accessibility documentation for this component can be found on the associated{" "}
-              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
-                component page
-              </a>{" "}
-              in the Component library in Figma.
-            </GoACallout>
+            <AccessibilityEmpty figmaLink={FIGMA_LINK} />
           </GoATab>
+
         </GoATabs>
       </ComponentContent>
     </>

--- a/src/routes/components/DatePicker.tsx
+++ b/src/routes/components/DatePicker.tsx
@@ -14,11 +14,12 @@ import {
   GoAButtonGroup,
   GoATab,
   GoATabs,
-  GoACallout,
 } from "@abgov/react-components";
 import { useSandboxFormItem } from "@hooks/useSandboxFormItem.tsx";
 import { CodeSnippet } from "@components/code-snippet/CodeSnippet.tsx";
 import { ComponentContent } from "@components/component-content/ComponentContent";
+import { AccessibilityEmpty } from "@components/accessibility-empty/AccessibilityEmpty.tsx";
+import { DesignEmpty } from "@components/design-empty/DesignEmpty.tsx";
 
 // == Page props ==
 
@@ -356,33 +357,13 @@ export default function DatePickerPage() {
           </GoATab>
 
           <GoATab heading="Design">
-            <GoACallout
-              heading="Design documentation in Figma"
-              type="important"
-              size="medium"
-              maxWidth="540px"
-            >
-              Detailed design documentation for this component can be found on the associated{" "}
-              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
-                component page
-              </a>{" "}
-              in the Component library in Figma.
-            </GoACallout>
+            <DesignEmpty figmaLink={FIGMA_LINK} />
           </GoATab>
+
           <GoATab heading="Accessibility">
-            <GoACallout
-              heading="Accessibility documentation in Figma"
-              type="important"
-              size="medium"
-              maxWidth="550px"
-            >
-              Detailed accessibility documentation for this component can be found on the associated{" "}
-              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
-                component page
-              </a>{" "}
-              in the Component library in Figma.
-            </GoACallout>
+            <AccessibilityEmpty figmaLink={FIGMA_LINK} />
           </GoATab>
+
         </GoATabs>
       </ComponentContent>
     </>

--- a/src/routes/components/DatePicker.tsx
+++ b/src/routes/components/DatePicker.tsx
@@ -1,20 +1,20 @@
-import { Category, ComponentHeader } from "@components/component-header/ComponentHeader.tsx";
-import { ComponentBinding, Sandbox } from "@components/sandbox";
 import { useState } from "react";
+import { ComponentBinding, Sandbox } from "@components/sandbox";
 import {
   ComponentProperties,
   ComponentProperty,
-} from "@components/component-properties/ComponentProperties.tsx";
-
+} from "@components/component-properties/ComponentProperties";
+import { Category, ComponentHeader } from "@components/component-header/ComponentHeader";
 import {
   GoABadge,
-  GoATab,
-  GoATabs,
-  GoADatePickerProps,
   GoADatePicker,
+  GoADatePickerProps,
   GoAFormItem,
   GoAButton,
   GoAButtonGroup,
+  GoATab,
+  GoATabs,
+  GoACallout,
 } from "@abgov/react-components";
 import { useSandboxFormItem } from "@hooks/useSandboxFormItem.tsx";
 import { CodeSnippet } from "@components/code-snippet/CodeSnippet.tsx";
@@ -22,14 +22,16 @@ import { ComponentContent } from "@components/component-content/ComponentContent
 
 // == Page props ==
 
+const FIGMA_LINK =
+  "https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=33054-33175";
 const componentName = "Date picker";
+const description =
+  "Lets users select a date through a calendar without the need to manually type it in a field.";
 const category = Category.INPUTS_AND_ACTIONS;
 const relatedComponents = [
   // { link: "/content/date-format", name: "Date format" },
   { link: "/components/form-item", name: "Form item" },
 ];
-const description =
-  "Lets users select a date through a calendar without the need to manually type it in a field.";
 type ComponentPropsType = GoADatePickerProps;
 type CastingType = {
   [key: string]: unknown;
@@ -148,13 +150,15 @@ export default function DatePickerPage() {
         category={category}
         description={description}
         relatedComponents={relatedComponents}
+        githubLink={componentName}
+        figmaLink={FIGMA_LINK}
       />
 
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
         <GoATabs>
-          <GoATab heading="Code examples">
+          <GoATab heading="Code playground">
             <h2 id="component" style={{ display: "none" }}>
-              Component
+              Playground
             </h2>
             <Sandbox
               properties={componentBindings}
@@ -206,10 +210,10 @@ export default function DatePickerPage() {
               </GoAFormItem>
             </Sandbox>
             <ComponentProperties properties={componentProperties} />
+          </GoATab>
 
-            <h2 id="component-examples" className="hidden" aria-hidden="true">
-              Examples
-            </h2>
+          <GoATab heading={<>Examples<GoABadge type="information" content="1" /></>}>
+
 
             <h3 id="component-example-1">Reset example</h3>
             <Sandbox fullWidth skipRender onChange={onSandboxChange} flags={["reactive"]}>
@@ -351,13 +355,34 @@ export default function DatePickerPage() {
             </Sandbox>
           </GoATab>
 
-          <GoATab
-            heading={
-              <>
-                Design guidelines
-                <GoABadge type="information" content="In progress" />
-              </>
-            }></GoATab>
+          <GoATab heading="Design">
+            <GoACallout
+              heading="Design documentation in Figma"
+              type="important"
+              size="medium"
+              maxWidth="540px"
+            >
+              Detailed design documentation for this component can be found on the associated{" "}
+              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
+                component page
+              </a>{" "}
+              in the Component library in Figma.
+            </GoACallout>
+          </GoATab>
+          <GoATab heading="Accessibility">
+            <GoACallout
+              heading="Accessibility documentation in Figma"
+              type="important"
+              size="medium"
+              maxWidth="550px"
+            >
+              Detailed accessibility documentation for this component can be found on the associated{" "}
+              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
+                component page
+              </a>{" "}
+              in the Component library in Figma.
+            </GoACallout>
+          </GoATab>
         </GoATabs>
       </ComponentContent>
     </>

--- a/src/routes/components/Details.tsx
+++ b/src/routes/components/Details.tsx
@@ -14,10 +14,11 @@ import {
   GoARadioItem,
   GoATab,
   GoATabs,
-  GoACallout,
   GoABlock,
 } from "@abgov/react-components";
 import { ComponentContent } from "@components/component-content/ComponentContent";
+import { DesignEmpty } from "@components/design-empty/DesignEmpty.tsx";
+import { AccessibilityEmpty } from "@components/accessibility-empty/AccessibilityEmpty.tsx";
 
 const FIGMA_LINK =
   "https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=15931-553577";
@@ -244,33 +245,13 @@ export default function DetailsPage() {
           </GoATab>
 
           <GoATab heading="Design">
-            <GoACallout
-              heading="Design documentation in Figma"
-              type="important"
-              size="medium"
-              maxWidth="540px"
-            >
-              Detailed design documentation for this component can be found on the associated{" "}
-              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
-                component page
-              </a>{" "}
-              in the Component library in Figma.
-            </GoACallout>
+            <DesignEmpty figmaLink={FIGMA_LINK} />
           </GoATab>
+
           <GoATab heading="Accessibility">
-            <GoACallout
-              heading="Accessibility documentation in Figma"
-              type="important"
-              size="medium"
-              maxWidth="550px"
-            >
-              Detailed accessibility documentation for this component can be found on the associated{" "}
-              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
-                component page
-              </a>{" "}
-              in the Component library in Figma.
-            </GoACallout>
+            <AccessibilityEmpty figmaLink={FIGMA_LINK} />
           </GoATab>
+
         </GoATabs>
       </ComponentContent>
     </>

--- a/src/routes/components/Details.tsx
+++ b/src/routes/components/Details.tsx
@@ -7,7 +7,6 @@ import { ComponentBinding, Sandbox } from "@components/sandbox";
 import { Category, ComponentHeader } from "@components/component-header/ComponentHeader.tsx";
 import {
   GoABadge,
-  GoABlock,
   GoADetails,
   GoAFormItem,
   GoAInput,
@@ -15,11 +14,27 @@ import {
   GoARadioItem,
   GoATab,
   GoATabs,
+  GoACallout,
+  GoABlock,
 } from "@abgov/react-components";
 import { ComponentContent } from "@components/component-content/ComponentContent";
 
+const FIGMA_LINK =
+  "https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=15931-553577";
+const componentName = "Details";
+const category = Category.CONTENT_AND_LAYOUT;
+const relatedComponents = [
+  { link: "/components/accordion", name: "Accordion" },
+  { link: "/components/form-item", name: "Form item" },
+];
+const description = "Let users reveal more detailed information when they need it.";
+type ComponentPropsType = {
+  heading: string;
+  maxWidth?: string;
+};
+
 export default function DetailsPage() {
-  const [detailsProps, setDetailsProps] = useState({
+  const [detailsProps, setDetailsProps] = useState<ComponentPropsType>({
     heading: "Detail Heading",
   });
   const [detailsBindings, setDetailsBindings] = useState<ComponentBinding[]>([
@@ -35,7 +50,7 @@ export default function DetailsPage() {
       name: "maxWidth",
       requirement: "optional",
       value: "",
-    },    
+    },
   ]);
 
   const componentProperties: ComponentProperty[] = [
@@ -80,20 +95,18 @@ export default function DetailsPage() {
   return (
     <>
       <ComponentHeader
-        name="Details"
-        category={Category.CONTENT_AND_LAYOUT}
-        description="Let users reveal more detailed information when they need it."
-        relatedComponents={[
-          { link: "/components/accordion", name: "Accordion" },
-          { link: "/components/form-item", name: "Form item" },
-        ]}
+        name={componentName}
+        category={category}
+        description={description}
+        relatedComponents={relatedComponents}
+        githubLink={componentName}
+        figmaLink={FIGMA_LINK}
       />
 
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
-
         <GoATabs>
-          <GoATab heading="Code examples">
-            <h2 id="component" style={{display: "none"}}>Component</h2>
+          <GoATab heading="Code playground">
+            <h2 id="component" style={{ display: "none" }}>Playground</h2>
             <Sandbox properties={detailsBindings} onChange={onSandboxChange} fullWidth>
               <GoADetails {...detailsProps}>
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc vel lacinia metus, sed
@@ -107,16 +120,16 @@ export default function DetailsPage() {
               </GoADetails>
             </Sandbox>
 
-            {/*Component properties table*/}
+            {/* Component properties table */}
             <ComponentProperties properties={componentProperties} />
+          </GoATab>
 
-            {/* Examples*/}
-            <h2 id="component-examples" className="hidden" aria-hidden="true">Examples</h2>
+          <GoATab heading={<>Examples<GoABadge type="information" content="3" /></>}>
 
             <h3 id="component-example-show-more-information-for-basic-question">
               Show more information for a basic question
             </h3>
-            <Sandbox fullWidth note="Example below: Advanced Education - Pay for my education">
+            <Sandbox fullWidth>
               <GoAFormItem label="Do you pay for childcare?" helpText="Examples of child care include day care, day homes, and baby-sitters.">
                 <GoARadioGroup name="pay" onChange={() => { }}>
                   <GoARadioItem label="Yes" value="yes" name="pay" />
@@ -140,7 +153,7 @@ export default function DetailsPage() {
                 label="Do you have additional education expense?"
                 helpText="You can request this money now or at any time during your program."
               >
-                <GoARadioGroup name="additional" onChange={noop}>
+                <GoARadioGroup name="additional" onChange={() => { }}>
                   <GoARadioItem label="Yes" value="yes" name="additional" />
                   <GoARadioItem label="No" value="no" name="additional" />
                 </GoARadioGroup>
@@ -230,15 +243,33 @@ export default function DetailsPage() {
             </Sandbox>
           </GoATab>
 
-          <GoATab
-            heading={
-              <>
-                Design guidelines
-                <GoABadge type="information" content="In progress" />
-              </>
-            }
-          >
-            <p>Coming Soon</p>
+          <GoATab heading="Design">
+            <GoACallout
+              heading="Design documentation in Figma"
+              type="important"
+              size="medium"
+              maxWidth="540px"
+            >
+              Detailed design documentation for this component can be found on the associated{" "}
+              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
+                component page
+              </a>{" "}
+              in the Component library in Figma.
+            </GoACallout>
+          </GoATab>
+          <GoATab heading="Accessibility">
+            <GoACallout
+              heading="Accessibility documentation in Figma"
+              type="important"
+              size="medium"
+              maxWidth="550px"
+            >
+              Detailed accessibility documentation for this component can be found on the associated{" "}
+              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
+                component page
+              </a>{" "}
+              in the Component library in Figma.
+            </GoACallout>
           </GoATab>
         </GoATabs>
       </ComponentContent>

--- a/src/routes/components/Divider.tsx
+++ b/src/routes/components/Divider.tsx
@@ -5,10 +5,11 @@ import {
   ComponentProperty,
 } from "@components/component-properties/ComponentProperties.tsx";
 import { Category, ComponentHeader } from "@components/component-header/ComponentHeader.tsx";
-import { GoADivider, GoATab, GoATabs, GoACallout } from "@abgov/react-components";
+import { GoADivider, GoATab, GoATabs, } from "@abgov/react-components";
 import { ComponentContent } from "@components/component-content/ComponentContent";
 import Sandbox from "@components/sandbox/Sandbox.tsx";
 import "./AllComponents.css";
+import { DesignEmpty } from "@components/design-empty/DesignEmpty.tsx";
 
 // == Page props ==
 
@@ -94,18 +95,7 @@ export default function DividerPage() {
           {/* No Examples Tab since there are no examples */}
 
           <GoATab heading="Design">
-            <GoACallout
-              heading="Design documentation in Figma"
-              type="important"
-              size="medium"
-              maxWidth="540px"
-            >
-              Detailed design documentation for this component can be found on the associated{" "}
-              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
-                component page
-              </a>{" "}
-              in the Component library in Figma.
-            </GoACallout>
+            <DesignEmpty figmaLink={FIGMA_LINK} />
           </GoATab>
 
         </GoATabs>

--- a/src/routes/components/Divider.tsx
+++ b/src/routes/components/Divider.tsx
@@ -5,13 +5,26 @@ import {
   ComponentProperty,
 } from "@components/component-properties/ComponentProperties.tsx";
 import { Category, ComponentHeader } from "@components/component-header/ComponentHeader.tsx";
-import { GoABadge, GoADivider, GoATab, GoATabs } from "@abgov/react-components";
+import { GoADivider, GoATab, GoATabs, GoACallout } from "@abgov/react-components";
 import { ComponentContent } from "@components/component-content/ComponentContent";
 import Sandbox from "@components/sandbox/Sandbox.tsx";
 import "./AllComponents.css";
 
+// == Page props ==
+
+const FIGMA_LINK =
+  "https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=46-115";
+const componentName = "Divider";
+const category = Category.UTILITIES;
+const relatedComponents = [
+  { link: "/components/container", name: "Container" },
+];
+const description =
+  "Indicate a separation of layout, or to distinguish large chunks of information on a page.";
+type ComponentPropsType = Record<string, unknown>;
+
 export default function DividerPage() {
-  const [dividerProps, setDividerProps] = useState({});
+  const [dividerProps, setDividerProps] = useState<ComponentPropsType>({});
   const [dividerBindings, setDividerBindings] = useState<ComponentBinding[]>([
     {
       label: "Top Margin",
@@ -57,34 +70,44 @@ export default function DividerPage() {
   return (
     <>
       <ComponentHeader
-        name="Divider"
-        category={Category.UTILITIES}
-        description="Indicate a separation of layout, or to distinguish large chunks of information on a page."
-        relatedComponents={[
-          { link: "/components/container", name: "Container" },
-        ]}
+        name={componentName}
+        category={category}
+        description={description}
+        relatedComponents={relatedComponents}
+        githubLink={componentName}
+        figmaLink={FIGMA_LINK}
       />
 
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
 
         <GoATabs>
-          <GoATab heading="Code examples">
-            <h2 id="component" style={{display: "none"}}>Component</h2>
+          <GoATab heading="Code playground">
+            <h2 id="component" style={{ display: "none" }}>Playground</h2>
             <Sandbox properties={dividerBindings} onChange={onSandboxChange} fullWidth>
               <GoADivider {...dividerProps} />
             </Sandbox>
 
+            {/* Component properties table */}
             <ComponentProperties properties={componentProperties} />
           </GoATab>
 
-          <GoATab
-            heading={
-              <>
-                Design guidelines
-                <GoABadge type="information" content="In progress" />
-              </>
-            }
-          ></GoATab>
+          {/* No Examples Tab since there are no examples */}
+
+          <GoATab heading="Design">
+            <GoACallout
+              heading="Design documentation in Figma"
+              type="important"
+              size="medium"
+              maxWidth="540px"
+            >
+              Detailed design documentation for this component can be found on the associated{" "}
+              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
+                component page
+              </a>{" "}
+              in the Component library in Figma.
+            </GoACallout>
+          </GoATab>
+
         </GoATabs>
       </ComponentContent>
     </>

--- a/src/routes/components/Dropdown.tsx
+++ b/src/routes/components/Dropdown.tsx
@@ -14,9 +14,10 @@ import {
   GoARadioItem,
   GoATab,
   GoATabs,
-  GoACallout,
 } from "@abgov/react-components";
 import { ComponentContent } from "@components/component-content/ComponentContent";
+import { DesignEmpty } from "@components/design-empty/DesignEmpty.tsx";
+import { AccessibilityEmpty } from "@components/accessibility-empty/AccessibilityEmpty.tsx";
 
 const FIGMA_LINK =
   "https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=105-42";
@@ -180,34 +181,13 @@ export default function DropdownPage() {
           </GoATab>
 
           <GoATab heading="Design">
-            <GoACallout
-              heading="Design documentation in Figma"
-              type="important"
-              size="medium"
-              maxWidth="540px"
-            >
-              Detailed design documentation for this component can be found on the associated{" "}
-              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
-                component page
-              </a>{" "}
-              in the Component library in Figma.
-            </GoACallout>
+            <DesignEmpty figmaLink={FIGMA_LINK} />
           </GoATab>
 
           <GoATab heading="Accessibility">
-            <GoACallout
-              heading="Accessibility documentation in Figma"
-              type="important"
-              size="medium"
-              maxWidth="550px"
-            >
-              Detailed accessibility documentation for this component can be found on the associated{" "}
-              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
-                component page
-              </a>{" "}
-              in the Component library in Figma.
-            </GoACallout>
+            <AccessibilityEmpty figmaLink={FIGMA_LINK} />
           </GoATab>
+
         </GoATabs>
       </ComponentContent>
     </>

--- a/src/routes/components/Dropdown.tsx
+++ b/src/routes/components/Dropdown.tsx
@@ -1,201 +1,83 @@
 import { useState } from "react";
 import {
-  GoABadge,
-  GoADropdown,
-  GoADropdownItem, GoADropdownProps,
-  GoAFormItem,
-  GoATab,
-  GoATabs
-} from "@abgov/react-components";
-import { CodeSnippet } from "@components/code-snippet/CodeSnippet";
-import { ComponentBinding, Sandbox } from "@components/sandbox";
-import ICONS from "./icons.json";
-import { Category, ComponentHeader } from "@components/component-header/ComponentHeader.tsx";
-import {
   ComponentProperties,
   ComponentProperty,
 } from "@components/component-properties/ComponentProperties.tsx";
-import { useSandboxFormItem } from "@hooks/useSandboxFormItem.tsx";
+import { ComponentBinding, Sandbox } from "@components/sandbox";
+import { Category, ComponentHeader } from "@components/component-header/ComponentHeader.tsx";
+import {
+  GoABadge,
+  GoADetails,
+  GoAFormItem,
+  GoABlock,
+  GoARadioGroup,
+  GoARadioItem,
+  GoATab,
+  GoATabs,
+  GoACallout,
+} from "@abgov/react-components";
 import { ComponentContent } from "@components/component-content/ComponentContent";
-import { DropdownExamples } from "@examples/dropdown/DropdownExamples";
 
-// == Page props ==
+const FIGMA_LINK =
+  "https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=105-42";
 const componentName = "Dropdown";
-const description = "Present a list of options to the user to select from.";
-const category = Category.INPUTS_AND_ACTIONS;
+const category = Category.CONTENT_AND_LAYOUT;
 const relatedComponents = [
-  { link: "/components/checkbox", name: "Checkbox" },
+  { link: "/components/accordion", name: "Accordion" },
   { link: "/components/form-item", name: "Form item" },
-  { link: "/components/popover", name: "Popover" },
-  { link: "/components/radio", name: "Radio" },
 ];
-type ComponentPropsType = GoADropdownProps;
-type CastingType = {
-  name: string;
-  value: string;
-  [key: string]: unknown;
-  onChange: (name: string, values: string[] | string) => void;
-}
+const description = "Let users reveal more detailed information when they need it.";
+
+type ComponentPropsType = {
+  heading: string;
+  maxWidth?: string;
+};
+
 
 export default function DropdownPage() {
   const [dropdownProps, setDropdownProps] = useState<ComponentPropsType>({
-    name: "item",
-    value: "",
-    onChange: onChange,
+    heading: "Dropdown Heading",
   });
   const [dropdownBindings, setDropdownBindings] = useState<ComponentBinding[]>([
     {
-      label: "Placeholder",
+      label: "Heading",
       type: "string",
-      name: "placeholder",
-      value: "",
+      name: "heading",
+      value: "Dropdown Heading",
     },
     {
-      label: "Leading icon",
-      type: "combobox",
-      name: "leadingIcon",
-      options: [""].concat(ICONS),
-      value: "",
-    },
-    {
-      label: "Max height",
+      label: "Max Width",
       type: "string",
-      name: "maxHeight",
+      name: "maxWidth",
+      requirement: "optional",
       value: "",
     },
-    {
-      label: "Width",
-      type: "string",
-      name: "width",
-      value: "",
-    },
-    { label: "Disabled", type: "boolean", name: "disabled", value: false },
-    { label: "Error", type: "boolean", name: "error", value: false },
-    { label: "Native", type: "boolean", name: "native", value: false },
-    { label: "Filterable", type: "boolean", name: "filterable", value: false },
-    { label: "ARIA label", type: "string", name: "ariaLabel", value: "" },
   ]);
-  const { formItemBindings, formItemProps, onFormItemChange } = useSandboxFormItem({ label: "Basic dropdown" });
 
-  const dropdownProperties: ComponentProperty[] = [
+  const componentProperties: ComponentProperty[] = [
     {
-      name: "name",
+      name: "heading",
       type: "string",
-      description: "Identifier for the Dropdown. Should be unique.",
-    },
-    {
-      name: "value",
-      type: "string",
-      description: "Stores the value of the item selected from the dropdown.",
-    },
-    {
-      name: "leadingIcon",
-      lang: "react",
-      type: "GoAIconType",
-      description: "Show an icon to the left of the dropdown option.",
-    },
-    {
-      name: "leadingicon",
-      lang: "angular",
-      type: "GoAIconType",
-      description: "Show an icon to the left of the dropdown option.",
-    },
-    {
-      name: "maxHeight",
-      lang: "react",
-      type: "string",
-      description: "Maximum height of the dropdown menu items popover. Non-native only.",
-      defaultValue: "276px",
-    },
-    {
-      name: "maxheight",
-      lang: "angular",
-      type: "string",
-      description: "Maximum height of the dropdown menu items popover. Non-native only.",
-      defaultValue: "276px",
-    },
-    {
-      name: "placeholder",
-      type: "string",
-      description:
-        "The text displayed for the dropdown before a selection is made. Non-native only.",
-    },
-    {
-      name: "width",
-      type: "string",
-      description: "Overrides the autosized menu width. Non-native only.",
-    },
-    {
-      name: "disabled",
-      type: "boolean",
-      description: "Disable this control.",
-      defaultValue: "false",
-    },
-    {
-      name: "relative",
-      type: "boolean",
-      description: "Set to true if a parent element has a css positive of relative.",
-      defaultValue: "false",
-    },
-    {
-      name: "error",
-      type: "boolean",
-      description: "Show an error state",
-      defaultValue: "false",
-    },
-    {
-      name: "ariaLabel",
-      lang: "react",
-      type: "string",
-      description:
-        "Defines how the selected value will be translated for the screen reader. If not specified it will fall back to the name.",
-    },
-    {
-      name: "arialabel",
-      lang: "angular",
-      type: "string",
-      description:
-        "Defines how the selected value will be translated for the screen reader. If not specified it will fall back to the name.",
-    },
-    {
-      name: "ariaLabelledBy",
-      type: "string",
-      description:
-        "The aria-labelledby attribute identifies the element(or elements) that labels the dropdown it is applied to. Normally it is the id of the label.",
-      lang: "react",
-    },
-    {
-      name: "arialabelledby",
-      type: "string",
-      description:
-        "The aria-labelledby attribute identifies the element(or elements) that labels the dropdown it is applied to. Normally it is the id of the label.",
-      lang: "angular",
-    },
-    {
-      name: "native",
-      type: "boolean",
-      defaultValue: "false",
-      description: "When true will render the native <select> html element.",
-    },
-    {
-      name: "filterable",
-      type: "boolean",
-      defaultValue: "false",
-      description:
-        "When true the dropdown will have the ability to filter options by typing into the input field.",
-    },
-    {
-      name: "onChange",
-      lang: "react",
-      type: "(name: string, value: string[] | string | null) => void",
       required: true,
-      description: "Callback function when dropdown value is changed",
+      description: "The title heading",
     },
     {
-      name: "_change",
+      name: "open",
+      type: "boolean",
+      description: "Controls if dropdown is expanded or not",
+      defaultValue: "false",
+    },
+    {
+      name: "maxWidth",
+      type: "string",
+      description: "Sets the maximum width of the dropdown.",
+      lang: "react",
+    },
+    {
+      name: "maxwidth",
+      type: "string",
+      description: "Sets the maximum width of the dropdown.",
       lang: "angular",
-      type: "(name: string, value: string[] | string | null) => void",
-      description: "Callback function when dropdown value is changed.",
     },
     {
       name: "mt,mr,mb,ml",
@@ -203,135 +85,128 @@ export default function DropdownPage() {
       description: "Apply margin to the top, right, bottom, and/or left of the component.",
     },
   ];
-  const dropdownItemProperties: ComponentProperty[] = [
-    {
-      name: "value",
-      type: "string",
-      required: true,
-      description: "The value of the item. This value will be contained within the onChange event",
-    },
-    {
-      name: "label",
-      type: "string",
-      description:
-        "The displayed value within the selection box. The value property is the fallback value.",
-    },
-    {
-      name: "filter",
-      type: "string",
-      description:
-        "In case of the filterable dropdown, this property is for us to set what we want to search the option with different keywords. The label or value property is the fallback value.",
-    },
-    {
-      name: "mountType",
-      lang: "react",
-      type: "append | prepend | reset",
-      description: "The mount type for the dropdown item.",
-      defaultValue: "append"
-    },
-    {
-      name:"mount",
-      lang: "angular",
-      type: "append | prepend | reset",
-      description: "The mount type for the dropdown item.",
-      defaultValue: "append"
-    }
-  ];
 
   function onSandboxChange(bindings: ComponentBinding[], props: Record<string, unknown>) {
+    setDropdownProps(props as { heading: string; [key: string]: unknown });
     setDropdownBindings(bindings);
-    setDropdownProps(props as CastingType);
   }
 
-  // Demo
-  const [color, setColor] = useState<string>("");
-
-  function onChange(_name: string, value: string | string[]) {
-    setColor(value as string);
-    setDropdownProps({ ...dropdownProps, value: value as string } as CastingType);
-  }
+  const noop = () => { };
 
   return (
     <>
-      <ComponentHeader name={componentName} category={category} description={description} relatedComponents={relatedComponents} />
+      <ComponentHeader
+        name={componentName}
+        category={category}
+        description={description}
+        relatedComponents={relatedComponents}
+        githubLink={componentName}
+        figmaLink={FIGMA_LINK}
+      />
+
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
-
         <GoATabs>
-          <GoATab heading="Code examples">
-            <h2 id="component" style={{display: "none"}}>Component</h2>
-            <Sandbox
-              properties={dropdownBindings}
-              formItemProperties={formItemBindings}
-              onChange={onSandboxChange}
-              onChangeFormItemBindings={onFormItemChange}
-              flags={["reactive"]}>
-              <CodeSnippet
-                lang="typescript"
-                tags="angular"
-                allowCopy={true}
-                code={`
-                // non-reactive code
-                export class MyComponent {
-                  onChange(event: Event) {
-                    // handle change
-                    console.log((event as CustomEvent).detail.value);
-                  }
-                }  
-              `}
-              />
-
-              <CodeSnippet
-                lang="typescript"
-                tags={["angular", "reactive"]}
-                allowCopy={true}
-                code={`
-                // reactive code
-                import { FormControl } from "@angular/forms";
-                export class MyComponent {
-                  itemFormCtrl = new FormControl("");
-                }  
-              `}
-              />
-
-              <CodeSnippet
-                lang="typescript"
-                tags="react"
-                allowCopy={true}
-                code={`
-                function onChange(name: string, value: string | string[]) {
-                 console.log("onChange", name, value);
-                }
-              `}
-              />
-
-              <GoAFormItem {...formItemProps}>
-                <GoADropdown name="item" value={color} {...dropdownProps}>
-                  <GoADropdownItem value="red" label="Red" />
-                  <GoADropdownItem value="green" label="Green" />
-                  <GoADropdownItem value="blue" label="Blue" />
-                </GoADropdown>
-              </GoAFormItem>
+          <GoATab heading="Code playground">
+            <h2 id="component" style={{ display: "none" }}>Playground</h2>
+            <Sandbox properties={dropdownBindings} onChange={onSandboxChange} fullWidth>
+              <GoADetails {...dropdownProps}>
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc vel lacinia metus, sed
+                sodales lectus. Aliquam sed volutpat velit. Sed in lacus ut dui placerat accumsan
+                malesuada quis erat. Aenean mi diam, rhoncus vitae justo eu, venenatis maximus nunc.
+                In vel est commodo, porttitor sem vel, tincidunt ipsum. In hac habitasse platea
+                dictumst. Mauris varius mollis dui. Aenean ut dui eu arcu rutrum auctor. Curabitur
+                cursus velit vel libero sollicitudin tincidunt. Proin tincidunt, enim et ultrices
+                rhoncus, nibh leo imperdiet sapien, sed porttitor ipsum nulla non massa. Nulla
+                facilisi.
+              </GoADetails>
             </Sandbox>
 
-            <ComponentProperties properties={dropdownProperties} />
-
-            <ComponentProperties
-              heading="Dropdown item properties"
-              properties={dropdownItemProperties}
-            />
-
-            <DropdownExamples/>
+            {/* Component properties table */}
+            <ComponentProperties properties={componentProperties} />
           </GoATab>
 
-          <GoATab
-            heading={
-              <>
-                Design guidelines
-                <GoABadge type="information" content="In progress" />
-              </>
-            }
-          >
-            <p>Coming Soon</p>
+          <GoATab heading={<>Examples<GoABadge type="information" content="2" /></>}>
+
+            <h3 id="component-example-basic-dropdown">
+              Basic Dropdown Example
+            </h3>
+            <Sandbox fullWidth>
+              <GoAFormItem label="Select an option">
+                <GoARadioGroup name="option" onChange={noop}>
+                  <GoARadioItem label="Option 1" value="1" name="option" />
+                  <GoARadioItem label="Option 2" value="2" name="option" />
+                  <GoARadioItem label="Option 3" value="3" name="option" />
+                </GoARadioGroup>
+              </GoAFormItem>
+
+              <GoADetails heading="More Information about Options" mt="l">
+                <p>
+                  Selecting an option allows you to proceed with your choice. Please ensure you select the appropriate option based on your requirements.
+                </p>
+              </GoADetails>
+            </Sandbox>
+
+            <h3 id="component-example-dropdown-with-additional-info">
+              Dropdown with Additional Information
+            </h3>
+            <Sandbox fullWidth>
+              <GoAFormItem label="Choose a category" helpText="Select the category that best fits your needs.">
+                <GoARadioGroup name="category" onChange={noop}>
+                  <GoARadioItem label="Category A" value="A" name="category" />
+                  <GoARadioItem label="Category B" value="B" name="category" />
+                  <GoARadioItem label="Category C" value="C" name="category" />
+                </GoARadioGroup>
+              </GoAFormItem>
+
+              <GoADetails heading="Why is this important?" mt="l">
+                <GoABlock gap="m" mt="m">
+                  <div>
+                    <strong>Category A:</strong>
+                    <ul className="goa-unordered-list">
+                      <li>Feature A1</li>
+                      <li>Feature A2</li>
+                    </ul>
+                  </div>
+                  <div>
+                    <strong>Category B:</strong>
+                    <ul className="goa-unordered-list">
+                      <li>Feature B1</li>
+                      <li>Feature B2</li>
+                    </ul>
+                  </div>
+                </GoABlock>
+              </GoADetails>
+            </Sandbox>
+          </GoATab>
+
+          <GoATab heading="Design">
+            <GoACallout
+              heading="Design documentation in Figma"
+              type="important"
+              size="medium"
+              maxWidth="540px"
+            >
+              Detailed design documentation for this component can be found on the associated{" "}
+              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
+                component page
+              </a>{" "}
+              in the Component library in Figma.
+            </GoACallout>
+          </GoATab>
+
+          <GoATab heading="Accessibility">
+            <GoACallout
+              heading="Accessibility documentation in Figma"
+              type="important"
+              size="medium"
+              maxWidth="550px"
+            >
+              Detailed accessibility documentation for this component can be found on the associated{" "}
+              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
+                component page
+              </a>{" "}
+              in the Component library in Figma.
+            </GoACallout>
           </GoATab>
         </GoATabs>
       </ComponentContent>

--- a/src/routes/components/FileUploader.tsx
+++ b/src/routes/components/FileUploader.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { ComponentBinding, Sandbox } from "@components/sandbox";
 import { Category, ComponentHeader } from "@components/component-header/ComponentHeader";
-import { propsToString } from "@components/sandbox/BaseSerializer"
+import { propsToString } from "@components/sandbox/BaseSerializer";
 import {
   GoAFileUploadCard,
   GoAFileUploadInput,
@@ -9,6 +9,7 @@ import {
   GoAFormItem,
   GoATab,
   GoATabs,
+  GoACallout, GoABadge
 } from "@abgov/react-components";
 import {
   ComponentProperties,
@@ -54,12 +55,14 @@ class MockUploader implements Uploader {
   }
 }
 
+const FIGMA_LINK =
+  "https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=804-5767";
 const componentName = "File uploader";
 const description = "Help users select and upload a file.";
 const category = Category.INPUTS_AND_ACTIONS;
 const relatedComponents = [
   { link: "/components/container", name: "Container" },
-  { link: "/components/progress-indicator", name: "Progress indicator" }
+  { link: "/components/progress-indicator", name: "Progress indicator" },
 ];
 type ComponentPropsType = Omit<GoAFileUploadInputProps, "onSelectFile">;
 type CastingType = {
@@ -227,12 +230,20 @@ export default function FileUploaderPage() {
 
   return (
     <>
-      <ComponentHeader name={componentName} category={category} description={description} relatedComponents={relatedComponents} />
+      <ComponentHeader
+        name={componentName}
+        category={category}
+        description={description}
+        relatedComponents={relatedComponents}
+        githubLink={componentName}
+        figmaLink={FIGMA_LINK}
+      />
+
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
 
         <GoATabs>
-          <GoATab heading="Code examples">
-            <h2 id="component" style={{display: "none"}}>Component</h2>
+          <GoATab heading="Code playground">
+            <h2 id="component" style={{ display: "none" }}>Playground</h2>
             <Sandbox properties={fileUploaderBindings} onChange={onSandboxChange} fullWidth skipRender>
 
               {/* ******* */}
@@ -322,7 +333,6 @@ export default function FileUploaderPage() {
                 </goa-form-item>
               `}
               />
-
 
               {/* ***** */}
               {/* React */}
@@ -415,6 +425,53 @@ export default function FileUploaderPage() {
             />
 
           </GoATab>
+
+          <GoATab
+            heading={
+              <>
+                Examples
+                <GoABadge type="information" content="0" />
+              </>
+            }
+          >
+            <GoACallout heading="We are currently collecting design examples for this component" type="important" size="medium" maxWidth="540px">
+              {" "}
+              <a href="https://design.alberta.ca/get-started/support#:~:text=Raise%20an%20issue-,Talk%20to%20us,-Slack" target="_blank" rel="noreferrer">
+                Talk to the design system team
+              </a>{" "}
+              to contribute examples from your service.
+            </GoACallout>
+          </GoATab>
+
+          <GoATab heading="Design">
+            <GoACallout
+              heading="Design documentation in Figma"
+              type="important"
+              size="medium"
+              maxWidth="540px"
+            >
+              Detailed design documentation for this component can be found on the associated{" "}
+              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
+                component page
+              </a>{" "}
+              in the Component library in Figma.
+            </GoACallout>
+          </GoATab>
+          <GoATab heading="Accessibility">
+            <GoACallout
+              heading="Accessibility documentation in Figma"
+              type="important"
+              size="medium"
+              maxWidth="550px"
+            >
+              Detailed accessibility documentation for this component can be found on the associated{" "}
+              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
+                component page
+              </a>{" "}
+              in the Component library in Figma.
+            </GoACallout>
+          </GoATab>
+
         </GoATabs>
       </ComponentContent>
     </>

--- a/src/routes/components/FileUploader.tsx
+++ b/src/routes/components/FileUploader.tsx
@@ -9,7 +9,7 @@ import {
   GoAFormItem,
   GoATab,
   GoATabs,
-  GoACallout, GoABadge
+  GoABadge,
 } from "@abgov/react-components";
 import {
   ComponentProperties,
@@ -17,6 +17,9 @@ import {
 } from "@components/component-properties/ComponentProperties";
 import { CodeSnippet } from "@components/code-snippet/CodeSnippet";
 import { ComponentContent } from "@components/component-content/ComponentContent";
+import { AccessibilityEmpty } from "@components/accessibility-empty/AccessibilityEmpty.tsx";
+import { DesignEmpty } from "@components/design-empty/DesignEmpty.tsx";
+import { ExamplesEmpty } from "@components/examples-empty/ExamplesEmpty.tsx";
 
 interface Uploader {
   upload: (url: string | ArrayBuffer) => void;
@@ -426,50 +429,18 @@ export default function FileUploaderPage() {
 
           </GoATab>
 
-          <GoATab
-            heading={
-              <>
-                Examples
-                <GoABadge type="information" content="0" />
-              </>
-            }
-          >
-            <GoACallout heading="We are currently collecting design examples for this component" type="important" size="medium" maxWidth="540px">
-              {" "}
-              <a href="https://design.alberta.ca/get-started/support#:~:text=Raise%20an%20issue-,Talk%20to%20us,-Slack" target="_blank" rel="noreferrer">
-                Talk to the design system team
-              </a>{" "}
-              to contribute examples from your service.
-            </GoACallout>
+          <GoATab heading={
+            <>Examples<GoABadge type="information" content="0" /></>
+          }>
+            <ExamplesEmpty />
           </GoATab>
 
           <GoATab heading="Design">
-            <GoACallout
-              heading="Design documentation in Figma"
-              type="important"
-              size="medium"
-              maxWidth="540px"
-            >
-              Detailed design documentation for this component can be found on the associated{" "}
-              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
-                component page
-              </a>{" "}
-              in the Component library in Figma.
-            </GoACallout>
+            <DesignEmpty figmaLink={FIGMA_LINK}></DesignEmpty>
           </GoATab>
+
           <GoATab heading="Accessibility">
-            <GoACallout
-              heading="Accessibility documentation in Figma"
-              type="important"
-              size="medium"
-              maxWidth="550px"
-            >
-              Detailed accessibility documentation for this component can be found on the associated{" "}
-              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
-                component page
-              </a>{" "}
-              in the Component library in Figma.
-            </GoACallout>
+            <AccessibilityEmpty figmaLink={FIGMA_LINK}/>
           </GoATab>
 
         </GoATabs>

--- a/src/routes/components/FilterChip.tsx
+++ b/src/routes/components/FilterChip.tsx
@@ -15,10 +15,11 @@ import {
   GoAInput,
   GoATab,
   GoATabs,
-  GoACallout,
 } from "@abgov/react-components";
 import { ComponentContent } from "@components/component-content/ComponentContent";
 import { CodeSnippet } from "@components/code-snippet/CodeSnippet.tsx";
+import { DesignEmpty } from "@components/design-empty/DesignEmpty.tsx";
+import { AccessibilityEmpty } from "@components/accessibility-empty/AccessibilityEmpty.tsx";
 
 // == Page props ==
 
@@ -515,33 +516,13 @@ export default function FilterChipPage() {
           </GoATab>
 
           <GoATab heading="Design">
-            <GoACallout
-              heading="Design documentation in Figma"
-              type="important"
-              size="medium"
-              maxWidth="540px"
-            >
-              Detailed design documentation for this component can be found on the associated{" "}
-              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
-                component page
-              </a>{" "}
-              in the Component library in Figma.
-            </GoACallout>
+            <DesignEmpty figmaLink={FIGMA_LINK} />
           </GoATab>
+
           <GoATab heading="Accessibility">
-            <GoACallout
-              heading="Accessibility documentation in Figma"
-              type="important"
-              size="medium"
-              maxWidth="550px"
-            >
-              Detailed accessibility documentation for this component can be found on the associated{" "}
-              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
-                component page
-              </a>{" "}
-              in the Component library in Figma.
-            </GoACallout>
+            <AccessibilityEmpty figmaLink={FIGMA_LINK} />
           </GoATab>
+
         </GoATabs>
       </ComponentContent>
     </>

--- a/src/routes/components/FilterChip.tsx
+++ b/src/routes/components/FilterChip.tsx
@@ -1,3 +1,9 @@
+import { useState, useContext } from "react";
+import { ComponentBinding, LanguageContext, Sandbox } from "@components/sandbox";
+import {
+  ComponentProperties,
+  ComponentProperty,
+} from "@components/component-properties/ComponentProperties.tsx";
 import { Category, ComponentHeader } from "@components/component-header/ComponentHeader.tsx";
 import {
   GoABadge,
@@ -9,25 +15,23 @@ import {
   GoAInput,
   GoATab,
   GoATabs,
+  GoACallout,
 } from "@abgov/react-components";
-import { ComponentBinding, LanguageContext, Sandbox } from "@components/sandbox";
-import { useContext, useState } from "react";
-import {
-  ComponentProperties,
-  ComponentProperty,
-} from "@components/component-properties/ComponentProperties.tsx";
 import { ComponentContent } from "@components/component-content/ComponentContent";
 import { CodeSnippet } from "@components/code-snippet/CodeSnippet.tsx";
 
-// Page props
+// == Page props ==
+
+const FIGMA_LINK =
+  "https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=46-115";
 const componentName = "Filter Chip";
-const description = "Allow the user to filter content.";
 const category = Category.FEEDBACK_AND_ALERTS;
 const relatedComponents = [
   { link: "/components/badge", name: "Badge" },
   { link: "/components/popover", name: "Popover" },
   { link: "/components/Table", name: "Table" },
 ];
+const description = "Allow the user to filter content.";
 type ComponentPropsType = GoAFilterChipProps;
 
 type CastingType = {
@@ -61,7 +65,6 @@ export default function FilterChipPage() {
       type: "boolean",
       description: "Shows an error state.",
     },
-
     {
       name: "content",
       type: "string",
@@ -149,17 +152,23 @@ export default function FilterChipPage() {
         category={category}
         description={description}
         relatedComponents={relatedComponents}
+        githubLink={componentName}
+        figmaLink={FIGMA_LINK}
       />
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
         <GoATabs>
-          <GoATab heading="Code examples">
+          <GoATab heading="Code playground">
             <h2 id="component" style={{ display: "none" }}>
-              Component
+              Playground
             </h2>
             <Sandbox properties={componentBindings} onChange={onSandboxChange}>
               <GoAFilterChip {...componentProps} />
             </Sandbox>
+            {/* Component properties table */}
             <ComponentProperties properties={componentProperties} />
+          </GoATab>
+
+          <GoATab heading={<>Examples<GoABadge type="information" content="3" /></>}>
 
             <h3 id="component-example-delete">Delete Event</h3>
             <Sandbox skipRender>
@@ -403,7 +412,6 @@ export default function FilterChipPage() {
                       }
                     }
                   }
-                
                 `}
                 />
               </>
@@ -506,13 +514,34 @@ export default function FilterChipPage() {
             )}
           </GoATab>
 
-          <GoATab
-            heading={
-              <>
-                Design guidelines
-                <GoABadge type="information" content="In progress" />
-              </>
-            }></GoATab>
+          <GoATab heading="Design">
+            <GoACallout
+              heading="Design documentation in Figma"
+              type="important"
+              size="medium"
+              maxWidth="540px"
+            >
+              Detailed design documentation for this component can be found on the associated{" "}
+              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
+                component page
+              </a>{" "}
+              in the Component library in Figma.
+            </GoACallout>
+          </GoATab>
+          <GoATab heading="Accessibility">
+            <GoACallout
+              heading="Accessibility documentation in Figma"
+              type="important"
+              size="medium"
+              maxWidth="550px"
+            >
+              Detailed accessibility documentation for this component can be found on the associated{" "}
+              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
+                component page
+              </a>{" "}
+              in the Component library in Figma.
+            </GoACallout>
+          </GoATab>
         </GoATabs>
       </ComponentContent>
     </>

--- a/src/routes/components/FormItemPage.tsx
+++ b/src/routes/components/FormItemPage.tsx
@@ -5,10 +5,12 @@ import {
   ComponentProperty,
 } from "@components/component-properties/ComponentProperties.tsx";
 import { Category, ComponentHeader } from "@components/component-header/ComponentHeader.tsx";
-import { GoAFormItem, GoAInput, GoATab, GoATabs, GoACallout, GoABadge } from "@abgov/react-components";
+import { GoAFormItem, GoAInput, GoATab, GoATabs, GoABadge, } from "@abgov/react-components";
 import { ComponentContent } from "@components/component-content/ComponentContent";
 import { CodeSnippet } from "@components/code-snippet/CodeSnippet.tsx";
 import "./AllComponents.css";
+import { DesignEmpty } from "@components/design-empty/DesignEmpty.tsx";
+import { AccessibilityEmpty } from "@components/accessibility-empty/AccessibilityEmpty.tsx";
 
 // == Page props ==
 
@@ -345,33 +347,13 @@ export default function FormItemPage() {
           </GoATab>
 
           <GoATab heading="Design">
-            <GoACallout
-              heading="Design documentation in Figma"
-              type="important"
-              size="medium"
-              maxWidth="540px"
-            >
-              Detailed design documentation for this component can be found on the associated{" "}
-              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
-                component page
-              </a>{" "}
-              in the Component library in Figma.
-            </GoACallout>
+            <DesignEmpty figmaLink={FIGMA_LINK} />
           </GoATab>
+
           <GoATab heading="Accessibility">
-            <GoACallout
-              heading="Accessibility documentation in Figma"
-              type="important"
-              size="medium"
-              maxWidth="550px"
-            >
-              Detailed accessibility documentation for this component can be found on the associated{" "}
-              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
-                component page
-              </a>{" "}
-              in the Component library in Figma.
-            </GoACallout>
+            <AccessibilityEmpty figmaLink={FIGMA_LINK} />
           </GoATab>
+
         </GoATabs>
       </ComponentContent>
     </>

--- a/src/routes/components/FormItemPage.tsx
+++ b/src/routes/components/FormItemPage.tsx
@@ -5,9 +5,27 @@ import {
   ComponentProperty,
 } from "@components/component-properties/ComponentProperties.tsx";
 import { Category, ComponentHeader } from "@components/component-header/ComponentHeader.tsx";
-import { GoABadge, GoAFormItem, GoAInput, GoATab, GoATabs } from "@abgov/react-components";
+import { GoAFormItem, GoAInput, GoATab, GoATabs, GoACallout, GoABadge } from "@abgov/react-components";
 import { ComponentContent } from "@components/component-content/ComponentContent";
 import { CodeSnippet } from "@components/code-snippet/CodeSnippet.tsx";
+import "./AllComponents.css";
+
+// == Page props ==
+
+const FIGMA_LINK =
+  "https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=27284-300347";
+const componentName = "Form Item";
+const category = Category.INPUTS_AND_ACTIONS;
+const relatedComponents = [
+  { link: "/components/checkbox", name: "Checkbox" },
+  { link: "/components/dropdown", name: "Dropdown" },
+  { link: "/components/input", name: "Input" },
+  { link: "/components/Radio", name: "Radio" },
+  { link: "/components/text-area", name: "Text area" },
+];
+const description =
+  "Wraps an input control with a text label, requirement label, helper text, and error text.";
+
 
 export default function FormItemPage() {
   const language = useContext(LanguageContext);
@@ -68,7 +86,8 @@ export default function FormItemPage() {
       value: "",
     },
   ]);
-  const componentProps: ComponentProperty[] = [
+
+  const componentProperties: ComponentProperty[] = [
     {
       name: "label",
       type: "string",
@@ -134,7 +153,7 @@ export default function FormItemPage() {
       type: "string",
       description: "Sets the maximum width of the form item.",
       lang: "angular",
-    },    
+    },
     {
       name: "testId",
       type: "string",
@@ -164,23 +183,20 @@ export default function FormItemPage() {
   return (
     <>
       <ComponentHeader
-        name="Form Item"
-        category={Category.INPUTS_AND_ACTIONS}
-        description="Wraps an input control with a text label, requirement label, helper text, and error text."
-        relatedComponents={[
-          { link: "/components/checkbox", name: "Checkbox" },
-          { link: "/components/dropdown", name: "Dropdown" },
-          { link: "/components/Radio", name: "Radio" },
-          { link: "/components/text-area", name: "Text area" },
-          { link: "/components/text-field", name: "Text field" },
-        ]}
+        name={componentName}
+        category={category}
+        description={description}
+        relatedComponents={relatedComponents}
+        githubLink={componentName}
+        figmaLink={FIGMA_LINK}
       />
 
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
-
         <GoATabs>
-          <GoATab heading="Code examples">
-            <h2 id="component" style={{display: "none"}}>Component</h2>
+          <GoATab heading="Code playground">
+            <h2 id="component" style={{ display: "none" }}>
+              Playground
+            </h2>
             <Sandbox properties={formItemBindings} onChange={onSandboxChange} flags={["reactive"]}>
               <CodeSnippet
                 lang="typescript"
@@ -228,15 +244,16 @@ export default function FormItemPage() {
               </GoAFormItem>
             </Sandbox>
 
-            <ComponentProperties properties={componentProps} />
+            {/* Component properties table */}
+            <ComponentProperties properties={componentProperties} />
+          </GoATab>
+          <GoATab heading={<>Examples<GoABadge type="information" content="2" /></>}>
 
-            <h2 id="component-examples" className="hidden" aria-hidden="true">Examples</h2>
+
 
             <h3 id="component-example-sortable-columns">Slotted Helper Text</h3>
             <Sandbox skipRender>
-              <GoAFormItem 
-                label="First name" 
-                helpText={helptextReactNode}>
+              <GoAFormItem label="First name" helpText={helptextReactNode}>
                 <GoAInput onChange={noop} value="" name="item" />
               </GoAFormItem>
 
@@ -261,25 +278,27 @@ export default function FormItemPage() {
                   allowCopy={true}
                   code={`
                   <goa-form-item label="First name">
-                    <goa-input goaValue name="item" [formControl]="itemFormCtrl" [value]="itemFormCtrl.value"></goa-input>
+                    <goa-input
+                      goaValue
+                      name="item"
+                      [formControl]="itemFormCtrl"
+                      [value]="itemFormCtrl.value"
+                    ></goa-input>
 
                     <div slot="helptext">
                       <span>This is </span>
                       <i>slotted</i>
                       <b>help text</b>.
                     </div>
-
                   </goa-form-item>
                   `}
                 />
               )}
             </Sandbox>
 
-            <h3 id="component-example-sortable-columns">Slotted Error Text</h3>
+            <h3 id="component-example-slotted-error-text">Slotted Error Text</h3>
             <Sandbox skipRender>
-              <GoAFormItem 
-                label="First name" 
-                error={errorReactNode}>
+              <GoAFormItem label="First name" error={errorReactNode}>
                 <GoAInput onChange={noop} value="" name="item" />
               </GoAFormItem>
 
@@ -289,10 +308,11 @@ export default function FormItemPage() {
                   tags="react"
                   allowCopy={true}
                   code={`
-                  <GoAFormItem 
+                  <GoAFormItem
                     label="First name"
-                    error={<><i>This is </i> slotted <b>error text</b>.</>}>
-                    <GoAInput onChange={onChange} value={value} name="item"></GoAInput>
+                    error={<><i>This is </i> slotted <b>error text</b>.</>}
+                  >
+                    <GoAInput onChange={onChange} value={value} name="item" />
                   </GoAFormItem>
                   `}
                 />
@@ -305,28 +325,52 @@ export default function FormItemPage() {
                   allowCopy={true}
                   code={`
                   <goa-form-item label="First name">
-                  <goa-input goaValue name="item" [formControl]="itemFormCtrl" [value]="itemFormCtrl.value"></goa-input>
+                    <goa-input
+                      goaValue
+                      name="item"
+                      [formControl]="itemFormCtrl"
+                      [value]="itemFormCtrl.value"
+                    ></goa-input>
 
                     <div slot="error">
                       <span>This is </span>
                       <i>slotted </i>
                       <b>error text.</b>
                     </div>
-
                   </goa-form-item>
                   `}
                 />
               )}
             </Sandbox>
           </GoATab>
-          <GoATab
-            heading={
-              <>
-                Design guidelines
-                <GoABadge type="information" content="In progress" />
-              </>
-            }>
-            <p>Coming Soon</p>
+
+          <GoATab heading="Design">
+            <GoACallout
+              heading="Design documentation in Figma"
+              type="important"
+              size="medium"
+              maxWidth="540px"
+            >
+              Detailed design documentation for this component can be found on the associated{" "}
+              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
+                component page
+              </a>{" "}
+              in the Component library in Figma.
+            </GoACallout>
+          </GoATab>
+          <GoATab heading="Accessibility">
+            <GoACallout
+              heading="Accessibility documentation in Figma"
+              type="important"
+              size="medium"
+              maxWidth="550px"
+            >
+              Detailed accessibility documentation for this component can be found on the associated{" "}
+              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
+                component page
+              </a>{" "}
+              in the Component library in Figma.
+            </GoACallout>
           </GoATab>
         </GoATabs>
       </ComponentContent>

--- a/src/routes/components/FormStepper.tsx
+++ b/src/routes/components/FormStepper.tsx
@@ -11,6 +11,7 @@ import {
   GoATab,
   GoATabs,
   GoAContainer,
+  GoACallout,
 } from "@abgov/react-components";
 import { CodeSnippet } from "@components/code-snippet/CodeSnippet";
 import { LanguageContext, Sandbox } from "@components/sandbox";
@@ -22,10 +23,15 @@ import {
 } from "@components/component-properties/ComponentProperties";
 import { ComponentContent } from "@components/component-content/ComponentContent";
 
+// == Page props ==
+
+const FIGMA_LINK =
+  "https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=1014-6629";
 const componentName = "Form Stepper";
-const description = "Provides a visual representation of a form through a series of steps.";
-const componentCategory = Category.STRUCTURE_AND_NAVIGATION;
+const category = Category.STRUCTURE_AND_NAVIGATION;
 const relatedComponents = [{ link: "/components/form-item", name: "Form item" }];
+const description = "Provides a visual representation of a form through a series of steps.";
+
 type ComponentPropsType = GoAFormStepperProps;
 
 
@@ -105,15 +111,18 @@ export default function FormStepperPage() {
     <>
       <ComponentHeader
         name={componentName}
-        category={componentCategory}
+        category={category}
         description={description}
         relatedComponents={relatedComponents}
+        githubLink={componentName}
+        figmaLink={FIGMA_LINK}
       />
+
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
         <GoATabs>
-          <GoATab heading="Code examples">
+          <GoATab heading="Code playground">
             <h2 id="component" style={{ display: "none" }}>
-              Component
+              Playground
             </h2>
             <GoAContainer mt="m" mb="none">
               <div style={{ padding: "40px" }}>
@@ -201,26 +210,15 @@ export default function FormStepperPage() {
             {/*Component properties table*/}
             <ComponentProperties heading="Stepper Properties" properties={componentProperties} />
             <ComponentProperties heading="Step Properties" properties={formStepProperties} />
+          </GoATab>
 
-            {/* Examples*/}
-            <h2 id="component-examples" className="hidden" aria-hidden="true">
-              Examples
-            </h2>
-            {/*Example 1*/}
+
+          <GoATab heading={<>Examples<GoABadge type="information" content="2" /></>}>
+
+
+            {/* Example 1 */}
             <h3 id="component-example-controlled-navigation">Controlled Navigation</h3>
-            <p>
-              The user needs to partially or completely finish a step to be able to move forward to
-              the next step. In this case:
-              <ul>
-                <li>A step that is “Not started” will not be clickable.</li>
-                <li>A user cannot use the stepper to navigate to another page.</li>
-                <li>
-                  Clicking the Active step when you are on that step will do nothing. (no page
-                  refresh).
-                </li>
-              </ul>
-              To use the controlled type you must set a step value ≥ 1
-            </p>
+
             <Sandbox fullWidth skipRender allow={["div"]}>
               <CodeSnippet
                 lang="typescript"
@@ -334,12 +332,23 @@ export default function FormStepperPage() {
                 </GoAButton>
               </div>
             </Sandbox>
+            <GoACallout type="important" heading="When using a form stepper with controlled navigation" size="medium" mt="l">
+              The user needs to partially or completely finish a step to be able to move forward to
+              the next step. In this case: <ul>
+              <li>A step that is “Not started” will not be clickable.</li>
+              <li>A user cannot use the stepper to navigate to another page.</li>
+              <li>
+                Clicking the Active step when you are on that step will do nothing. (no page
+                refresh).
+              </li>
+            </ul>
+              To use the controlled type you must set a step value ≥ 1.
+            </GoACallout>
 
-            {/*Example 2*/}
-            <h3 id="component-example-step-status">Step status</h3>
-            The status of each step can be configured to either “complete” or “incomplete” using the
-            status property.
 
+
+            {/* Example 2 */}
+            <h3 id="component-example-step-status">Step Status</h3>
             <Sandbox fullWidth skipRender allow={["div"]}>
               <CodeSnippet
                 lang="typescript"
@@ -461,16 +470,40 @@ export default function FormStepperPage() {
                 </GoAButton>
               </div>
             </Sandbox>
+            <GoACallout type="important" size="medium" mt="l">
+              The status of each step can be configured to either “complete” or “incomplete” using the
+              status property.
+            </GoACallout>
           </GoATab>
 
-          <GoATab
-            heading={
-              <>
-                Design guidelines
-                <GoABadge type="information" content="In progress" />
-              </>
-            }>
-            <p>Coming Soon</p>
+          <GoATab heading="Design">
+            <GoACallout
+              heading="Design documentation in Figma"
+              type="important"
+              size="medium"
+              maxWidth="540px"
+            >
+              Detailed design documentation for this component can be found on the associated{" "}
+              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
+                component page
+              </a>{" "}
+              in the Component library in Figma.
+            </GoACallout>
+          </GoATab>
+
+          <GoATab heading="Accessibility">
+            <GoACallout
+              heading="Accessibility documentation in Figma"
+              type="important"
+              size="medium"
+              maxWidth="550px"
+            >
+              Detailed accessibility documentation for this component can be found on the associated{" "}
+              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
+                component page
+              </a>{" "}
+              in the Component library in Figma.
+            </GoACallout>
           </GoATab>
         </GoATabs>
       </ComponentContent>

--- a/src/routes/components/FormStepper.tsx
+++ b/src/routes/components/FormStepper.tsx
@@ -22,6 +22,8 @@ import {
   ComponentProperty,
 } from "@components/component-properties/ComponentProperties";
 import { ComponentContent } from "@components/component-content/ComponentContent";
+import { DesignEmpty } from "@components/design-empty/DesignEmpty.tsx";
+import { AccessibilityEmpty } from "@components/accessibility-empty/AccessibilityEmpty.tsx";
 
 // == Page props ==
 
@@ -477,34 +479,13 @@ export default function FormStepperPage() {
           </GoATab>
 
           <GoATab heading="Design">
-            <GoACallout
-              heading="Design documentation in Figma"
-              type="important"
-              size="medium"
-              maxWidth="540px"
-            >
-              Detailed design documentation for this component can be found on the associated{" "}
-              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
-                component page
-              </a>{" "}
-              in the Component library in Figma.
-            </GoACallout>
+            <DesignEmpty figmaLink={FIGMA_LINK} />
           </GoATab>
 
           <GoATab heading="Accessibility">
-            <GoACallout
-              heading="Accessibility documentation in Figma"
-              type="important"
-              size="medium"
-              maxWidth="550px"
-            >
-              Detailed accessibility documentation for this component can be found on the associated{" "}
-              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
-                component page
-              </a>{" "}
-              in the Component library in Figma.
-            </GoACallout>
+            <AccessibilityEmpty figmaLink={FIGMA_LINK} />
           </GoATab>
+
         </GoATabs>
       </ComponentContent>
     </>

--- a/src/routes/components/Grid.tsx
+++ b/src/routes/components/Grid.tsx
@@ -5,8 +5,27 @@ import {
   ComponentProperty,
 } from "@components/component-properties/ComponentProperties";
 import { Category, ComponentHeader } from "@components/component-header/ComponentHeader";
-import { GoABadge, GoAGrid, GoATab, GoATabs } from "@abgov/react-components";
+import {
+  GoAGrid,
+  GoATab,
+  GoATabs,
+  GoACallout,
+} from "@abgov/react-components";
 import { ComponentContent } from "@components/component-content/ComponentContent";
+import "./AllComponents.css";
+
+// == Page props ==
+
+
+const componentName = "Grid";
+const category = Category.UTILITIES;
+const description = "Arrange a number of components into a responsive grid pattern.";
+const relatedComponents = [
+  { link: "/components/block", name: "Block" },
+  { link: "/components/divider", name: "Divider" },
+  { link: "/patterns", name: "Layout" },
+  { link: "/components/spacer", name: "Spacer" },
+];
 
 export default function GridPage() {
   const [gridProps, setGridProps] = useState({
@@ -63,23 +82,20 @@ export default function GridPage() {
   return (
     <>
       <ComponentHeader
-        name="Grid"
-        category={Category.UTILITIES}
-        description="Arrange a number of components into a responsive grid pattern."
-        relatedComponents={[
-          { link: "/components/block", name: "Block" },
-          { link: "/components/divider", name: "Divider" },
-          { link: "/patterns", name: "Layout" },
-          { link: "/components/spacer", name: "Spacer" },
-        ]}
+        name={componentName}
+        category={category}
+        description={description}
+        relatedComponents={relatedComponents}
+        githubLink={componentName}
       />
 
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
 
         <GoATabs>
-          <GoATab heading="Code examples">
-            {/*Grid sandbox*/}
-            <h2 id="component" style={{display: "none"}}>Component</h2>
+          <GoATab heading="Code playground">
+            <h2 id="component" style={{ display: "none" }}>
+              Playground
+            </h2>
             <Sandbox properties={gridBindings} onChange={onSandboxChange} fullWidth>
               <GoAGrid {...gridProps}>
                 <div
@@ -133,14 +149,18 @@ export default function GridPage() {
             <ComponentProperties properties={componentProperties} />
           </GoATab>
 
-          <GoATab
-            heading={
-              <>
-                Design guidelines
-                <GoABadge type="information" content="In progress" />
-              </>
-            }
-          ></GoATab>
+          {/* Since there are 0 examples, no "Examples" tab is included */}
+
+          <GoATab heading="Design">
+            <GoACallout heading="Using Grid in design" type="important" size="medium" maxWidth="540px">
+              The grid component is accomplished in design by using{" "}
+              <a href="https://www.figma.com/best-practices/everything-you-need-to-know-about-layout-grids/" target="_blank" rel="noreferrer">
+                grids and guides in Figma
+              </a>{" "}
+              our design tool.
+            </GoACallout>
+          </GoATab>
+
         </GoATabs>
       </ComponentContent>
     </>

--- a/src/routes/components/Grid.tsx
+++ b/src/routes/components/Grid.tsx
@@ -9,7 +9,8 @@ import {
   GoAGrid,
   GoATab,
   GoATabs,
-  GoACallout,
+  GoAText,
+  GoAContainer,
 } from "@abgov/react-components";
 import { ComponentContent } from "@components/component-content/ComponentContent";
 import "./AllComponents.css";
@@ -152,13 +153,15 @@ export default function GridPage() {
           {/* Since there are 0 examples, no "Examples" tab is included */}
 
           <GoATab heading="Design">
-            <GoACallout heading="Using Grid in design" type="important" size="medium" maxWidth="540px">
-              The grid component is accomplished in design by using{" "}
-              <a href="https://www.figma.com/best-practices/everything-you-need-to-know-about-layout-grids/" target="_blank" rel="noreferrer">
-                grids and guides in Figma
-              </a>{" "}
-              our design tool.
-            </GoACallout>
+            <GoAContainer type="non-interactive" accent="filled" padding="relaxed" width="content">
+              <GoAText size="body-m" mt="none" mb="none">
+                In design, use Figma's built-in{" "}
+                <a href="https://help.figma.com/hc/en-us/articles/360040451373-Explore-auto-layout-properties" target="_blank" rel="noreferrer">
+                  auto layout
+                </a>{" "}
+                feature set to <i>wrap</i> to create a responsive grid pattern that can respond to different screen sizes instead of the <i>Grid</i> component.
+              </GoAText>
+            </GoAContainer>
           </GoATab>
 
         </GoATabs>

--- a/src/routes/components/HeroBanner.tsx
+++ b/src/routes/components/HeroBanner.tsx
@@ -12,11 +12,12 @@ import {
   GoAHeroBannerActions,
   GoATab,
   GoATabs,
-  GoACallout,
 } from "@abgov/react-components";
 import { CodeSnippet } from "@components/code-snippet/CodeSnippet";
 import { ComponentContent } from "@components/component-content/ComponentContent";
 import "./AllComponents.css";
+import { DesignEmpty } from "@components/design-empty/DesignEmpty.tsx";
+import { AccessibilityEmpty } from "@components/accessibility-empty/AccessibilityEmpty.tsx";
 
 // == Page props ==
 
@@ -242,35 +243,13 @@ export default function HeroBannerPage() {
           </GoATab>
 
           <GoATab heading="Design">
-
-          <GoACallout
-              heading="Design documentation in Figma"
-              type="important"
-              size="medium"
-              maxWidth="540px"
-            >
-              Detailed design documentation for this component can be found on the associated{" "}
-              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
-                component page
-              </a>{" "}
-              in the Component library in Figma.
-            </GoACallout>
+            <DesignEmpty figmaLink={FIGMA_LINK} />
           </GoATab>
 
           <GoATab heading="Accessibility">
-            <GoACallout
-              heading="Accessibility documentation in Figma"
-              type="important"
-              size="medium"
-              maxWidth="550px"
-            >
-              Detailed accessibility documentation for this component can be found on the associated{" "}
-              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
-                component page
-              </a>{" "}
-              in the Component library in Figma.
-            </GoACallout>
+            <AccessibilityEmpty figmaLink={FIGMA_LINK} />
           </GoATab>
+
         </GoATabs>
       </ComponentContent>
     </>

--- a/src/routes/components/HeroBanner.tsx
+++ b/src/routes/components/HeroBanner.tsx
@@ -6,14 +6,31 @@ import {
 } from "@components/component-properties/ComponentProperties.tsx";
 import { Category, ComponentHeader } from "@components/component-header/ComponentHeader.tsx";
 import {
+  GoABadge,
   GoAButton,
   GoAHeroBanner,
   GoAHeroBannerActions,
   GoATab,
   GoATabs,
+  GoACallout,
 } from "@abgov/react-components";
+import { CodeSnippet } from "@components/code-snippet/CodeSnippet";
 import { ComponentContent } from "@components/component-content/ComponentContent";
-import { CodeSnippet } from "@components/code-snippet/CodeSnippet.tsx";
+import "./AllComponents.css";
+
+// == Page props ==
+
+const FIGMA_LINK =
+  "https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=622-14412";
+const componentName = "Hero banner";
+const category = Category.STRUCTURE_AND_NAVIGATION;
+const description =
+  "A visual band of text, including a background colour or image and a call to action.";
+const relatedComponents = [
+  { link: "/components/footer", name: "Footer" },
+  { link: "/patterns", name: "Layout" },
+  { link: "/components/spacer", name: "Spacer" },
+];
 
 export default function HeroBannerPage() {
   const [heroBannerProps, setHeroBannerProps] = useState({
@@ -150,32 +167,38 @@ export default function HeroBannerPage() {
   return (
     <>
       <ComponentHeader
-        name="Hero banner"
-        category={Category.STRUCTURE_AND_NAVIGATION}
-        description="A visual band of text, including a background colour or image and a call to action."
+        name={componentName}
+        category={category}
+        description={description}
+        relatedComponents={relatedComponents}
+        githubLink={componentName}
+        figmaLink={FIGMA_LINK}
       />
 
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
         <GoATabs>
-          <GoATab heading="Code examples">
-            {/*Hero Banner Sandbox*/}
+          <GoATab heading="Code playground">
             <h2 id="component" style={{ display: "none" }}>
-              Component
+              Playground
             </h2>
-            <Sandbox properties={heroBannerBindings} fullWidth={true} onChange={onSandboxChange}>
+            <Sandbox
+              properties={heroBannerBindings}
+              onChange={onSandboxChange}
+              fullWidth
+            >
               <GoAHeroBanner {...heroBannerProps}>
                 Resources are available to help Alberta entrepreneurs and small businesses start,
                 grow and succeed.
               </GoAHeroBanner>
             </Sandbox>
 
+            {/* Component properties */}
             <ComponentProperties properties={componentProperties} />
+          </GoATab>
 
-            {/* Examples*/}
-            <h2 id="component-examples" className="hidden" aria-hidden="true">
-              Examples
-            </h2>
+          <GoATab heading={<>Examples<GoABadge type="information" content="1" /></>}>
 
+            {/* Example 1 */}
             <h3 id="component-example-actions">Hero Banner with actions</h3>
             <Sandbox skipRender fullWidth>
               <CodeSnippet
@@ -216,6 +239,37 @@ export default function HeroBannerPage() {
                 </GoAHeroBannerActions>
               </GoAHeroBanner>
             </Sandbox>
+          </GoATab>
+
+          <GoATab heading="Design">
+
+          <GoACallout
+              heading="Design documentation in Figma"
+              type="important"
+              size="medium"
+              maxWidth="540px"
+            >
+              Detailed design documentation for this component can be found on the associated{" "}
+              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
+                component page
+              </a>{" "}
+              in the Component library in Figma.
+            </GoACallout>
+          </GoATab>
+
+          <GoATab heading="Accessibility">
+            <GoACallout
+              heading="Accessibility documentation in Figma"
+              type="important"
+              size="medium"
+              maxWidth="550px"
+            >
+              Detailed accessibility documentation for this component can be found on the associated{" "}
+              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
+                component page
+              </a>{" "}
+              in the Component library in Figma.
+            </GoACallout>
           </GoATab>
         </GoATabs>
       </ComponentContent>

--- a/src/routes/components/IconButton.tsx
+++ b/src/routes/components/IconButton.tsx
@@ -7,7 +7,6 @@ import {
   GoATab,
   GoATable,
   GoATabs,
-  GoACallout,
 } from "@abgov/react-components";
 import { Category, ComponentHeader } from "@components/component-header/ComponentHeader.tsx";
 import {
@@ -19,6 +18,8 @@ import { useState } from "react";
 import ICONS from "./icons.json";
 import { ComponentContent } from "@components/component-content/ComponentContent";
 import "./AllComponents.css";
+import { DesignEmpty } from "@components/design-empty/DesignEmpty.tsx";
+import { AccessibilityEmpty } from "@components/accessibility-empty/AccessibilityEmpty.tsx";
 
 // == Page props ==
 
@@ -298,34 +299,13 @@ export default function IconButtonPage() {
           </GoATab>
 
           <GoATab heading="Design">
-            <GoACallout
-              heading="Design documentation in Figma"
-              type="important"
-              size="medium"
-              maxWidth="540px"
-            >
-              Detailed design documentation for this component can be found on the associated{" "}
-              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
-                component page
-              </a>{" "}
-              in the Component library in Figma.
-            </GoACallout>
+            <DesignEmpty figmaLink={FIGMA_LINK} />
           </GoATab>
 
           <GoATab heading="Accessibility">
-            <GoACallout
-              heading="Accessibility documentation in Figma"
-              type="important"
-              size="medium"
-              maxWidth="550px"
-            >
-              Detailed accessibility documentation for this component can be found on the associated{" "}
-              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
-                component page
-              </a>{" "}
-              in the Component library in Figma.
-            </GoACallout>
+            <AccessibilityEmpty figmaLink={FIGMA_LINK} />
           </GoATab>
+
         </GoATabs>
       </ComponentContent>
     </>

--- a/src/routes/components/IconButton.tsx
+++ b/src/routes/components/IconButton.tsx
@@ -7,6 +7,7 @@ import {
   GoATab,
   GoATable,
   GoATabs,
+  GoACallout,
 } from "@abgov/react-components";
 import { Category, ComponentHeader } from "@components/component-header/ComponentHeader.tsx";
 import {
@@ -17,16 +18,27 @@ import { ComponentBinding, Sandbox } from "@components/sandbox";
 import { useState } from "react";
 import ICONS from "./icons.json";
 import { ComponentContent } from "@components/component-content/ComponentContent";
+import "./AllComponents.css";
 
+// == Page props ==
+
+const FIGMA_LINK =
+  "https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=27301-302107";
 const componentName = "Icon button";
 const description = "A compact button with an icon and no text.";
 const componentCategory = Category.INPUTS_AND_ACTIONS;
+const relatedComponents = [
+  { link: "/components/icons", name: "Icons" },
+  { link: "/components/button", name: "Button" },
+  { link: "/components/tooltip", name: "Tooltip" },
+];
 type ComponentPropsType = GoAIconButtonProps;
 type CastingType = {
   // add any required props here
   icon: GoAIconType;
   [key: string]: unknown;
 };
+
 export default function IconButtonPage() {
   const [iconButtonProps, setIconButtonProps] = useState<ComponentPropsType>({
     icon: "refresh",
@@ -71,7 +83,7 @@ export default function IconButtonPage() {
       type: "string",
       name: "ariaLabel",
       value: "Refresh icon",
-    }
+    },
   ]);
 
   const componentProperties: ComponentProperty[] = [
@@ -158,23 +170,26 @@ export default function IconButtonPage() {
         name={componentName}
         category={componentCategory}
         description={description}
+        relatedComponents={relatedComponents}
+        githubLink={componentName}
+        figmaLink={FIGMA_LINK}
       />
 
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
-
         <GoATabs>
-          <GoATab heading="Code examples">
+          <GoATab heading="Code playground">
             <h2 id="component" style={{display: "none"}}>Component</h2>
             <Sandbox properties={iconButtonBindings} onChange={onSandboxChange}>
               <GoAIconButton {...iconButtonProps} />
             </Sandbox>
 
-            {/*Component properties table*/}
+            {/* Component properties */}
             <ComponentProperties properties={componentProperties} />
+          </GoATab>
 
-            {/* Examples */}
-            <h2 id="component-examples" className="hidden" aria-hidden="true">Examples</h2>
+          <GoATab heading={<>Examples<GoABadge type="information" content="1" /></>}>
 
+            {/* Example 1 */}
             <h3 id="component-example-multiple-actions-table">Show multiple actions in a compact table</h3>
             <Sandbox fullWidth>
               <GoATable width="100%">
@@ -282,14 +297,34 @@ export default function IconButtonPage() {
             </Sandbox>
           </GoATab>
 
-          <GoATab
-            heading={
-              <>
-                Design guidelines
-                <GoABadge type="information" content="In progress" />
-              </>
-            }>
-            <p>Coming Soon</p>
+          <GoATab heading="Design">
+            <GoACallout
+              heading="Design documentation in Figma"
+              type="important"
+              size="medium"
+              maxWidth="540px"
+            >
+              Detailed design documentation for this component can be found on the associated{" "}
+              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
+                component page
+              </a>{" "}
+              in the Component library in Figma.
+            </GoACallout>
+          </GoATab>
+
+          <GoATab heading="Accessibility">
+            <GoACallout
+              heading="Accessibility documentation in Figma"
+              type="important"
+              size="medium"
+              maxWidth="550px"
+            >
+              Detailed accessibility documentation for this component can be found on the associated{" "}
+              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
+                component page
+              </a>{" "}
+              in the Component library in Figma.
+            </GoACallout>
           </GoATab>
         </GoATabs>
       </ComponentContent>

--- a/src/routes/components/Icons.tsx
+++ b/src/routes/components/Icons.tsx
@@ -9,6 +9,22 @@ import { GoAGrid, GoAIcon, GoAIconType, GoATab, GoATabs } from "@abgov/react-com
 import { Category, ComponentHeader } from "@components/component-header/ComponentHeader.tsx";
 import { IconSnippet } from "@components/icon-snippet/IconSnippet.tsx";
 import { ComponentContent } from "@components/component-content/ComponentContent";
+import "./AllComponents.css";
+
+// == Page props ==
+
+const FIGMA_LINK =
+  "https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=24019-471310";
+const componentName = "Icons";
+const category = Category.UTILITIES;
+const description =
+  "A simple and universal graphic symbol representing an action, object, or concept to help guide the user.";
+const relatedComponents = [
+  { link: "/components/badge", name: "Badge" },
+  { link: "/components/callout", name: "Callout" },
+  { link: "/components/icon-button", name: "Icon button" },
+  { link: "/components/Tooltip", name: "Tooltip" },
+];
 
 export default function IconsPage() {
   const [iconsProps, setIconsProps] = useState({
@@ -142,12 +158,12 @@ export default function IconsPage() {
       type: "string",
       lang: "angular",
       description: "Sets the data-testid attribute. Used with ByTestId queries in tests.",
-    },  
+    },
     {
       name: "mt,mr,mb,ml",
       type: "none | 3xs | 2xs | xs | s | m | l | xl | 2xl | 3xl | 4xl",
       description: "Apply margin to the top, right, bottom, and/or left of the component.",
-    },  
+    },
   ];
 
   function onSandboxChange(iconsBindings: ComponentBinding[], props: Record<string, unknown>) {
@@ -158,36 +174,31 @@ export default function IconsPage() {
   return (
     <>
       <ComponentHeader
-        name="Icons"
-        category={Category.UTILITIES}
-        description="A simple and universal graphic symbol representing an action, object, or concept to help guide the user."
-        relatedComponents={[
-          { link: "/components/badge", name: "Badge" },
-          { link: "/components/callout", name: "Callout" },
-          { link: "/components/icon-button", name: "Icon button" },
-          { link: "/components/Tooltip", name: "Tooltip" },
-        ]}
+        name={componentName}
+        category={category}
+        description={description}
+        relatedComponents={relatedComponents}
+        githubLink={componentName}
+        figmaLink={FIGMA_LINK}
       />
 
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
         <GoATabs>
-          <GoATab heading="Code examples">
-            {/*Icons Sandbox*/}
+          <GoATab heading="Code playground">
             <h2 id="component" style={{ display: "none" }}>
-              Component
+              Playground
             </h2>
             <Sandbox properties={iconsBindings} onChange={onSandboxChange}>
               <GoAIcon {...iconsProps} />
             </Sandbox>
 
-            {/*Icons Properties*/}
+            {/* Icons Properties */}
             <ComponentProperties properties={componentProperties} />
+          </GoATab>
 
-            {/*Icons example*/}
-            <h2 id="component-examples" className="hidden" aria-hidden="true">
-              Examples
-            </h2>
+          <GoATab heading="Icon categories">
 
+            {/* Category 1 */}
             <h3 id="component-example-alert-messaging">Alert and messaging</h3>
             <GoAGrid minChildWidth="230px" gap="l" mt="m">
               <IconSnippet type={"information-circle"} />
@@ -200,6 +211,7 @@ export default function IconsPage() {
               <IconSnippet type={"remove-circle"} />
             </GoAGrid>
 
+            {/* Category 2 */}
             <h3 id="component-example-basic">Basic</h3>
             <GoAGrid minChildWidth="230px" gap="l" mt="m">
               <IconSnippet type={"close"} />
@@ -208,8 +220,9 @@ export default function IconsPage() {
               <IconSnippet type={"remove"} />
             </GoAGrid>
 
+            {/* Category 3 */}
             <h3 id="component-example-direction">Direction</h3>
-            <GoAGrid minChildWidth={"230px"} gap={"l"} mt="m">
+            <GoAGrid minChildWidth="230px" gap="l" mt="m">
               <IconSnippet type={"chevron-down"} />
               <IconSnippet type={"chevron-up"} />
               <IconSnippet type={"chevron-back"} />
@@ -224,8 +237,9 @@ export default function IconsPage() {
               <IconSnippet type={"caret-forward"} />
             </GoAGrid>
 
+            {/* Category 4 */}
             <h3 id="component-example-interaction">Interactions</h3>
-            <GoAGrid minChildWidth={"230px"} gap={"l"} mt="m">
+            <GoAGrid minChildWidth="230px" gap="l" mt="m">
               <IconSnippet type={"menu"} />
               <IconSnippet type={"reload"} />
               <IconSnippet type={"search"} />
@@ -246,14 +260,17 @@ export default function IconsPage() {
               <IconSnippet type={"download"} />
             </GoAGrid>
 
+            {/* Category 5 */}
             <h3 id="component-example-accounts">Accounts</h3>
-            <GoAGrid minChildWidth={"230px"} gap={"l"} mt="m">
+            <GoAGrid minChildWidth="230px" gap="l" mt="m">
               <IconSnippet type={"person-circle"} />
               <IconSnippet type={"settings"} />
               <IconSnippet type={"mail"} />
               <IconSnippet type={"call"} />
             </GoAGrid>
           </GoATab>
+
+
         </GoATabs>
       </ComponentContent>
     </>

--- a/src/routes/components/List.tsx
+++ b/src/routes/components/List.tsx
@@ -4,6 +4,7 @@ import { CodeSnippet } from "@components/code-snippet/CodeSnippet.tsx";
 import { useContext } from "react";
 import { LanguageContext } from "@components/sandbox";
 import { ComponentContent } from "@components/component-content/ComponentContent";
+import { DesignEmpty } from "@components/design-empty/DesignEmpty.tsx";
 
 export default function ListPage() {
   const language = useContext(LanguageContext);
@@ -213,19 +214,9 @@ export default function ListPage() {
           </GoATab>
 
           <GoATab heading="Design">
-            <GoACallout
-              heading="Design documentation in Figma"
-              type="important"
-              size="medium"
-              maxWidth="550px"
-            >
-              Detailed design documentation for this component can be found on the associated{" "}
-              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
-                component page
-              </a>{" "}
-              in the Component library in Figma.
-            </GoACallout>
+            <DesignEmpty figmaLink={FIGMA_LINK} />
           </GoATab>
+
         </GoATabs>
       </ComponentContent>
     </>

--- a/src/routes/components/List.tsx
+++ b/src/routes/components/List.tsx
@@ -1,5 +1,5 @@
 import { Category, ComponentHeader } from "@components/component-header/ComponentHeader.tsx";
-import { GoABadge, GoAContainer, GoATab, GoATabs } from "@abgov/react-components";
+import { GoACallout, GoAContainer, GoATab, GoATabs, GoAText } from "@abgov/react-components";
 import { CodeSnippet } from "@components/code-snippet/CodeSnippet.tsx";
 import { useContext } from "react";
 import { LanguageContext } from "@components/sandbox";
@@ -8,16 +8,37 @@ import { ComponentContent } from "@components/component-content/ComponentContent
 export default function ListPage() {
   const language = useContext(LanguageContext);
 
+  const FIGMA_LINK =
+    "https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=27301-303450";
+  const description = "Organize information into brief and clear groups.";
+  const componentName = "List";
+  const category = Category.INPUTS_AND_ACTIONS;
+
+
   return (
+
     <>
       <ComponentHeader
-        name="List"
-        category={Category.CONTENT_AND_LAYOUT}
-        description="Organize information into brief and clear groups."
+        name={componentName}
+        category={category}
+        description={description}
+        githubLink={componentName}
+        figmaLink={FIGMA_LINK}
       />
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
         <GoATabs>
-          <GoATab heading="Code examples">
+          <GoATab heading="Examples">
+
+            <GoACallout
+              type="information"
+              size="medium"
+              maxWidth="550px"
+            >
+              The list is not a GoA component, it can be used through CSS.
+            </GoACallout>
+            <h3 id="component-example-ordered-list" style={{ display: "none" }}>Ordered list</h3>
+            <GoAText size="heading-m" mt="xl" mb="l" as="h3"> Ordered list </GoAText>
+
             {/*We don't use sandbox because it isn't starting with "GoA" components*/}
             <GoAContainer>
               <ol className="goa-ordered-list">
@@ -136,10 +157,6 @@ export default function ListPage() {
             )}
             {/* Examples*/}
 
-            <h2 id="component-examples" className="hidden" aria-hidden="true">
-              Examples
-            </h2>
-
             <h3 id="component-example-unordered-list">Unordered list</h3>
             <GoAContainer mt="m">
               <ul className="goa-unordered-list">
@@ -195,14 +212,19 @@ export default function ListPage() {
             )}
           </GoATab>
 
-          <GoATab
-            heading={
-              <>
-                Design guidelines
-                <GoABadge type="information" content="In progress" />
-              </>
-            }>
-            <p>Coming Soon</p>
+          <GoATab heading="Design">
+            <GoACallout
+              heading="Design documentation in Figma"
+              type="important"
+              size="medium"
+              maxWidth="550px"
+            >
+              Detailed design documentation for this component can be found on the associated{" "}
+              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
+                component page
+              </a>{" "}
+              in the Component library in Figma.
+            </GoACallout>
           </GoATab>
         </GoATabs>
       </ComponentContent>

--- a/src/routes/components/MicrositeHeader.tsx
+++ b/src/routes/components/MicrositeHeader.tsx
@@ -5,7 +5,6 @@ import {
   GoAServiceLevel,
   GoATab,
   GoATabs,
-  GoACallout,
 } from "@abgov/react-components";
 import { Category, ComponentHeader } from "@components/component-header/ComponentHeader.tsx";
 import {
@@ -16,6 +15,8 @@ import { ComponentBinding, Sandbox } from "@components/sandbox";
 import { useState } from "react";
 import { ComponentContent } from "@components/component-content/ComponentContent";
 import MicrositeHeaderExamples from "@examples/microsite-header/MicrositeHeaderExamples.tsx";
+import { DesignEmpty } from "@components/design-empty/DesignEmpty.tsx";
+import { AccessibilityEmpty } from "@components/accessibility-empty/AccessibilityEmpty.tsx";
 
 // == Page props ==
 const FIGMA_LINK =
@@ -218,30 +219,13 @@ export default function MicrositeHeaderPage() {
           </GoATab>
 
           <GoATab heading="Design">
-            <GoACallout heading="Design documentation in Figma" type="important" size="medium" maxWidth="540px">
-              Detailed design documentation for this component can be found on the associated{" "}
-              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
-                component page
-              </a>{" "}
-              in the Component library in Figma.
-            </GoACallout>
+            <DesignEmpty figmaLink={FIGMA_LINK} />
           </GoATab>
 
           <GoATab heading="Accessibility">
-
-          <GoACallout
-              heading="Accessibility documentation in Figma"
-              type="important"
-              size="medium"
-              maxWidth="550px"
-            >
-              Detailed accessibility documentation for this component can be found on the associated{" "}
-              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
-                component page
-              </a>{" "}
-              in the Component library in Figma.
-            </GoACallout>
+            <AccessibilityEmpty figmaLink={FIGMA_LINK} />
           </GoATab>
+
         </GoATabs>
       </ComponentContent>
     </>

--- a/src/routes/components/MicrositeHeader.tsx
+++ b/src/routes/components/MicrositeHeader.tsx
@@ -5,6 +5,7 @@ import {
   GoAServiceLevel,
   GoATab,
   GoATabs,
+  GoACallout,
 } from "@abgov/react-components";
 import { Category, ComponentHeader } from "@components/component-header/ComponentHeader.tsx";
 import {
@@ -16,17 +17,24 @@ import { useState } from "react";
 import { ComponentContent } from "@components/component-content/ComponentContent";
 import MicrositeHeaderExamples from "@examples/microsite-header/MicrositeHeaderExamples.tsx";
 
+// == Page props ==
+const FIGMA_LINK =
+  "https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=2-81";
 const componentName = "Microsite header";
+const category = Category.STRUCTURE_AND_NAVIGATION;
 const description =
-  "Communicate what stage the service is at, connect to <a href='https://www.alberta.ca' target='_blank'>Alberta.ca</a>, and gather feedback on your service.";
-const componentCategory = Category.STRUCTURE_AND_NAVIGATION;
-const relatedComponents = [{ link: "/components/header", name: "Header" }];
+  "Communicate what stage the service is at, connect to Alberta.ca, and gather feedback on your service from users.";
+const relatedComponents = [
+  { link: "/components/footer", name: "Footer" },
+  { link: "/components/header", name: "Header" },
+];
+
 type ComponentPropsType = GoAHeaderProps;
 type CastingType = {
-  // add any required props here
   type: GoAServiceLevel;
   [key: string]: unknown;
 };
+
 export default function MicrositeHeaderPage() {
   const [micrositeHeaderProps, setMicrositeHeaderProps] = useState<ComponentPropsType>({
     type: "alpha" as GoAServiceLevel,
@@ -176,34 +184,63 @@ export default function MicrositeHeaderPage() {
     <>
       <ComponentHeader
         name={componentName}
-        category={componentCategory}
+        category={category}
         description={description}
         relatedComponents={relatedComponents}
+        githubLink={componentName}
+        figmaLink={FIGMA_LINK}
       />
 
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
         <GoATabs>
-          <GoATab heading="Code examples">
+          <GoATab heading="Code playground">
+            {/* Microsite Header Sandbox */}
             <h2 id="component" style={{ display: "none" }}>
-              Component
+              Playground
             </h2>
             <Sandbox properties={micrositeHeaderBindings} onChange={onSandboxChange} fullWidth>
               <GoAMicrositeHeader {...micrositeHeaderProps} />
             </Sandbox>
 
-            {/*Component properties table*/}
+            {/* Component properties table */}
             <ComponentProperties properties={componentProperties} />
-            <MicrositeHeaderExamples />
+          </GoATab>
+            <GoATab
+              heading={
+                <>
+                  Examples
+                  <GoABadge type="information" content="2" />
+                </>
+              }
+            >
+              <MicrositeHeaderExamples />
+
           </GoATab>
 
-          <GoATab
-            heading={
-              <>
-                Design guidelines
-                <GoABadge type="information" content="In progress" />
-              </>
-            }>
-            <p>Coming Soon</p>
+          <GoATab heading="Design">
+            <GoACallout heading="Design documentation in Figma" type="important" size="medium" maxWidth="540px">
+              Detailed design documentation for this component can be found on the associated{" "}
+              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
+                component page
+              </a>{" "}
+              in the Component library in Figma.
+            </GoACallout>
+          </GoATab>
+
+          <GoATab heading="Accessibility">
+
+          <GoACallout
+              heading="Accessibility documentation in Figma"
+              type="important"
+              size="medium"
+              maxWidth="550px"
+            >
+              Detailed accessibility documentation for this component can be found on the associated{" "}
+              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
+                component page
+              </a>{" "}
+              in the Component library in Figma.
+            </GoACallout>
           </GoATab>
         </GoATabs>
       </ComponentContent>

--- a/src/routes/components/Modal.tsx
+++ b/src/routes/components/Modal.tsx
@@ -7,6 +7,7 @@ import {
   GoAModalProps,
   GoATab,
   GoATabs,
+  GoACallout,
 } from "@abgov/react-components";
 import { ComponentBinding, LanguageContext, Sandbox } from "@components/sandbox";
 import { useContext, useEffect, useState } from "react";
@@ -20,25 +21,26 @@ import { CodeSnippet } from "@components/code-snippet/CodeSnippet.tsx";
 import ModalExamples from "@examples/modal/ModalExamples.tsx";
 
 // == Page props ==
-
+const FIGMA_LINK =
+  "https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=622-13874";
 const componentName = "Modal";
+const category = Category.FEEDBACK_AND_ALERTS;
 const description =
   "An overlay that appears in front of all other content, and requires a user to take an action before continuing.";
-const category = Category.FEEDBACK_AND_ALERTS;
 const relatedComponents = [
   { link: "/components/button-group", name: "Button group" },
   { link: "/components/callout", name: "Callout" },
 ];
+
 type ComponentPropsType = Omit<GoAModalProps, "open"> & { closable?: boolean };
 type CastingType = {
-  // add any required props here
   [key: string]: unknown;
 };
 
 export default function ModalPage() {
   const language = useContext(LanguageContext);
   const [componentProps, setComponentProps] = useState<ComponentPropsType>({
-    heading: "Are you sure you want to exit your application?",
+    heading: "Are you sure you want to [exit your application]?",
     role: "alertdialog",
   });
 
@@ -221,13 +223,16 @@ export default function ModalPage() {
         category={category}
         description={description}
         relatedComponents={relatedComponents}
+        githubLink={componentName}
+        figmaLink={FIGMA_LINK}
       />
 
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
         <GoATabs>
-          <GoATab heading="Code examples">
+          <GoATab heading="Code playground">
+            {/* Modal Sandbox */}
             <h2 id="component" style={{ display: "none" }}>
-              Component
+              Playground
             </h2>
             <Sandbox properties={componentBindings} onChange={onSandboxChange}>
               <CodeSnippet
@@ -259,18 +264,19 @@ export default function ModalPage() {
               <GoAButton onClick={() => setOpen(true)}>Show Modal</GoAButton>
 
               {!isClosableChecked(componentBindings) && (
-                <GoAModal {...componentProps} open={open}>
+                <GoAModal {...componentProps} open={open} actions={
+                  <GoAButtonGroup alignment="end">
+                    <GoAButton type="secondary" onClick={() => setOpen(false)}>
+                      Secondary
+                    </GoAButton>
+                    <GoAButton type="primary" onClick={() => setOpen(false)}>
+                      Primary
+                    </GoAButton>
+                  </GoAButtonGroup>
+                }>
                   Lorem ipsum dolor sit amet consectetur adipisicing elit. Mollitia obcaecati id
                   molestiae, natus dicta, eaque qui iusto similique, libero explicabo eligendi eius
                   laboriosam! Repellendus ducimus officia asperiores. Eos, eius numquam.
-                  <GoAButtonGroup alignment="end" mt="xl">
-                    <GoAButton type="tertiary" onClick={() => setOpen(false)}>
-                      Cancel
-                    </GoAButton>
-                    <GoAButton type="primary" onClick={() => setOpen(false)}>
-                      Exit
-                    </GoAButton>
-                  </GoAButtonGroup>
                 </GoAModal>
               )}
 
@@ -283,17 +289,55 @@ export default function ModalPage() {
               )}
             </Sandbox>
 
+            {/* Modal component properties table */}
             <ComponentProperties properties={componentProperties} />
-            <ModalExamples/>
           </GoATab>
 
-          <GoATab
-            heading={
-              <>
-                Design guidelines
-                <GoABadge type="information" content="In progress" />
-              </>
-            }></GoATab>
+            <GoATab
+              heading={
+                <>
+                  Examples
+                  <GoABadge type="information" content="6" />
+                </>
+              }
+            >
+            {/* Examples */}
+
+            <ModalExamples/>
+
+            </GoATab>
+
+
+          <GoATab heading="Design">
+            <GoACallout
+              heading="Design documentation in Figma"
+              type="important"
+              size="medium"
+              maxWidth="540px"
+            >
+              Detailed design documentation for this component can be found on the associated{" "}
+              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
+                component page
+              </a>{" "}
+              in the Component library in Figma.
+            </GoACallout>
+          </GoATab>
+
+          <GoATab heading="Accessibility">
+
+          <GoACallout
+              heading="Accessibility documentation in Figma"
+              type="important"
+              size="medium"
+              maxWidth="550px"
+            >
+              Detailed accessibility documentation for this component can be found on the associated{" "}
+              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
+                component page
+              </a>{" "}
+              in the Component library in Figma.
+            </GoACallout>
+          </GoATab>
         </GoATabs>
       </ComponentContent>
     </>

--- a/src/routes/components/Modal.tsx
+++ b/src/routes/components/Modal.tsx
@@ -7,7 +7,6 @@ import {
   GoAModalProps,
   GoATab,
   GoATabs,
-  GoACallout,
 } from "@abgov/react-components";
 import { ComponentBinding, LanguageContext, Sandbox } from "@components/sandbox";
 import { useContext, useEffect, useState } from "react";
@@ -19,6 +18,8 @@ import { resetScrollbars } from "../../utils/styling";
 import { ComponentContent } from "@components/component-content/ComponentContent";
 import { CodeSnippet } from "@components/code-snippet/CodeSnippet.tsx";
 import ModalExamples from "@examples/modal/ModalExamples.tsx";
+import { DesignEmpty } from "@components/design-empty/DesignEmpty.tsx";
+import { AccessibilityEmpty } from "@components/accessibility-empty/AccessibilityEmpty.tsx";
 
 // == Page props ==
 const FIGMA_LINK =
@@ -309,34 +310,11 @@ export default function ModalPage() {
 
 
           <GoATab heading="Design">
-            <GoACallout
-              heading="Design documentation in Figma"
-              type="important"
-              size="medium"
-              maxWidth="540px"
-            >
-              Detailed design documentation for this component can be found on the associated{" "}
-              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
-                component page
-              </a>{" "}
-              in the Component library in Figma.
-            </GoACallout>
+            <DesignEmpty figmaLink={FIGMA_LINK} />
           </GoATab>
 
           <GoATab heading="Accessibility">
-
-          <GoACallout
-              heading="Accessibility documentation in Figma"
-              type="important"
-              size="medium"
-              maxWidth="550px"
-            >
-              Detailed accessibility documentation for this component can be found on the associated{" "}
-              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
-                component page
-              </a>{" "}
-              in the Component library in Figma.
-            </GoACallout>
+            <AccessibilityEmpty figmaLink={FIGMA_LINK} />
           </GoATab>
         </GoATabs>
       </ComponentContent>

--- a/src/routes/components/Notificationbanner.tsx
+++ b/src/routes/components/Notificationbanner.tsx
@@ -5,6 +5,7 @@ import {
   GoATab,
   GoATabs,
   NotificationType,
+  GoACallout,
 } from "@abgov/react-components";
 import { ComponentBinding, Sandbox } from "@components/sandbox";
 import { useState } from "react";
@@ -15,13 +16,15 @@ import {
 import { ComponentContent } from "@components/component-content/ComponentContent";
 
 // == Page props ==
-
-const componentName = "Notification Banner";
-const description = "Display important page level information or notifications.";
+const FIGMA_LINK =
+  "https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=622-12949";
+const componentName = "Notification banner";
 const category = Category.FEEDBACK_AND_ALERTS;
+const description = "Display important page level information or notifications.";
 const relatedComponents = [
   { link: "/components/callout", name: "Callout" },
 ];
+
 type ComponentPropsType = {
   type: NotificationType;
   content?: string;
@@ -109,14 +112,23 @@ export default function NotificationBannerPage() {
 
   return (
     <>
-      <ComponentHeader name={componentName} category={category} description={description} relatedComponents={relatedComponents} />
+      <ComponentHeader
+        name={componentName}
+        category={category}
+        description={description}
+        relatedComponents={relatedComponents}
+        githubLink={componentName}
+        figmaLink={FIGMA_LINK}
+      />
 
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
 
         <GoATabs>
-          <GoATab heading="Code examples">
-            <h2 id="component" style={{display: "none"}}>Component</h2>
-            <Sandbox properties={componentBindings} onChange={onSandboxChange} fullWidth={true}>
+          <GoATab heading="Code playground">
+            <h2 id="component" style={{ display: "none" }}>
+              Playground
+            </h2>
+            <Sandbox properties={componentBindings} onChange={onSandboxChange} fullWidth>
               <GoANotification {...componentProps}>Notification banner message</GoANotification>
             </Sandbox>
             <ComponentProperties properties={componentProperties} />
@@ -125,11 +137,52 @@ export default function NotificationBannerPage() {
           <GoATab
             heading={
               <>
-                Design guidelines
-                <GoABadge type="information" content="In progress" />
+                Examples
+                <GoABadge type="information" content="0" />
               </>
             }
-          ></GoATab>
+          >
+            <GoACallout heading="We are currently collecting design examples for this component" type="important" size="medium" maxWidth="540px">
+              {" "}
+              <a href="https://design.alberta.ca/get-started/support#:~:text=Raise%20an%20issue-,Talk%20to%20us,-Slack" target="_blank" rel="noreferrer">
+                Talk to the design system team
+              </a>{" "}
+              to contribute examples from your service.
+            </GoACallout>
+
+          </GoATab>
+
+          <GoATab heading="Design">
+
+          <GoACallout
+              heading="Design documentation in Figma"
+              type="important"
+              size="medium"
+              maxWidth="540px"
+            >
+              Detailed design documentation for this component can be found on the associated{" "}
+              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
+                component page
+              </a>{" "}
+              in the Component library in Figma.
+            </GoACallout>
+          </GoATab>
+
+          <GoATab heading="Accessibility">
+
+          <GoACallout
+              heading="Accessibility documentation in Figma"
+              type="important"
+              size="medium"
+              maxWidth="550px"
+            >
+              Detailed accessibility documentation for this component can be found on the associated{" "}
+              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
+                component page
+              </a>{" "}
+              in the Component library in Figma.
+            </GoACallout>
+          </GoATab>
         </GoATabs>
       </ComponentContent>
     </>

--- a/src/routes/components/Notificationbanner.tsx
+++ b/src/routes/components/Notificationbanner.tsx
@@ -5,7 +5,6 @@ import {
   GoATab,
   GoATabs,
   NotificationType,
-  GoACallout,
 } from "@abgov/react-components";
 import { ComponentBinding, Sandbox } from "@components/sandbox";
 import { useState } from "react";
@@ -14,6 +13,9 @@ import {
   ComponentProperty,
 } from "@components/component-properties/ComponentProperties.tsx";
 import { ComponentContent } from "@components/component-content/ComponentContent";
+import { ExamplesEmpty } from "@components/examples-empty/ExamplesEmpty.tsx";
+import { DesignEmpty } from "@components/design-empty/DesignEmpty.tsx";
+import { AccessibilityEmpty } from "@components/accessibility-empty/AccessibilityEmpty.tsx";
 
 // == Page props ==
 const FIGMA_LINK =
@@ -142,47 +144,17 @@ export default function NotificationBannerPage() {
               </>
             }
           >
-            <GoACallout heading="We are currently collecting design examples for this component" type="important" size="medium" maxWidth="540px">
-              {" "}
-              <a href="https://design.alberta.ca/get-started/support#:~:text=Raise%20an%20issue-,Talk%20to%20us,-Slack" target="_blank" rel="noreferrer">
-                Talk to the design system team
-              </a>{" "}
-              to contribute examples from your service.
-            </GoACallout>
-
+            <ExamplesEmpty/>
           </GoATab>
 
           <GoATab heading="Design">
-
-          <GoACallout
-              heading="Design documentation in Figma"
-              type="important"
-              size="medium"
-              maxWidth="540px"
-            >
-              Detailed design documentation for this component can be found on the associated{" "}
-              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
-                component page
-              </a>{" "}
-              in the Component library in Figma.
-            </GoACallout>
+            <DesignEmpty figmaLink={FIGMA_LINK} />
           </GoATab>
 
           <GoATab heading="Accessibility">
-
-          <GoACallout
-              heading="Accessibility documentation in Figma"
-              type="important"
-              size="medium"
-              maxWidth="550px"
-            >
-              Detailed accessibility documentation for this component can be found on the associated{" "}
-              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
-                component page
-              </a>{" "}
-              in the Component library in Figma.
-            </GoACallout>
+            <AccessibilityEmpty figmaLink={FIGMA_LINK} />
           </GoATab>
+
         </GoATabs>
       </ComponentContent>
     </>

--- a/src/routes/components/Pagination.tsx
+++ b/src/routes/components/Pagination.tsx
@@ -9,6 +9,7 @@ import {
   GoASpacer,
   GoADropdown,
   GoADropdownItem,
+  GoACallout,
 } from "@abgov/react-components";
 import { Category, ComponentHeader } from "@components/component-header/ComponentHeader.tsx";
 import {
@@ -20,6 +21,15 @@ import { faker } from "@faker-js/faker";
 import { useEffect, useState } from "react";
 import { CodeSnippet } from "@components/code-snippet/CodeSnippet";
 import { ComponentContent } from "@components/component-content/ComponentContent";
+import "./AllComponents.css";
+
+// == Page props ==
+const FIGMA_LINK =
+  "https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=622-13964";
+const componentName = "Pagination";
+const category = Category.STRUCTURE_AND_NAVIGATION;
+const description = "Help users navigate between multiple pages or screens as part of a set.";
+const relatedComponents = [{ link: "/components/table", name: "Table" }];
 
 type ComponentPropsType = Omit<GoAPaginationProps, "pageNumber" | "onChange">;
 type CastingType = {
@@ -47,11 +57,6 @@ interface User {
   lastName: string;
   age: number;
 }
-
-const componentName = "Pagination";
-const description = "Help users navigation between multiple pages or screens as part of a set.";
-const componentCategory = Category.STRUCTURE_AND_NAVIGATION;
-const relatedComponents = [{ link: "/components/table", name: "Table" }];
 
 export default function PaginationPage() {
   const [paginationProps, setPaginationProps] = useState<ComponentPropsType>({
@@ -169,6 +174,7 @@ export default function PaginationPage() {
     (paginationBindings.find(binding => binding.name === "itemCount")?.value as number) || 30;
   let perPageUsers: number =
     (paginationBindings.find(binding => binding.name === "perPageCount")?.value as number) || 10;
+
   useEffect(() => {
     const _users = [];
     for (let i = 1; i < totalUsers + 1; i++) {
@@ -274,16 +280,19 @@ export default function PaginationPage() {
     <>
       <ComponentHeader
         name={componentName}
-        category={componentCategory}
+        category={category}
         description={description}
         relatedComponents={relatedComponents}
+        githubLink={componentName}
+        figmaLink={FIGMA_LINK}
       />
 
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
         <GoATabs>
-          <GoATab heading="Code examples">
+          <GoATab heading="Code playground">
+            {/* Pagination Sandbox */}
             <h2 id="component" style={{ display: "none" }}>
-              Component
+              Playground
             </h2>
             <Sandbox
               properties={paginationBindings}
@@ -458,11 +467,16 @@ export default function PaginationPage() {
 
             {/*Component properties table*/}
             <ComponentProperties properties={componentProperties} />
-
-            <h2 id="component-examples" className="hidden" aria-hidden="true">
-              Examples
-            </h2>
-
+          </GoATab>
+            <GoATab
+              heading={
+                <>
+                  Examples
+                  <GoABadge type="information" content="1" />
+                </>
+              }
+            >
+            {/* Example 1 */}
             <h3 id="component-example-1">Show X per page</h3>
 
             <Sandbox
@@ -756,14 +770,36 @@ export default function PaginationPage() {
             </Sandbox>
           </GoATab>
 
-          <GoATab
-            heading={
-              <>
-                Design guidelines
-                <GoABadge type="information" content="In progress" />
-              </>
-            }>
-            <p>Coming Soon</p>
+          <GoATab heading="Design">
+
+          <GoACallout
+              heading="Design documentation in Figma"
+              type="important"
+              size="medium"
+              maxWidth="540px"
+            >
+              Detailed design documentation for this component can be found on the associated{" "}
+              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
+                component page
+              </a>{" "}
+              in the Component library in Figma.
+            </GoACallout>
+          </GoATab>
+
+          <GoATab heading="Accessibility">
+
+          <GoACallout
+              heading="Accessibility documentation in Figma"
+              type="important"
+              size="medium"
+              maxWidth="550px"
+            >
+              Detailed accessibility documentation for this component can be found on the associated{" "}
+              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
+                component page
+              </a>{" "}
+              in the Component library in Figma.
+            </GoACallout>
           </GoATab>
         </GoATabs>
       </ComponentContent>

--- a/src/routes/components/Pagination.tsx
+++ b/src/routes/components/Pagination.tsx
@@ -9,7 +9,6 @@ import {
   GoASpacer,
   GoADropdown,
   GoADropdownItem,
-  GoACallout,
 } from "@abgov/react-components";
 import { Category, ComponentHeader } from "@components/component-header/ComponentHeader.tsx";
 import {
@@ -22,6 +21,8 @@ import { useEffect, useState } from "react";
 import { CodeSnippet } from "@components/code-snippet/CodeSnippet";
 import { ComponentContent } from "@components/component-content/ComponentContent";
 import "./AllComponents.css";
+import { DesignEmpty } from "@components/design-empty/DesignEmpty.tsx";
+import { AccessibilityEmpty } from "@components/accessibility-empty/AccessibilityEmpty.tsx";
 
 // == Page props ==
 const FIGMA_LINK =
@@ -771,36 +772,13 @@ export default function PaginationPage() {
           </GoATab>
 
           <GoATab heading="Design">
-
-          <GoACallout
-              heading="Design documentation in Figma"
-              type="important"
-              size="medium"
-              maxWidth="540px"
-            >
-              Detailed design documentation for this component can be found on the associated{" "}
-              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
-                component page
-              </a>{" "}
-              in the Component library in Figma.
-            </GoACallout>
+            <DesignEmpty figmaLink={FIGMA_LINK} />
           </GoATab>
 
           <GoATab heading="Accessibility">
-
-          <GoACallout
-              heading="Accessibility documentation in Figma"
-              type="important"
-              size="medium"
-              maxWidth="550px"
-            >
-              Detailed accessibility documentation for this component can be found on the associated{" "}
-              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
-                component page
-              </a>{" "}
-              in the Component library in Figma.
-            </GoACallout>
+            <AccessibilityEmpty figmaLink={FIGMA_LINK} />
           </GoATab>
+
         </GoATabs>
       </ComponentContent>
     </>

--- a/src/routes/components/Popover.tsx
+++ b/src/routes/components/Popover.tsx
@@ -5,10 +5,23 @@ import {
   ComponentProperty,
 } from "@components/component-properties/ComponentProperties.tsx";
 import { Category, ComponentHeader } from "@components/component-header/ComponentHeader.tsx";
-import { GoABadge, GoAButton, GoAPopover, GoATab, GoATabs } from "@abgov/react-components";
+import { GoABadge, GoAButton, GoAPopover, GoATab, GoATabs, GoACallout, } from "@abgov/react-components";
 import { CodeSnippet } from "@components/code-snippet/CodeSnippet.tsx";
 import { propsToString } from "@components/sandbox/BaseSerializer.ts";
 import { ComponentContent } from "@components/component-content/ComponentContent";
+import "./AllComponents.css";
+
+// == Page props ==
+const FIGMA_LINK =
+  "https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=27301-302109";
+const componentName = "Popover";
+const category = Category.CONTENT_AND_LAYOUT;
+const description = "A small overlay that opens on demand, used in other components.";
+const relatedComponents = [
+  { link: "/components/dropdown", name: "Dropdown" },
+  { link: "/components/header", name: "Header" },
+  { link: "/components/tooltip", name: "Tooltip" },
+];
 
 export default function PopoverPage() {
   const [popoverProps, setPopoverProps] = useState({});
@@ -126,23 +139,20 @@ export default function PopoverPage() {
   return (
     <>
       <ComponentHeader
-        name="Popover"
-        category={Category.CONTENT_AND_LAYOUT}
-        description="A small overlay that opens on demand, used in other components."
-        relatedComponents={[
-          { link: "/components/dropdown", name: "Dropdown" },
-          { link: "/components/header", name: "Header" },
-          { link: "/components/tooltip", name: "Tooltip" },
-
-        ]}
+        name={componentName}
+        category={category}
+        description={description}
+        relatedComponents={relatedComponents}
+        githubLink={componentName}
+        figmaLink={FIGMA_LINK}
       />
 
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
 
         <GoATabs>
-          <GoATab heading="Code examples">
+          <GoATab heading="Code Playground">
             {/*Popover sandbox*/}
-            <h2 id="component" style={{display: "none"}}>Component</h2>
+            <h2 id="component" style={{display: "none"}}>Playground</h2>
             <Sandbox properties={popoverBindings} skipRender onChange={onSandboxChange}>
 
               {/*Angular*/}
@@ -161,7 +171,7 @@ export default function PopoverPage() {
               `}
               />
 
-              {/*React*/}
+              {/* React */}
               <CodeSnippet
                 lang="typescript"
                 tags="react"
@@ -199,18 +209,58 @@ export default function PopoverPage() {
               </GoAPopover>
             </Sandbox>
 
-            {/*Popover table properties*/}
+            {/* Popover component properties table */}
             <ComponentProperties properties={componentProperties} />
           </GoATab>
 
-          <GoATab
-            heading={
-              <>
-                Design guidelines
-                <GoABadge type="information" content="In progress" />
-              </>
-            }
-          ></GoATab>
+            <GoATab
+              heading={
+                <>
+                  Examples
+                  <GoABadge type="information" content="0" />
+                </>
+              }
+            >
+              <GoACallout heading="We are currently collecting design examples for this component" type="important" size="medium" maxWidth="540px">
+                {" "}
+                <a href="https://design.alberta.ca/get-started/support#:~:text=Raise%20an%20issue-,Talk%20to%20us,-Slack" target="_blank" rel="noreferrer">
+                  Talk to the design system team
+                </a>{" "}
+                to contribute examples from your service.
+              </GoACallout>
+            </GoATab>
+
+          <GoATab heading="Design">
+
+          <GoACallout
+              heading="Design documentation in Figma"
+              type="important"
+              size="medium"
+              maxWidth="540px"
+            >
+              Detailed design documentation for this component can be found on the associated{" "}
+              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
+                component page
+              </a>{" "}
+              in the Component library in Figma.
+            </GoACallout>
+          </GoATab>
+
+          <GoATab heading="Accessibility">
+
+          <GoACallout
+              heading="Accessibility documentation in Figma"
+              type="important"
+              size="medium"
+              maxWidth="550px"
+            >
+              Detailed accessibility documentation for this component can be found on the associated{" "}
+              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
+                component page
+              </a>{" "}
+              in the Component library in Figma.
+            </GoACallout>
+          </GoATab>
         </GoATabs>
       </ComponentContent>
     </>

--- a/src/routes/components/Popover.tsx
+++ b/src/routes/components/Popover.tsx
@@ -5,11 +5,14 @@ import {
   ComponentProperty,
 } from "@components/component-properties/ComponentProperties.tsx";
 import { Category, ComponentHeader } from "@components/component-header/ComponentHeader.tsx";
-import { GoABadge, GoAButton, GoAPopover, GoATab, GoATabs, GoACallout, } from "@abgov/react-components";
+import { GoABadge, GoAButton, GoAPopover, GoATab, GoATabs, } from "@abgov/react-components";
 import { CodeSnippet } from "@components/code-snippet/CodeSnippet.tsx";
 import { propsToString } from "@components/sandbox/BaseSerializer.ts";
 import { ComponentContent } from "@components/component-content/ComponentContent";
 import "./AllComponents.css";
+import { ExamplesEmpty } from "@components/examples-empty/ExamplesEmpty.tsx";
+import { DesignEmpty } from "@components/design-empty/DesignEmpty.tsx";
+import { AccessibilityEmpty } from "@components/accessibility-empty/AccessibilityEmpty.tsx";
 
 // == Page props ==
 const FIGMA_LINK =
@@ -221,46 +224,17 @@ export default function PopoverPage() {
                 </>
               }
             >
-              <GoACallout heading="We are currently collecting design examples for this component" type="important" size="medium" maxWidth="540px">
-                {" "}
-                <a href="https://design.alberta.ca/get-started/support#:~:text=Raise%20an%20issue-,Talk%20to%20us,-Slack" target="_blank" rel="noreferrer">
-                  Talk to the design system team
-                </a>{" "}
-                to contribute examples from your service.
-              </GoACallout>
+              <ExamplesEmpty/>
             </GoATab>
 
           <GoATab heading="Design">
-
-          <GoACallout
-              heading="Design documentation in Figma"
-              type="important"
-              size="medium"
-              maxWidth="540px"
-            >
-              Detailed design documentation for this component can be found on the associated{" "}
-              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
-                component page
-              </a>{" "}
-              in the Component library in Figma.
-            </GoACallout>
+            <DesignEmpty figmaLink={FIGMA_LINK} />
           </GoATab>
 
           <GoATab heading="Accessibility">
-
-          <GoACallout
-              heading="Accessibility documentation in Figma"
-              type="important"
-              size="medium"
-              maxWidth="550px"
-            >
-              Detailed accessibility documentation for this component can be found on the associated{" "}
-              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
-                component page
-              </a>{" "}
-              in the Component library in Figma.
-            </GoACallout>
+            <AccessibilityEmpty figmaLink={FIGMA_LINK} />
           </GoATab>
+
         </GoATabs>
       </ComponentContent>
     </>

--- a/src/routes/components/ProgressIndicator.tsx
+++ b/src/routes/components/ProgressIndicator.tsx
@@ -10,21 +10,25 @@ import {
   GoABadge,
   GoATab,
   GoATabs,
+  GoACallout,
   GoACircularProgress,
   GoACircularProgressProps,
 } from "@abgov/react-components";
 import { resetScrollbars } from "../../utils/styling";
 import { ComponentContent } from "@components/component-content/ComponentContent";
+import "./AllComponents.css";
 
 // == Page props ==
-
+const FIGMA_LINK =
+  "https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=622-13604";
 const componentName = "Progress indicator";
-const description = "Provide visual feedback to users while loading.";
 const category = Category.FEEDBACK_AND_ALERTS;
+const description = "Provide visual feedback to users while loading.";
 const relatedComponents = [
   { link: "/components/file-uploader", name: "File uploader" },
-  { link: "/components/skeleton-loader", name: "Skeleton loading" }
+  { link: "/components/skeleton-loader", name: "Skeleton loading" },
 ];
+
 type ComponentPropsType = GoACircularProgressProps;
 type CastingType = {
   // add any required props here
@@ -100,7 +104,6 @@ export default function ProgressIndicatorPage() {
     },
   ];
 
-
   function onSandboxChange(bindings: ComponentBinding[], props: Record<string, unknown>) {
     const updatedProps = { ...props, visible: true } as CastingType;
 
@@ -110,7 +113,7 @@ export default function ProgressIndicatorPage() {
     if (props?.variant === "fullscreen") {
       setTimeout(() => {
         setComponentProps({ ...updatedProps, visible: false });
-        // reset body styles after closing the modal, sandbox renders multiple times that not trigger modal component no-scroll destroy effects
+        // Reset body styles after closing the modal, sandbox renders multiple times that do not trigger modal component no-scroll destroy effects
         resetScrollbars();
       }, 3000);
     }
@@ -118,26 +121,79 @@ export default function ProgressIndicatorPage() {
 
   return (
     <>
-      <ComponentHeader name={componentName} category={category} description={description} relatedComponents={relatedComponents} />
+      <ComponentHeader
+        name={componentName}
+        category={category}
+        description={description}
+        relatedComponents={relatedComponents}
+        githubLink={componentName}
+        figmaLink={FIGMA_LINK}
+      />
+
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
 
         <GoATabs>
-          <GoATab heading="Code examples">
-            <h2 id="component" style={{display: "none"}}>Component</h2>
+          <GoATab heading="Code playground">
+            {/* Progress Indicator Sandbox */}
+            <h2 id="component" style={{ display: "none" }}>
+              Playground
+            </h2>
             <Sandbox properties={componentBindings} onChange={onSandboxChange}>
               <GoACircularProgress {...componentProps} />
             </Sandbox>
+
+            {/* Progress Indicator component properties table */}
             <ComponentProperties properties={componentProperties} />
           </GoATab>
+
+          {/* Since there are 0 examples, the "Examples" tab is omitted */}
 
           <GoATab
             heading={
               <>
-                Design guidelines
-                <GoABadge type="information" content="In progress" />
+                Examples
+                <GoABadge type="information" content="0" />
               </>
             }
-          ></GoATab>
+          >
+            <GoACallout heading="We are currently working on design examples for this component" type="important" size="medium" maxWidth="540px">
+              {" "}
+              <a href="https://design.alberta.ca/get-started/support#:~:text=Raise%20an%20issue-,Talk%20to%20us,-Slack" target="_blank" rel="noreferrer">
+                Talk to the design system team
+              </a>{" "}
+              to contribute examples from your service.
+            </GoACallout>
+          </GoATab>
+
+          <GoATab heading="Design">
+            <GoACallout
+              heading="Design documentation in Figma"
+              type="important"
+              size="medium"
+              maxWidth="540px"
+            >
+              Detailed design documentation for this component can be found on the associated{" "}
+              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
+                component page
+              </a>{" "}
+              in the Component library in Figma.
+            </GoACallout>
+          </GoATab>
+
+          <GoATab heading="Accessibility">
+            <GoACallout
+              heading="Accessibility documentation in Figma"
+              type="important"
+              size="medium"
+              maxWidth="550px"
+            >
+              Detailed accessibility documentation for this component can be found on the associated{" "}
+              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
+                component page
+              </a>{" "}
+              in the Component library in Figma.
+            </GoACallout>
+          </GoATab>
         </GoATabs>
       </ComponentContent>
     </>

--- a/src/routes/components/ProgressIndicator.tsx
+++ b/src/routes/components/ProgressIndicator.tsx
@@ -10,13 +10,15 @@ import {
   GoABadge,
   GoATab,
   GoATabs,
-  GoACallout,
   GoACircularProgress,
   GoACircularProgressProps,
 } from "@abgov/react-components";
 import { resetScrollbars } from "../../utils/styling";
 import { ComponentContent } from "@components/component-content/ComponentContent";
 import "./AllComponents.css";
+import { ExamplesEmpty } from "@components/examples-empty/ExamplesEmpty.tsx";
+import { DesignEmpty } from "@components/design-empty/DesignEmpty.tsx";
+import { AccessibilityEmpty } from "@components/accessibility-empty/AccessibilityEmpty.tsx";
 
 // == Page props ==
 const FIGMA_LINK =
@@ -156,44 +158,17 @@ export default function ProgressIndicatorPage() {
               </>
             }
           >
-            <GoACallout heading="We are currently working on design examples for this component" type="important" size="medium" maxWidth="540px">
-              {" "}
-              <a href="https://design.alberta.ca/get-started/support#:~:text=Raise%20an%20issue-,Talk%20to%20us,-Slack" target="_blank" rel="noreferrer">
-                Talk to the design system team
-              </a>{" "}
-              to contribute examples from your service.
-            </GoACallout>
+            <ExamplesEmpty/>
           </GoATab>
 
           <GoATab heading="Design">
-            <GoACallout
-              heading="Design documentation in Figma"
-              type="important"
-              size="medium"
-              maxWidth="540px"
-            >
-              Detailed design documentation for this component can be found on the associated{" "}
-              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
-                component page
-              </a>{" "}
-              in the Component library in Figma.
-            </GoACallout>
+            <DesignEmpty figmaLink={FIGMA_LINK} />
           </GoATab>
 
           <GoATab heading="Accessibility">
-            <GoACallout
-              heading="Accessibility documentation in Figma"
-              type="important"
-              size="medium"
-              maxWidth="550px"
-            >
-              Detailed accessibility documentation for this component can be found on the associated{" "}
-              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
-                component page
-              </a>{" "}
-              in the Component library in Figma.
-            </GoACallout>
+            <AccessibilityEmpty figmaLink={FIGMA_LINK} />
           </GoATab>
+
         </GoATabs>
       </ComponentContent>
     </>

--- a/src/routes/components/Radio.tsx
+++ b/src/routes/components/Radio.tsx
@@ -8,10 +8,12 @@ import { Category, ComponentHeader } from "@components/component-header/Componen
 import {
   GoABadge,
   GoAFormItem,
-  GoARadioGroup, GoARadioGroupProps,
+  GoARadioGroup,
+  GoARadioGroupProps,
   GoARadioItem,
   GoATab,
-  GoATabs
+  GoATabs,
+  GoACallout,
 } from "@abgov/react-components";
 import { CodeSnippet } from "@components/code-snippet/CodeSnippet.tsx";
 import { useSandboxFormItem } from "@hooks/useSandboxFormItem.tsx";
@@ -19,21 +21,24 @@ import { ComponentContent } from "@components/component-content/ComponentContent
 import RadioExamples from "@examples/radio/RadioExamples.tsx";
 
 // == Page props ==
+const FIGMA_LINK =
+  "https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=102-26";
 const componentName = "Radio";
-const description = "Allow users to select one option from a set.";
 const category = Category.INPUTS_AND_ACTIONS;
+const description = "Allow users to select one option from a set.";
 const relatedComponents = [
   { link: "/components/checkbox", name: "Checkbox" },
   { link: "/components/dropdown", name: "Dropdown" },
-  { link: "/components/form-item", name: "Form item" }
+  { link: "/components/form-item", name: "Form item" },
 ];
+
 type ComponentPropsType = GoARadioGroupProps;
 type CastingType = {
   name: string;
   value: string;
   [key: string]: unknown;
   onChange: (name: string, value: string) => void;
-}
+};
 
 export default function RadioPage() {
   const [radioProps, setRadioProps] = useState<ComponentPropsType>({
@@ -141,6 +146,7 @@ export default function RadioPage() {
       description: "Apply margin to the top, right, bottom, and/or left of the component.",
     },
   ];
+
   const radioItemProperties: ComponentProperty[] = [
     {
       name: "value",
@@ -205,14 +211,22 @@ export default function RadioPage() {
 
   return (
     <>
-      <ComponentHeader name={componentName} description={description} category={category} relatedComponents={relatedComponents} />
+      <ComponentHeader
+        name={componentName}
+        category={category}
+        description={description}
+        relatedComponents={relatedComponents}
+        githubLink={componentName}
+        figmaLink={FIGMA_LINK}
+      />
 
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
-
         <GoATabs>
-          <GoATab heading="Code examples">
-            {/*Radio sandbox*/}
-            <h2 id="component" style={{display: "none"}}>Component</h2>
+          <GoATab heading="Code playground">
+            {/* Radio Sandbox */}
+            <h2 id="component" style={{ display: "none" }}>
+              Playground
+            </h2>
             <Sandbox
               properties={radioBindings}
               formItemProperties={formItemBindings}
@@ -266,21 +280,52 @@ export default function RadioPage() {
               </GoAFormItem>
             </Sandbox>
 
-            {/*Radio Group properties*/}
+            {/* Radio Group properties */}
             <ComponentProperties heading="Radio group properties" properties={radioGroupProperties} />
-            {/*Radio Item properties*/}
+            {/* Radio Item properties */}
             <ComponentProperties heading="Radio Item properties" properties={radioItemProperties} />
+          </GoATab>
+            <GoATab
+              heading={
+                <>
+                  Examples
+                  <GoABadge type="information" content="2" />
+                </>
+              }
+            >
             <RadioExamples />
           </GoATab>
 
-          <GoATab
-            heading={
-              <>
-                Design guidelines
-                <GoABadge type="information" content="In progress" />
-              </>
-            }
-          ></GoATab>
+          <GoATab heading="Design">
+
+          <GoACallout
+              heading="Design documentation in Figma"
+              type="important"
+              size="medium"
+              maxWidth="540px"
+            >
+              Detailed design documentation for this component can be found on the associated{" "}
+              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
+                component page
+              </a>{" "}
+              in the Component library in Figma.
+            </GoACallout>
+          </GoATab>
+
+          <GoATab heading="Accessibility">
+            <GoACallout
+              heading="Accessibility documentation in Figma"
+              type="important"
+              size="medium"
+              maxWidth="550px"
+            >
+              Detailed accessibility documentation for this component can be found on the associated{" "}
+              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
+                component page
+              </a>{" "}
+              in the Component library in Figma.
+            </GoACallout>
+          </GoATab>
         </GoATabs>
       </ComponentContent>
     </>

--- a/src/routes/components/Radio.tsx
+++ b/src/routes/components/Radio.tsx
@@ -13,12 +13,13 @@ import {
   GoARadioItem,
   GoATab,
   GoATabs,
-  GoACallout,
 } from "@abgov/react-components";
 import { CodeSnippet } from "@components/code-snippet/CodeSnippet.tsx";
 import { useSandboxFormItem } from "@hooks/useSandboxFormItem.tsx";
 import { ComponentContent } from "@components/component-content/ComponentContent";
 import RadioExamples from "@examples/radio/RadioExamples.tsx";
+import { DesignEmpty } from "@components/design-empty/DesignEmpty.tsx";
+import { AccessibilityEmpty } from "@components/accessibility-empty/AccessibilityEmpty.tsx";
 
 // == Page props ==
 const FIGMA_LINK =
@@ -297,35 +298,13 @@ export default function RadioPage() {
           </GoATab>
 
           <GoATab heading="Design">
-
-          <GoACallout
-              heading="Design documentation in Figma"
-              type="important"
-              size="medium"
-              maxWidth="540px"
-            >
-              Detailed design documentation for this component can be found on the associated{" "}
-              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
-                component page
-              </a>{" "}
-              in the Component library in Figma.
-            </GoACallout>
+            <DesignEmpty figmaLink={FIGMA_LINK} />
           </GoATab>
 
           <GoATab heading="Accessibility">
-            <GoACallout
-              heading="Accessibility documentation in Figma"
-              type="important"
-              size="medium"
-              maxWidth="550px"
-            >
-              Detailed accessibility documentation for this component can be found on the associated{" "}
-              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
-                component page
-              </a>{" "}
-              in the Component library in Figma.
-            </GoACallout>
+            <AccessibilityEmpty figmaLink={FIGMA_LINK} />
           </GoATab>
+
         </GoATabs>
       </ComponentContent>
     </>

--- a/src/routes/components/SideMenu.tsx
+++ b/src/routes/components/SideMenu.tsx
@@ -5,7 +5,6 @@ import {
   GoASideMenuHeading,
   GoATab,
   GoATabs,
-  GoACallout,
 } from "@abgov/react-components";
 import { CodeSnippet } from "@components/code-snippet/CodeSnippet";
 import { Category, ComponentHeader } from "@components/component-header/ComponentHeader.tsx";
@@ -16,6 +15,9 @@ import {
 import { Sandbox } from "@components/sandbox";
 import { ComponentContent } from "@components/component-content/ComponentContent";
 import "./AllComponents.css";
+import { ExamplesEmpty } from "@components/examples-empty/ExamplesEmpty.tsx";
+import { DesignEmpty } from "@components/design-empty/DesignEmpty.tsx";
+import { AccessibilityEmpty } from "@components/accessibility-empty/AccessibilityEmpty.tsx";
 
 // == Page props ==
 const FIGMA_LINK =
@@ -191,45 +193,17 @@ export default function SideMenuPage() {
               </>
             }
           >
-            <GoACallout heading="We are currently collecting design examples for this component" type="important" size="medium" maxWidth="540px">
-              {" "}
-              <a href="https://design.alberta.ca/get-started/support#:~:text=Raise%20an%20issue-,Talk%20to%20us,-Slack" target="_blank" rel="noreferrer">
-                Talk to the design system team
-              </a>{" "}
-              to contribute examples from your service.
-            </GoACallout>
+            <ExamplesEmpty/>
           </GoATab>
 
           <GoATab heading="Design">
-            <GoACallout
-              heading="Design documentation in Figma"
-              type="important"
-              size="medium"
-              maxWidth="540px"
-            >
-              Detailed design documentation for this component can be found on the associated{" "}
-              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
-                component page
-              </a>{" "}
-              in the Component library in Figma.
-            </GoACallout>
+            <DesignEmpty figmaLink={FIGMA_LINK} />
           </GoATab>
 
           <GoATab heading="Accessibility">
-
-          <GoACallout
-              heading="Accessibility documentation in Figma"
-              type="important"
-              size="medium"
-              maxWidth="550px"
-            >
-              Detailed accessibility documentation for this component can be found on the associated{" "}
-              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
-                component page
-              </a>{" "}
-              in the Component library in Figma.
-            </GoACallout>
+            <AccessibilityEmpty figmaLink={FIGMA_LINK} />
           </GoATab>
+
         </GoATabs>
       </ComponentContent>
     </>

--- a/src/routes/components/SideMenu.tsx
+++ b/src/routes/components/SideMenu.tsx
@@ -5,6 +5,7 @@ import {
   GoASideMenuHeading,
   GoATab,
   GoATabs,
+  GoACallout,
 } from "@abgov/react-components";
 import { CodeSnippet } from "@components/code-snippet/CodeSnippet";
 import { Category, ComponentHeader } from "@components/component-header/ComponentHeader.tsx";
@@ -14,14 +15,17 @@ import {
 } from "@components/component-properties/ComponentProperties.tsx";
 import { Sandbox } from "@components/sandbox";
 import { ComponentContent } from "@components/component-content/ComponentContent";
+import "./AllComponents.css";
 
+// == Page props ==
+const FIGMA_LINK =
+  "https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=24089-474089";
 const componentName = "Side menu";
-const description =
-  "A side navigation that helps the user navigate between pages.";
-const componentCategory = Category.STRUCTURE_AND_NAVIGATION;
+const category = Category.STRUCTURE_AND_NAVIGATION;
+const description = "A side navigation that helps the user navigate between pages.";
 const relatedComponents = [
   { link: "/components/header", name: "Header" },
-  { link: "/patterns", name: "Layout" }
+  { link: "/patterns/layout", name: "Layout" },
 ];
 
 export default function SideMenuPage() {
@@ -68,17 +72,23 @@ export default function SideMenuPage() {
     <>
       <ComponentHeader
         name={componentName}
-        category={componentCategory}
+        category={category}
         description={description}
         relatedComponents={relatedComponents}
+        githubLink={componentName}
+        figmaLink={FIGMA_LINK}
       />
 
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
 
         <GoATabs>
-          <GoATab heading="Code examples">
-            <h2 id="component" style={{display: "none"}}>Component</h2>
+          <GoATab heading="Code playground">
+            {/* Side Menu Sandbox */}
+            <h2 id="component" style={{ display: "none" }}>
+              Playground
+            </h2>
             <Sandbox fullWidth allow={["div"]} skipRender>
+              {/* Angular */}
               <CodeSnippet
                 lang="typescript"
                 tags="angular"
@@ -107,6 +117,8 @@ export default function SideMenuPage() {
                 </div>
               `}
               />
+
+              {/* React */}
               <CodeSnippet
                 allowCopy={true}
                 lang="typescript"
@@ -135,6 +147,8 @@ export default function SideMenuPage() {
                 </div>
                 `}
               />
+
+              {/* Rendered Side Menu */}
               <div style={{ maxWidth: "250px" }}>
                 <GoASideMenu>
                   <GoASideMenuHeading>Nav section 1</GoASideMenuHeading>
@@ -156,7 +170,7 @@ export default function SideMenuPage() {
               </div>
             </Sandbox>
 
-            {/*Component properties table*/}
+            {/* Component properties tables */}
             <ComponentProperties
               heading="Side menu group properties"
               properties={sideMenuGroupProperties}
@@ -167,14 +181,54 @@ export default function SideMenuPage() {
             />
           </GoATab>
 
+          {/* Since there are 0 examples, the "Examples" tab is omitted */}
+
           <GoATab
             heading={
               <>
-                Design guidelines
-                <GoABadge type="information" content="In progress" />
+                Examples
+                <GoABadge type="information" content="0" />
               </>
-            }>
-            <p>Coming Soon</p>
+            }
+          >
+            <GoACallout heading="We are currently collecting design examples for this component" type="important" size="medium" maxWidth="540px">
+              {" "}
+              <a href="https://design.alberta.ca/get-started/support#:~:text=Raise%20an%20issue-,Talk%20to%20us,-Slack" target="_blank" rel="noreferrer">
+                Talk to the design system team
+              </a>{" "}
+              to contribute examples from your service.
+            </GoACallout>
+          </GoATab>
+
+          <GoATab heading="Design">
+            <GoACallout
+              heading="Design documentation in Figma"
+              type="important"
+              size="medium"
+              maxWidth="540px"
+            >
+              Detailed design documentation for this component can be found on the associated{" "}
+              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
+                component page
+              </a>{" "}
+              in the Component library in Figma.
+            </GoACallout>
+          </GoATab>
+
+          <GoATab heading="Accessibility">
+
+          <GoACallout
+              heading="Accessibility documentation in Figma"
+              type="important"
+              size="medium"
+              maxWidth="550px"
+            >
+              Detailed accessibility documentation for this component can be found on the associated{" "}
+              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
+                component page
+              </a>{" "}
+              in the Component library in Figma.
+            </GoACallout>
           </GoATab>
         </GoATabs>
       </ComponentContent>

--- a/src/routes/components/Skeleton.tsx
+++ b/src/routes/components/Skeleton.tsx
@@ -5,16 +5,21 @@ import {
   ComponentProperty,
 } from "@components/component-properties/ComponentProperties.tsx";
 import { Category, ComponentHeader } from "@components/component-header/ComponentHeader.tsx";
-import { GoABadge, GoASkeleton, GoATab, GoATabs, GoASkeletonProps, SkeletonType } from "@abgov/react-components";
+import { GoASkeleton, GoATab, GoATabs, GoASkeletonProps, SkeletonType, GoACallout, GoAText, GoABlock,  } from "@abgov/react-components";
 import { ComponentContent } from "@components/component-content/ComponentContent";
+import "./AllComponents.css";
 
 // == Page props ==
+const FIGMA_LINK =
+  "https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=27301-303445";
 const componentName = "Skeleton loading";
-const description = "Provide visual feedback to users while loading a content heavy page or page element.";
 const category = Category.CONTENT_AND_LAYOUT;
+const description =
+  "Provide visual feedback to users while loading a content heavy page or page element.";
 const relatedComponents = [
   { link: "/components/progress-indicator", name: "Progress indicator" },
 ];
+
 type ComponentPropsType = GoASkeletonProps;
 type CastingType = {
   type: SkeletonType;
@@ -94,7 +99,6 @@ export default function SkeletonPage() {
       lang: "angular",
     },
     {
-
       name: "mt,mr,mb,ml",
       type: "none | 3xs | 2xs | xs | s | m | l | xl | 2xl | 3xl | 4xl",
       description: "Apply margin to the top, right, bottom, and/or left of the component.",
@@ -113,7 +117,7 @@ export default function SkeletonPage() {
       description: "Set component maximum width. Currently only used in card skeleton type",
       defaultValue: "320px",
       lang: "react",
-    },    
+    },
   ];
 
   function onSandboxChange(bindings: ComponentBinding[], props: Record<string, unknown>): void {
@@ -123,30 +127,134 @@ export default function SkeletonPage() {
 
   return (
     <>
-      <ComponentHeader name={componentName} category={category} description={description} relatedComponents={relatedComponents} />
+      <ComponentHeader
+        name={componentName}
+        category={category}
+        description={description}
+        relatedComponents={relatedComponents}
+        githubLink={componentName}
+        figmaLink={FIGMA_LINK}
+      />
 
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
 
         <GoATabs>
-          <GoATab heading="Code examples">
-            {/*Skeleton Sandbox*/}
-            <h2 id="component" style={{display: "none"}}>Component</h2>
+          <GoATab heading="Code playground">
+            {/* Skeleton Sandbox */}
+            <h2 id="component" style={{ display: "none" }}>
+              Playground
+            </h2>
             <Sandbox properties={skeletonBindings} onChange={onSandboxChange} fullWidth>
               <GoASkeleton {...skeletonProps} />
             </Sandbox>
 
-            {/*Skeleton Properties*/}
+            {/* Skeleton Properties */}
             <ComponentProperties properties={componentProperties} />
           </GoATab>
 
-          <GoATab
-            heading={
-              <>
-                Design guidelines
-                <GoABadge type="information" content="In progress" />
-              </>
-            }
-          ></GoATab>
+          {/* Since there are 0 examples, the "Examples" tab is omitted */}
+
+          <GoATab heading="Examples">
+
+            <GoABlock gap="xl" mb="xl" direction="column">
+              <GoAText size="heading-s" mt="none" mb="m">
+                Image
+              </GoAText>
+              <GoASkeleton type="image" size={1}></GoASkeleton>
+              <GoASkeleton type="image" size={2}></GoASkeleton>
+              <GoASkeleton type="image" size={3}></GoASkeleton>
+              <GoASkeleton type="image" size={4}></GoASkeleton>
+
+              <GoAText size="heading-s" mt="3xl" mb="m">
+                Text
+              </GoAText>
+              <GoASkeleton type="text" size={1}></GoASkeleton>
+              <GoASkeleton type="text" size={2}></GoASkeleton>
+              <GoASkeleton type="text" size={3}></GoASkeleton>
+              <GoASkeleton type="text" size={4}></GoASkeleton>
+
+              <GoAText size="heading-s" mt="3xl" mb="m">
+                Title
+              </GoAText>
+              <GoASkeleton type="title" size={1}></GoASkeleton>
+              <GoASkeleton type="title" size={2}></GoASkeleton>
+              <GoASkeleton type="title" size={3}></GoASkeleton>
+              <GoASkeleton type="title" size={4}></GoASkeleton>
+
+              <GoAText size="heading-s" mt="3xl" mb="m">
+                Text-small
+              </GoAText>
+              <GoASkeleton type="text-small" size={1}></GoASkeleton>
+              <GoASkeleton type="text-small" size={2}></GoASkeleton>
+              <GoASkeleton type="text-small" size={3}></GoASkeleton>
+              <GoASkeleton type="text-small" size={4}></GoASkeleton>
+
+              <GoAText size="heading-s" mt="3xl" mb="m">
+                Avatar
+              </GoAText>
+              <GoASkeleton type="avatar" size={1}></GoASkeleton>
+              <GoASkeleton type="avatar" size={2}></GoASkeleton>
+              <GoASkeleton type="avatar" size={3}></GoASkeleton>
+              <GoASkeleton type="avatar" size={4}></GoASkeleton>
+
+              <GoAText size="heading-s" mt="3xl" mb="m">
+                Header
+              </GoAText>
+              <GoASkeleton type="header" size={1}></GoASkeleton>
+              <GoASkeleton type="header" size={2}></GoASkeleton>
+              <GoASkeleton type="header" size={3}></GoASkeleton>
+              <GoASkeleton type="header" size={4}></GoASkeleton>
+
+              <GoAText size="heading-s" mt="3xl" mb="m">
+                Paragraph
+              </GoAText>
+              <GoASkeleton type="paragraph" size={1}></GoASkeleton>
+              <GoASkeleton type="paragraph" size={2}></GoASkeleton>
+              <GoASkeleton type="paragraph" size={3}></GoASkeleton>
+              <GoASkeleton type="paragraph" size={4}></GoASkeleton>
+
+              <GoAText size="heading-s" mt="3xl" mb="m">
+                Thumbnail
+              </GoAText>
+              <GoASkeleton type="thumbnail" size={1}></GoASkeleton>
+              <GoASkeleton type="thumbnail" size={2}></GoASkeleton>
+              <GoASkeleton type="thumbnail" size={3}></GoASkeleton>
+              <GoASkeleton type="thumbnail" size={4}></GoASkeleton>
+
+              <GoAText size="heading-s" mt="3xl" mb="m">
+                Card
+              </GoAText>
+              <GoASkeleton type="card" size={1} maxWidth="360px"></GoASkeleton>
+              <GoASkeleton type="card" size={2}></GoASkeleton>
+              <GoASkeleton type="card" size={3}></GoASkeleton>
+              <GoASkeleton type="card" size={4}></GoASkeleton>
+
+              <GoAText size="heading-s" mt="3xl" mb="m">
+                Profile
+              </GoAText>
+              <GoASkeleton type="profile" size={1}></GoASkeleton>
+              <GoASkeleton type="profile" size={2}></GoASkeleton>
+              <GoASkeleton type="profile" size={3}></GoASkeleton>
+              <GoASkeleton type="profile" size={4}></GoASkeleton>
+            </GoABlock>
+          </GoATab>
+
+          <GoATab heading="Design">
+            <GoACallout
+              heading="Design documentation in Figma"
+              type="important"
+              size="medium"
+              maxWidth="540px"
+            >
+              Detailed design documentation for this component can be found on the associated{" "}
+              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
+                component page
+              </a>{" "}
+              in the Component library in Figma.
+            </GoACallout>
+          </GoATab>
+
+
         </GoATabs>
       </ComponentContent>
     </>

--- a/src/routes/components/Skeleton.tsx
+++ b/src/routes/components/Skeleton.tsx
@@ -5,9 +5,10 @@ import {
   ComponentProperty,
 } from "@components/component-properties/ComponentProperties.tsx";
 import { Category, ComponentHeader } from "@components/component-header/ComponentHeader.tsx";
-import { GoASkeleton, GoATab, GoATabs, GoASkeletonProps, SkeletonType, GoACallout, GoAText, GoABlock,  } from "@abgov/react-components";
+import { GoASkeleton, GoATab, GoATabs, GoASkeletonProps, SkeletonType, GoAText, GoABlock,  } from "@abgov/react-components";
 import { ComponentContent } from "@components/component-content/ComponentContent";
 import "./AllComponents.css";
+import { DesignEmpty } from "@components/design-empty/DesignEmpty.tsx";
 
 // == Page props ==
 const FIGMA_LINK =
@@ -154,7 +155,7 @@ export default function SkeletonPage() {
 
           {/* Since there are 0 examples, the "Examples" tab is omitted */}
 
-          <GoATab heading="Examples">
+          <GoATab heading="All">
 
             <GoABlock gap="xl" mb="xl" direction="column">
               <GoAText size="heading-s" mt="none" mb="m">
@@ -240,18 +241,7 @@ export default function SkeletonPage() {
           </GoATab>
 
           <GoATab heading="Design">
-            <GoACallout
-              heading="Design documentation in Figma"
-              type="important"
-              size="medium"
-              maxWidth="540px"
-            >
-              Detailed design documentation for this component can be found on the associated{" "}
-              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
-                component page
-              </a>{" "}
-              in the Component library in Figma.
-            </GoACallout>
+            <DesignEmpty figmaLink={FIGMA_LINK} />
           </GoATab>
 
 

--- a/src/routes/components/Spacer.tsx
+++ b/src/routes/components/Spacer.tsx
@@ -1,5 +1,5 @@
 import { Category, ComponentHeader } from "@components/component-header/ComponentHeader.tsx";
-import { GoABlock, GoASpacer, GoATab, GoATabs } from "@abgov/react-components";
+import { GoABlock, GoASpacer, GoATab, GoATabs, GoACallout, } from "@abgov/react-components";
 import { ComponentBinding, Sandbox } from "@components/sandbox";
 import { CSSProperties, useState } from "react";
 import {
@@ -7,6 +7,19 @@ import {
   ComponentProperty,
 } from "@components/component-properties/ComponentProperties.tsx";
 import { ComponentContent } from "@components/component-content/ComponentContent";
+
+// == Page props ==
+const FIGMA_LINK =
+  "https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=27301-303446";
+const componentName = "Spacer";
+const category = Category.UTILITIES;
+const description = "Negative area between the components and the interface.";
+const relatedComponents = [
+  { link: "/components/block", name: "Block" },
+  { link: "/components/divider", name: "Divider" },
+  { link: "/components/grid", name: "Grid" },
+  { link: "/patterns", name: "Layout" },
+];
 
 export default function SpacerPage() {
   const [hSpacerProps, setHSpacerProps] = useState({});
@@ -83,22 +96,22 @@ export default function SpacerPage() {
   return (
     <>
       <ComponentHeader
-        name="Spacer"
-        category={Category.UTILITIES}
-        description="Negative area between the components and the interface."
-        relatedComponents={[
-          { link: "/components/block", name: "Block" },
-          { link: "/components/divider", name: "Divider" },
-          { link: "/components/grid", name: "Grid" },
-          { link: "/patterns", name: "Layout" },
-        ]}
+        name={componentName}
+        category={category}
+        description={description}
+        relatedComponents={relatedComponents}
+        githubLink={componentName}
+        figmaLink={FIGMA_LINK}
       />
 
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
 
         <GoATabs>
-          <GoATab heading="Code examples">
-            <h2 id="component" style={{display: "none"}}>Component</h2>
+          <GoATab heading="Code playground">
+            {/* Spacer Sandbox */}
+            <h2 id="component" style={{ display: "none" }}>
+              Playground
+            </h2>
             <Sandbox properties={hSpacerBindings} onChange={onHSandboxChange}>
               <GoABlock gap="none">
                 <div style={styles}>
@@ -131,8 +144,27 @@ export default function SpacerPage() {
               </GoABlock>
             </Sandbox>
 
+            {/* Spacer Properties */}
             <ComponentProperties properties={componentProperties} />
           </GoATab>
+
+          {/* Since there are 0 examples, the "Examples" tab is omitted */}
+
+          <GoATab heading="Design">
+            <GoACallout
+              heading="Design documentation in Figma"
+              type="important"
+              size="medium"
+              maxWidth="540px"
+            >
+              Detailed design documentation for this component can be found on the associated{" "}
+              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
+                component page
+              </a>{" "}
+              in the Component library in Figma.
+            </GoACallout>
+          </GoATab>
+
         </GoATabs>
       </ComponentContent>
     </>

--- a/src/routes/components/Spacer.tsx
+++ b/src/routes/components/Spacer.tsx
@@ -1,5 +1,5 @@
 import { Category, ComponentHeader } from "@components/component-header/ComponentHeader.tsx";
-import { GoABlock, GoASpacer, GoATab, GoATabs, GoACallout, } from "@abgov/react-components";
+import { GoABlock, GoASpacer, GoATab, GoATabs, } from "@abgov/react-components";
 import { ComponentBinding, Sandbox } from "@components/sandbox";
 import { CSSProperties, useState } from "react";
 import {
@@ -7,6 +7,7 @@ import {
   ComponentProperty,
 } from "@components/component-properties/ComponentProperties.tsx";
 import { ComponentContent } from "@components/component-content/ComponentContent";
+import { DesignEmpty } from "@components/design-empty/DesignEmpty.tsx";
 
 // == Page props ==
 const FIGMA_LINK =
@@ -151,18 +152,7 @@ export default function SpacerPage() {
           {/* Since there are 0 examples, the "Examples" tab is omitted */}
 
           <GoATab heading="Design">
-            <GoACallout
-              heading="Design documentation in Figma"
-              type="important"
-              size="medium"
-              maxWidth="540px"
-            >
-              Detailed design documentation for this component can be found on the associated{" "}
-              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
-                component page
-              </a>{" "}
-              in the Component library in Figma.
-            </GoACallout>
+            <DesignEmpty figmaLink={FIGMA_LINK} />
           </GoATab>
 
         </GoATabs>

--- a/src/routes/components/Table.tsx
+++ b/src/routes/components/Table.tsx
@@ -13,10 +13,12 @@ import {
   GoATable,
   GoATableSortHeader,
   GoATabs,
+  GoACallout,
 } from "@abgov/react-components";
 import { CodeSnippet } from "@components/code-snippet/CodeSnippet.tsx";
 import { GoATableProps } from "@abgov/react-components";
 import { ComponentContent } from "@components/component-content/ComponentContent";
+import "./AllComponents.css";
 
 interface User {
   firstName: string;
@@ -28,6 +30,20 @@ type CastingType = {
   width: string;
   [key: string]: unknown;
 }
+
+// == Page props ==
+const componentName = "Table";
+const description =
+  "A set of structured data that is easy for a user to scan, examine, and compare.";
+const category = Category.FEEDBACK_AND_ALERTS;
+const relatedComponents = [
+  { link: "/components/button", name: "Button" },
+  { link: "/components/pagination", name: "Pagination" },
+  { link: "/components/tabs", name: "Tabs" },
+];
+const FIGMA_LINK = "https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=3785-18038";
+
+
 export default function TablePage() {
   const [tableProps, setTableProps] = useState<ComponentPropsType>({
     width: "100%"
@@ -85,7 +101,7 @@ export default function TablePage() {
     setTableProps(props as CastingType);
   }
 
-  // For table demo -- needs to do sort functionality
+  // For table demo -- needs to handle sort functionality
   const language = useContext(LanguageContext);
   const [users, setUsers] = useState<User[]>([]);
   useEffect(() => {
@@ -125,21 +141,22 @@ export default function TablePage() {
   return (
     <>
       <ComponentHeader
-        name="Table"
-        category={Category.CONTENT_AND_LAYOUT}
-        description="A set of structured data that is easy for a user to scan, examine, and compare."
-        relatedComponents={[
-          { link: "/components/button", name: "Button" },
-          { link: "/components/dropdown", name: "Dropdown" },
-          { link: "/components/pagination", name: "Pagination" },
-          { link: "/components/tabs", name: "Tabs" },
-        ]}
+        name={componentName}
+        category={category}
+        description={description}
+        relatedComponents={relatedComponents}
+        githubLink={componentName}
+        figmaLink={FIGMA_LINK}
       />
 
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
 
         <GoATabs>
-          <GoATab heading="Code examples">
+          <GoATab heading="Code playground">
+            {/* Table Sandbox */}
+            <h2 id="component" style={{ display: "none" }}>
+              Playground
+            </h2>
             <Sandbox properties={tableBindings} onChange={onSandboxChange} fullWidth>
               <GoATable {...tableProps}>
                 <thead>
@@ -195,9 +212,20 @@ export default function TablePage() {
               </GoATable>
             </Sandbox>
 
+            {/* Table Properties */}
             <ComponentProperties properties={componentProperties} />
-            <h2 id="component-examples" className="hidden" aria-hidden="true">Examples</h2>
+          </GoATab>
 
+          <GoATab
+            heading={
+              <>
+                Examples<GoABadge type="information" content="2" />
+              </>
+            }
+          >
+
+
+            {/* Example 1 */}
             <h3 id="component-example-sortable-columns">Sortable columns</h3>
             <GoAContainer mt="m" mb="none">
               <div style={{ padding: "40px" }}>
@@ -383,6 +411,7 @@ export default function TablePage() {
               />
             )}
 
+            {/* Example 2 */}
             <h3 id="component-example-number-column">Number column</h3>
             <Sandbox fullWidth>
               <GoATable width="100%">
@@ -409,13 +438,36 @@ export default function TablePage() {
             </Sandbox>
           </GoATab>
 
-          <GoATab
-            heading={
-              <>
-                Design guidelines
-                <GoABadge type="information" content="In progress" />
-              </>
-            }></GoATab>
+          <GoATab heading="Design">
+            <GoACallout
+              heading="Design documentation in Figma"
+              type="important"
+              size="medium"
+              maxWidth="540px"
+            >
+              Detailed design documentation for this component can be found on the associated{" "}
+              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
+                component page
+              </a>{" "}
+              in the Component library in Figma.
+            </GoACallout>
+          </GoATab>
+
+          <GoATab heading="Accessibility">
+
+          <GoACallout
+              heading="Accessibility documentation in Figma"
+              type="important"
+              size="medium"
+              maxWidth="550px"
+            >
+              Detailed accessibility documentation for this component can be found on the associated{" "}
+              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
+                component page
+              </a>{" "}
+              in the Component library in Figma.
+            </GoACallout>
+          </GoATab>
         </GoATabs>
       </ComponentContent>
     </>

--- a/src/routes/components/Table.tsx
+++ b/src/routes/components/Table.tsx
@@ -13,12 +13,13 @@ import {
   GoATable,
   GoATableSortHeader,
   GoATabs,
-  GoACallout,
 } from "@abgov/react-components";
 import { CodeSnippet } from "@components/code-snippet/CodeSnippet.tsx";
 import { GoATableProps } from "@abgov/react-components";
 import { ComponentContent } from "@components/component-content/ComponentContent";
 import "./AllComponents.css";
+import { DesignEmpty } from "@components/design-empty/DesignEmpty.tsx";
+import { AccessibilityEmpty } from "@components/accessibility-empty/AccessibilityEmpty.tsx";
 
 interface User {
   firstName: string;
@@ -439,35 +440,13 @@ export default function TablePage() {
           </GoATab>
 
           <GoATab heading="Design">
-            <GoACallout
-              heading="Design documentation in Figma"
-              type="important"
-              size="medium"
-              maxWidth="540px"
-            >
-              Detailed design documentation for this component can be found on the associated{" "}
-              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
-                component page
-              </a>{" "}
-              in the Component library in Figma.
-            </GoACallout>
+            <DesignEmpty figmaLink={FIGMA_LINK} />
           </GoATab>
 
           <GoATab heading="Accessibility">
-
-          <GoACallout
-              heading="Accessibility documentation in Figma"
-              type="important"
-              size="medium"
-              maxWidth="550px"
-            >
-              Detailed accessibility documentation for this component can be found on the associated{" "}
-              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
-                component page
-              </a>{" "}
-              in the Component library in Figma.
-            </GoACallout>
+            <AccessibilityEmpty figmaLink={FIGMA_LINK} />
           </GoATab>
+
         </GoATabs>
       </ComponentContent>
     </>

--- a/src/routes/components/Tabs.tsx
+++ b/src/routes/components/Tabs.tsx
@@ -1,4 +1,4 @@
-import { GoABadge, GoATab, GoATabs, GoACallout } from "@abgov/react-components";
+import { GoABadge, GoATab, GoATabs, } from "@abgov/react-components";
 import {
   ComponentProperties,
   ComponentProperty,
@@ -8,6 +8,9 @@ import { Category, ComponentHeader } from "@components/component-header/Componen
 import { ComponentContent } from "@components/component-content/ComponentContent";
 import { CodeSnippet } from "@components/code-snippet/CodeSnippet";
 import "./AllComponents.css";
+import { ExamplesEmpty } from "@components/examples-empty/ExamplesEmpty.tsx";
+import { DesignEmpty } from "@components/design-empty/DesignEmpty.tsx";
+import { AccessibilityEmpty } from "@components/accessibility-empty/AccessibilityEmpty.tsx";
 
 // == Page props ==
 const FIGMA_LINK =
@@ -139,46 +142,17 @@ export default function TabsPage() {
               </>
             }
           >
-            <GoACallout heading="We are currently collecting design examples for this component" type="important" size="medium" maxWidth="540px">
-              {" "}
-              <a href="https://design.alberta.ca/get-started/support#:~:text=Raise%20an%20issue-,Talk%20to%20us,-Slack" target="_blank" rel="noreferrer">
-                Talk to the design system team
-              </a>{" "}
-              to contribute examples from your service.
-            </GoACallout>
-
+            <ExamplesEmpty/>
           </GoATab>
 
           <GoATab heading="Design">
-            <GoACallout
-              heading="Design documentation in Figma"
-              type="important"
-              size="medium"
-              maxWidth="540px"
-            >
-              Detailed design documentation for this component can be found on the associated{" "}
-              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
-                component page
-              </a>{" "}
-              in the Component library in Figma.
-            </GoACallout>
+            <DesignEmpty figmaLink={FIGMA_LINK} />
           </GoATab>
 
           <GoATab heading="Accessibility">
-
-          <GoACallout
-              heading="Accessibility documentation in Figma"
-              type="important"
-              size="medium"
-              maxWidth="550px"
-            >
-              Detailed accessibility documentation for this component can be found on the associated{" "}
-              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
-                component page
-              </a>{" "}
-              in the Component library in Figma.
-            </GoACallout>
+            <AccessibilityEmpty figmaLink={FIGMA_LINK} />
           </GoATab>
+
         </GoATabs>
       </ComponentContent>
     </>

--- a/src/routes/components/Tabs.tsx
+++ b/src/routes/components/Tabs.tsx
@@ -9,7 +9,6 @@ import { Category, ComponentHeader } from "@components/component-header/Componen
 import { ComponentContent } from "@components/component-content/ComponentContent";
 import { CodeSnippet } from "@components/code-snippet/CodeSnippet";
 import "./AllComponents.css";
-import { ExamplesEmpty } from "@components/examples-empty/ExamplesEmpty.tsx";
 import { DesignEmpty } from "@components/design-empty/DesignEmpty.tsx";
 import { AccessibilityEmpty } from "@components/accessibility-empty/AccessibilityEmpty.tsx";
 
@@ -133,13 +132,24 @@ export default function TabsPage() {
             {/* GoATab Properties */}
             <ComponentProperties heading="GoATab Properties" properties={tabProperties} />
 
+
+          </GoATab>
+
+
+          <GoATab
+            heading={
+              <>
+                Examples
+                <GoABadge type="information" content="2" />
+              </>
+            }
+          >
             {/*Tabs Examples*/}
-            <h2 id="component-examples" className="hidden" aria-hidden="true">Examples</h2>
 
             <h3 id="component-example-different-views-data-table">Show different views of data in a table</h3>
             <Sandbox fullWidth skipRender>
 
-            <CodeSnippet
+              <CodeSnippet
                 lang="typescript"
                 tags="angular"
                 allowCopy={true}
@@ -348,96 +358,96 @@ export default function TabsPage() {
                 <GoATab heading="All">
                   <GoATable width="100%">
                     <thead>
-                      <tr>
-                        <th>Status</th>
-                        <th>Text</th>
-                        <th className="goa-table-number-header">Number</th>
-                        <th>Action</th>
-                      </tr>
+                    <tr>
+                      <th>Status</th>
+                      <th>Text</th>
+                      <th className="goa-table-number-header">Number</th>
+                      <th>Action</th>
+                    </tr>
                     </thead>
                     <tbody>
-                      {review.map((i) => (
-                        <tr key={i}>
-                          <td>
-                            <GoABadge type="important" content="Review pending" />
-                          </td>
-                          <td>Lorem Ipsum</td>
-                          <td className="goa-table-number-column">1234567890</td>
-                          <td>
-                            <GoAButton type="tertiary">Action</GoAButton>
-                          </td>
-                        </tr>
-                      ))}
-                      {complete.map((i) => (
-                        <tr key={i}>
-                          <td>
-                            <GoABadge type="information" content="Complete" />
-                          </td>
-                          <td>Lorem Ipsum</td>
-                          <td className="goa-table-number-column">1234567890</td>
-                          <td>
-                            <GoAButton type="tertiary">Action</GoAButton>
-                          </td>
-                        </tr>
-                      ))}
+                    {review.map((i) => (
+                      <tr key={i}>
+                        <td>
+                          <GoABadge type="important" content="Review pending" />
+                        </td>
+                        <td>Lorem Ipsum</td>
+                        <td className="goa-table-number-column">1234567890</td>
+                        <td>
+                          <GoAButton type="tertiary">Action</GoAButton>
+                        </td>
+                      </tr>
+                    ))}
+                    {complete.map((i) => (
+                      <tr key={i}>
+                        <td>
+                          <GoABadge type="information" content="Complete" />
+                        </td>
+                        <td>Lorem Ipsum</td>
+                        <td className="goa-table-number-column">1234567890</td>
+                        <td>
+                          <GoAButton type="tertiary">Action</GoAButton>
+                        </td>
+                      </tr>
+                    ))}
                     </tbody>
                   </GoATable>
                 </GoATab>
                 <GoATab heading={<>Review pending<GoABadge type="important" content="4"></GoABadge></>}>
                   <GoATable width="100%">
                     <thead>
-                      <tr>
-                        <th>Status</th>
-                        <th>Text</th>
-                        <th className="goa-table-number-header">Number</th>
-                        <th>Action</th>
-                      </tr>
+                    <tr>
+                      <th>Status</th>
+                      <th>Text</th>
+                      <th className="goa-table-number-header">Number</th>
+                      <th>Action</th>
+                    </tr>
                     </thead>
                     <tbody>
-                      {review.map((i) => (
-                        <tr key={i}>
-                          <td>
-                            <GoABadge type="important" content="Review pending" />
-                          </td>
-                          <td>Lorem Ipsum</td>
-                          <td className="goa-table-number-column">1234567890</td>
-                          <td>
-                            <GoAButton type="tertiary">Action</GoAButton>
-                          </td>
-                        </tr>
-                      ))}
+                    {review.map((i) => (
+                      <tr key={i}>
+                        <td>
+                          <GoABadge type="important" content="Review pending" />
+                        </td>
+                        <td>Lorem Ipsum</td>
+                        <td className="goa-table-number-column">1234567890</td>
+                        <td>
+                          <GoAButton type="tertiary">Action</GoAButton>
+                        </td>
+                      </tr>
+                    ))}
                     </tbody>
                   </GoATable>
                 </GoATab>
                 <GoATab heading={<>Complete<GoABadge type="information" content="338"></GoABadge></>}>
                   <GoATable width="100%">
                     <thead>
-                      <tr>
-                        <th>Status</th>
-                        <th>Text</th>
-                        <th className="goa-table-number-header">Number</th>
-                        <th>Action</th>
-                      </tr>
+                    <tr>
+                      <th>Status</th>
+                      <th>Text</th>
+                      <th className="goa-table-number-header">Number</th>
+                      <th>Action</th>
+                    </tr>
                     </thead>
                     <tbody>
-                      {complete.map((i) => (
-                        <tr key={i}>
-                          <td>
-                            <GoABadge type="information" content="Complete" />
-                          </td>
-                          <td>Lorem Ipsum</td>
-                          <td className="goa-table-number-column">1234567890</td>
-                          <td>
-                            <GoAButton type="tertiary">Action</GoAButton>
-                          </td>
-                        </tr>
-                      ))}
+                    {complete.map((i) => (
+                      <tr key={i}>
+                        <td>
+                          <GoABadge type="information" content="Complete" />
+                        </td>
+                        <td>Lorem Ipsum</td>
+                        <td className="goa-table-number-column">1234567890</td>
+                        <td>
+                          <GoAButton type="tertiary">Action</GoAButton>
+                        </td>
+                      </tr>
+                    ))}
                     </tbody>
                   </GoATable>
                 </GoATab>
               </GoATabs>
             </Sandbox>
-          
+
             <h3 id="component-example-set-specific-tab-active">Set a specific tab to be active</h3>
             <Sandbox fullWidth skipRender>
               <CodeSnippet
@@ -649,108 +659,95 @@ export default function TabsPage() {
                 <GoATab heading="All">
                   <GoATable width="100%">
                     <thead>
-                      <tr>
-                        <th>Status</th>
-                        <th>Text</th>
-                        <th className="goa-table-number-header">Number</th>
-                        <th>Action</th>
-                      </tr>
+                    <tr>
+                      <th>Status</th>
+                      <th>Text</th>
+                      <th className="goa-table-number-header">Number</th>
+                      <th>Action</th>
+                    </tr>
                     </thead>
                     <tbody>
-                      {review.map((i) => (
-                        <tr key={i}>
-                          <td>
-                            <GoABadge type="important" content="Review pending" />
-                          </td>
-                          <td>Lorem Ipsum</td>
-                          <td className="goa-table-number-column">1234567890</td>
-                          <td>
-                            <GoAButton type="tertiary">Action</GoAButton>
-                          </td>
-                        </tr>
-                      ))}
-                      {complete.map((i) => (
-                        <tr key={i}>
-                          <td>
-                            <GoABadge type="information" content="Complete" />
-                          </td>
-                          <td>Lorem Ipsum</td>
-                          <td className="goa-table-number-column">1234567890</td>
-                          <td>
-                            <GoAButton type="tertiary">Action</GoAButton>
-                          </td>
-                        </tr>
-                      ))}
+                    {review.map((i) => (
+                      <tr key={i}>
+                        <td>
+                          <GoABadge type="important" content="Review pending" />
+                        </td>
+                        <td>Lorem Ipsum</td>
+                        <td className="goa-table-number-column">1234567890</td>
+                        <td>
+                          <GoAButton type="tertiary">Action</GoAButton>
+                        </td>
+                      </tr>
+                    ))}
+                    {complete.map((i) => (
+                      <tr key={i}>
+                        <td>
+                          <GoABadge type="information" content="Complete" />
+                        </td>
+                        <td>Lorem Ipsum</td>
+                        <td className="goa-table-number-column">1234567890</td>
+                        <td>
+                          <GoAButton type="tertiary">Action</GoAButton>
+                        </td>
+                      </tr>
+                    ))}
                     </tbody>
                   </GoATable>
                 </GoATab>
                 <GoATab heading={<>Review pending<GoABadge type="important" content="4"></GoABadge></>}>
                   <GoATable width="100%">
                     <thead>
-                      <tr>
-                        <th>Status</th>
-                        <th>Text</th>
-                        <th className="goa-table-number-header">Number</th>
-                        <th>Action</th>
-                      </tr>
+                    <tr>
+                      <th>Status</th>
+                      <th>Text</th>
+                      <th className="goa-table-number-header">Number</th>
+                      <th>Action</th>
+                    </tr>
                     </thead>
                     <tbody>
-                      {review.map((i) => (
-                        <tr key={i}>
-                          <td>
-                            <GoABadge type="important" content="Review pending" />
-                          </td>
-                          <td>Lorem Ipsum</td>
-                          <td className="goa-table-number-column">1234567890</td>
-                          <td>
-                            <GoAButton type="tertiary">Action</GoAButton>
-                          </td>
-                        </tr>
-                      ))}
+                    {review.map((i) => (
+                      <tr key={i}>
+                        <td>
+                          <GoABadge type="important" content="Review pending" />
+                        </td>
+                        <td>Lorem Ipsum</td>
+                        <td className="goa-table-number-column">1234567890</td>
+                        <td>
+                          <GoAButton type="tertiary">Action</GoAButton>
+                        </td>
+                      </tr>
+                    ))}
                     </tbody>
                   </GoATable>
                 </GoATab>
                 <GoATab heading={<>Complete<GoABadge type="information" content="338"></GoABadge></>}>
                   <GoATable width="100%">
                     <thead>
-                      <tr>
-                        <th>Status</th>
-                        <th>Text</th>
-                        <th className="goa-table-number-header">Number</th>
-                        <th>Action</th>
-                      </tr>
+                    <tr>
+                      <th>Status</th>
+                      <th>Text</th>
+                      <th className="goa-table-number-header">Number</th>
+                      <th>Action</th>
+                    </tr>
                     </thead>
                     <tbody>
-                      {complete.map((i) => (
-                        <tr key={i}>
-                          <td>
-                            <GoABadge type="information" content="Complete" />
-                          </td>
-                          <td>Lorem Ipsum</td>
-                          <td className="goa-table-number-column">1234567890</td>
-                          <td>
-                            <GoAButton type="tertiary">Action</GoAButton>
-                          </td>
-                        </tr>
-                      ))}
+                    {complete.map((i) => (
+                      <tr key={i}>
+                        <td>
+                          <GoABadge type="information" content="Complete" />
+                        </td>
+                        <td>Lorem Ipsum</td>
+                        <td className="goa-table-number-column">1234567890</td>
+                        <td>
+                          <GoAButton type="tertiary">Action</GoAButton>
+                        </td>
+                      </tr>
+                    ))}
                     </tbody>
                   </GoATable>
                 </GoATab>
               </GoATabs>
             </Sandbox>
-          </GoATab>
-
-          {/* Since there are 0 examples, the "Examples" tab is omitted */}
-
-          <GoATab
-            heading={
-              <>
-                Examples
-                <GoABadge type="information" content="0" />
-              </>
-            }
-          >
-            <ExamplesEmpty/>
           </GoATab>
 
           <GoATab heading="Design">

--- a/src/routes/components/Tabs.tsx
+++ b/src/routes/components/Tabs.tsx
@@ -1,4 +1,4 @@
-import { GoABadge, GoATab, GoATabs } from "@abgov/react-components";
+import { GoABadge, GoATab, GoATabs, GoACallout } from "@abgov/react-components";
 import {
   ComponentProperties,
   ComponentProperty,
@@ -7,12 +7,22 @@ import { Sandbox } from "@components/sandbox";
 import { Category, ComponentHeader } from "@components/component-header/ComponentHeader.tsx";
 import { ComponentContent } from "@components/component-content/ComponentContent";
 import { CodeSnippet } from "@components/code-snippet/CodeSnippet";
+import "./AllComponents.css";
 
 // == Page props ==
+const FIGMA_LINK =
+  "https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=25293-519360";
 const componentName = "Tabs";
+const category = Category.STRUCTURE_AND_NAVIGATION;
 const description =
   "Let users navigate between related sections of content, displaying one section at a time.";
-const category = Category.STRUCTURE_AND_NAVIGATION;
+const relatedComponents = [
+  { link: "/components/button", name: "Button" },
+  { link: "/components/dropdown", name: "Dropdown" },
+  { link: "/components/pagination", name: "Pagination" },
+  { link: "/components/tabs", name: "Tabs" },
+];
+
 export default function TabsPage() {
   const componentProperties: ComponentProperty[] = [
     {
@@ -53,15 +63,24 @@ export default function TabsPage() {
 
   return (
     <>
-      <ComponentHeader name={componentName} category={category} description={description} />
+      <ComponentHeader
+        name={componentName}
+        category={category}
+        description={description}
+        relatedComponents={relatedComponents}
+        githubLink={componentName}
+        figmaLink={FIGMA_LINK}
+      />
 
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
         <GoATabs>
-          <GoATab heading="Code examples">
+          <GoATab heading="Code playground">
+            {/* Tabs Sandbox */}
             <h2 id="component" style={{ display: "none" }}>
-              Component
+              Playground
             </h2>
             <Sandbox fullWidth>
+              {/* Angular */}
               <CodeSnippet
                 lang="typescript"
                 tags="angular"
@@ -75,6 +94,8 @@ export default function TabsPage() {
                   } 
                 `}
               />
+
+              {/* React */}
               <CodeSnippet
                 lang="typescript"
                 tags="react"
@@ -85,6 +106,7 @@ export default function TabsPage() {
                   }
                   `}
               />
+
               <GoATabs onChange={noop}>
                 <GoATab heading="Tab Item 1">
                   Tab Item 1: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
@@ -103,16 +125,60 @@ export default function TabsPage() {
 
             {/*GoATabs Table Properties*/}
             <ComponentProperties heading="GoATabs Properties" properties={componentProperties} />
+            {/* GoATab Properties */}
             <ComponentProperties heading="GoATab Properties" properties={tabProperties} />
           </GoATab>
+
+          {/* Since there are 0 examples, the "Examples" tab is omitted */}
 
           <GoATab
             heading={
               <>
-                Design guidelines
-                <GoABadge type="information" content="In progress" />
+                Examples
+                <GoABadge type="information" content="0" />
               </>
-            }></GoATab>
+            }
+          >
+            <GoACallout heading="We are currently collecting design examples for this component" type="important" size="medium" maxWidth="540px">
+              {" "}
+              <a href="https://design.alberta.ca/get-started/support#:~:text=Raise%20an%20issue-,Talk%20to%20us,-Slack" target="_blank" rel="noreferrer">
+                Talk to the design system team
+              </a>{" "}
+              to contribute examples from your service.
+            </GoACallout>
+
+          </GoATab>
+
+          <GoATab heading="Design">
+            <GoACallout
+              heading="Design documentation in Figma"
+              type="important"
+              size="medium"
+              maxWidth="540px"
+            >
+              Detailed design documentation for this component can be found on the associated{" "}
+              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
+                component page
+              </a>{" "}
+              in the Component library in Figma.
+            </GoACallout>
+          </GoATab>
+
+          <GoATab heading="Accessibility">
+
+          <GoACallout
+              heading="Accessibility documentation in Figma"
+              type="important"
+              size="medium"
+              maxWidth="550px"
+            >
+              Detailed accessibility documentation for this component can be found on the associated{" "}
+              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
+                component page
+              </a>{" "}
+              in the Component library in Figma.
+            </GoACallout>
+          </GoATab>
         </GoATabs>
       </ComponentContent>
     </>

--- a/src/routes/components/TextArea.tsx
+++ b/src/routes/components/TextArea.tsx
@@ -16,20 +16,24 @@ import {
   GoATabs,
   GoATextArea,
   GoATextAreaProps,
+  GoACallout,
 } from "@abgov/react-components";
 import { CodeSnippet } from "@components/code-snippet/CodeSnippet.tsx";
 import { useSandboxFormItem } from "@hooks/useSandboxFormItem.tsx";
 import { ComponentContent } from "@components/component-content/ComponentContent";
+import "./AllComponents.css";
 
 // == Page props ==
-
+const FIGMA_LINK =
+  "https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=133-186";
 const componentName = "Text area";
-const description = "A multi-line field where users can input and edit text.";
 const category = Category.INPUTS_AND_ACTIONS;
+const description = "A multi-line field where users can input and edit text.";
 const relatedComponents = [
   { link: "/components/form-item", name: "Form item" },
   { link: "/components/input", name: "Input" },
 ];
+
 type ComponentPropsType = GoATextAreaProps;
 type CastingType = {
   name: string;
@@ -255,13 +259,16 @@ export default function TextAreaPage() {
         category={category}
         description={description}
         relatedComponents={relatedComponents}
+        githubLink={componentName}
+        figmaLink={FIGMA_LINK}
       />
 
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
         <GoATabs>
-          <GoATab heading="Code examples">
+          <GoATab heading="Code playground">
+            {/* Text Area Sandbox */}
             <h2 id="component" style={{ display: "none" }}>
-              Component
+              Playground
             </h2>
             <Sandbox
               properties={textAreaBindings}
@@ -269,7 +276,9 @@ export default function TextAreaPage() {
               onChange={onSandboxChange}
               onChangeFormItemBindings={onFormItemChange}
               flags={["reactive"]}
-              fullWidth>
+              fullWidth
+            >
+              {/* Angular */}
               <CodeSnippet
                 lang="typescript"
                 tags={["angular", "reactive"]}
@@ -297,6 +306,7 @@ export default function TextAreaPage() {
               `}
               />
 
+              {/* React */}
               <CodeSnippet
                 lang="typescript"
                 tags="react"
@@ -321,12 +331,18 @@ export default function TextAreaPage() {
               </GoAFormItem>
             </Sandbox>
 
+            {/* Text Area Properties */}
             <ComponentProperties properties={componentProperties} />
+          </GoATab>
 
-            {/*Examples*/}
-            <h2 id="component-examples" className="hidden" aria-hidden="true">
-              Examples
-            </h2>
+          {/* Examples Tab */}
+          <GoATab
+            heading={
+              <>
+                Examples<GoABadge type="information" content="1" />
+              </>
+            }
+          >
 
             <h3 id="component-example-1">Ask a question and give more information</h3>
             <Sandbox flags={["reactive"]} fullWidth>
@@ -363,14 +379,35 @@ export default function TextAreaPage() {
             </Sandbox>
           </GoATab>
 
-          <GoATab
-            heading={
-              <>
-                Design guidelines
-                <GoABadge type="information" content="In progress" />
-              </>
-            }>
-            <p>Coming Soon</p>
+          <GoATab heading="Design">
+
+          <GoACallout
+              heading="Design documentation in Figma"
+              type="important"
+              size="medium"
+              maxWidth="540px"
+            >
+              Detailed design documentation for this component can be found on the associated{" "}
+              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
+                component page
+              </a>{" "}
+              in the Component library in Figma.
+            </GoACallout>
+          </GoATab>
+
+          <GoATab heading="Accessibility">
+            <GoACallout
+              heading="Accessibility documentation in Figma"
+              type="important"
+              size="medium"
+              maxWidth="550px"
+            >
+              Detailed accessibility documentation for this component can be found on the associated{" "}
+              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
+                component page
+              </a>{" "}
+              in the Component library in Figma.
+            </GoACallout>
           </GoATab>
         </GoATabs>
       </ComponentContent>

--- a/src/routes/components/TextArea.tsx
+++ b/src/routes/components/TextArea.tsx
@@ -16,12 +16,13 @@ import {
   GoATabs,
   GoATextArea,
   GoATextAreaProps,
-  GoACallout,
 } from "@abgov/react-components";
 import { CodeSnippet } from "@components/code-snippet/CodeSnippet.tsx";
 import { useSandboxFormItem } from "@hooks/useSandboxFormItem.tsx";
 import { ComponentContent } from "@components/component-content/ComponentContent";
 import "./AllComponents.css";
+import { DesignEmpty } from "@components/design-empty/DesignEmpty.tsx";
+import { AccessibilityEmpty } from "@components/accessibility-empty/AccessibilityEmpty.tsx";
 
 // == Page props ==
 const FIGMA_LINK =
@@ -380,35 +381,13 @@ export default function TextAreaPage() {
           </GoATab>
 
           <GoATab heading="Design">
-
-          <GoACallout
-              heading="Design documentation in Figma"
-              type="important"
-              size="medium"
-              maxWidth="540px"
-            >
-              Detailed design documentation for this component can be found on the associated{" "}
-              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
-                component page
-              </a>{" "}
-              in the Component library in Figma.
-            </GoACallout>
+            <DesignEmpty figmaLink={FIGMA_LINK} />
           </GoATab>
 
           <GoATab heading="Accessibility">
-            <GoACallout
-              heading="Accessibility documentation in Figma"
-              type="important"
-              size="medium"
-              maxWidth="550px"
-            >
-              Detailed accessibility documentation for this component can be found on the associated{" "}
-              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
-                component page
-              </a>{" "}
-              in the Component library in Figma.
-            </GoACallout>
+            <AccessibilityEmpty figmaLink={FIGMA_LINK} />
           </GoATab>
+
         </GoATabs>
       </ComponentContent>
     </>

--- a/src/routes/components/TextField.tsx
+++ b/src/routes/components/TextField.tsx
@@ -12,7 +12,6 @@ import {
   GoAInputProps,
   GoATab,
   GoATabs,
-  GoACallout,
 } from "@abgov/react-components";
 import ICONS from "./icons.json";
 import { CodeSnippet } from "@components/code-snippet/CodeSnippet.tsx";
@@ -20,6 +19,8 @@ import { useSandboxFormItem } from "@hooks/useSandboxFormItem.tsx";
 import { ComponentContent } from "@components/component-content/ComponentContent";
 import TextFieldExamples from "@examples/text-field/TextFieldExamples";
 import "./AllComponents.css";
+import { DesignEmpty } from "@components/design-empty/DesignEmpty.tsx";
+import { AccessibilityEmpty } from "@components/accessibility-empty/AccessibilityEmpty.tsx";
 
 // == Page props ==
 const FIGMA_LINK =
@@ -511,40 +512,11 @@ export default function TextFieldPage() {
           </GoATab>
 
           <GoATab heading="Design">
-            <GoACallout
-              heading="Design documentation in Figma"
-              type="important"
-              size="medium"
-              maxWidth="540px"
-            >
-              Detailed design documentation for this component can be found on the associated{" "}
-              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
-                component page
-              </a>{" "}
-              in the Component library in Figma.
-            </GoACallout>
+            <DesignEmpty figmaLink={FIGMA_LINK} />
           </GoATab>
 
-          <GoATab
-            heading={
-              <>
-                Accessibility
-                <GoABadge type="information" content="In progress" />
-              </>
-            }
-          >
-            <GoACallout
-              heading="Accessibility documentation in Figma"
-              type="important"
-              size="medium"
-              maxWidth="550px"
-            >
-              Detailed accessibility documentation for this component can be found on the associated{" "}
-              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
-                component page
-              </a>{" "}
-              in the Component library in Figma.
-            </GoACallout>
+          <GoATab heading="Accessibility">
+            <AccessibilityEmpty figmaLink={FIGMA_LINK} />
           </GoATab>
         </GoATabs>
       </ComponentContent>

--- a/src/routes/components/TextField.tsx
+++ b/src/routes/components/TextField.tsx
@@ -11,22 +11,28 @@ import {
   GoAInput,
   GoAInputProps,
   GoATab,
-  GoATabs
+  GoATabs,
+  GoACallout,
 } from "@abgov/react-components";
 import ICONS from "./icons.json";
 import { CodeSnippet } from "@components/code-snippet/CodeSnippet.tsx";
 import { useSandboxFormItem } from "@hooks/useSandboxFormItem.tsx";
 import { ComponentContent } from "@components/component-content/ComponentContent";
 import TextFieldExamples from "@examples/text-field/TextFieldExamples";
+import "./AllComponents.css";
 
 // == Page props ==
+const FIGMA_LINK =
+  "https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=27301-303447";
 const componentName = "Input";
-const description = "A single-line field where users can input and edit text.";
 const category = Category.INPUTS_AND_ACTIONS;
+const description = "A single-line field where users can input and edit text.";
 const relatedComponents = [
   { link: "/components/form-item", name: "Form item" },
-  { link: "/components/text-area", name: "Text area" }
+  { link: "/components/radio", name: "Radio" },
+  { link: "/components/text-area", name: "Text area" },
 ];
+
 type ComponentPropsType = GoAInputProps;
 type CastingType = {
   name: string;
@@ -120,7 +126,7 @@ export default function TextFieldPage() {
       value: "",
       hidden: true,
       dynamic: true,
-    }
+    },
   ]);
   const { formItemBindings, formItemProps, onFormItemChange } = useSandboxFormItem({ label: "Basic" });
   const componentProperties: ComponentProperty[] = [
@@ -427,14 +433,17 @@ export default function TextFieldPage() {
         category={category}
         description={description}
         relatedComponents={relatedComponents}
+        githubLink={componentName}
+        figmaLink={FIGMA_LINK}
       />
 
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
-
         <GoATabs>
-          <GoATab heading="Code examples">
-            {/*Input sandbox*/}
-            <h2 id="component" style={{display: "none"}}>Component</h2>
+          <GoATab heading="Code playground">
+            {/* Input sandbox */}
+            <h2 id="component" style={{ display: "none" }}>
+              Playground
+            </h2>
             <Sandbox
               properties={componentBindings}
               formItemProperties={formItemBindings}
@@ -485,20 +494,57 @@ export default function TextFieldPage() {
               </GoAFormItem>
             </Sandbox>
 
-            {/*Input component properties table*/}
+            {/* Input component properties table */}
             <ComponentProperties properties={componentProperties} />
-            {/*Examples*/}
-            <TextFieldExamples/>
+          </GoATab>
+            <GoATab
+              heading={
+                <>
+                  Examples
+                  <GoABadge type="information" content="5" />
+                </>
+              }
+            >
+
+            {/* Examples */}
+            <TextFieldExamples />
+          </GoATab>
+
+          <GoATab heading="Design">
+            <GoACallout
+              heading="Design documentation in Figma"
+              type="important"
+              size="medium"
+              maxWidth="540px"
+            >
+              Detailed design documentation for this component can be found on the associated{" "}
+              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
+                component page
+              </a>{" "}
+              in the Component library in Figma.
+            </GoACallout>
           </GoATab>
 
           <GoATab
             heading={
               <>
-                Design guidelines
+                Accessibility
                 <GoABadge type="information" content="In progress" />
               </>
-            }>
-            <p>Coming Soon</p>
+            }
+          >
+            <GoACallout
+              heading="Accessibility documentation in Figma"
+              type="important"
+              size="medium"
+              maxWidth="550px"
+            >
+              Detailed accessibility documentation for this component can be found on the associated{" "}
+              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
+                component page
+              </a>{" "}
+              in the Component library in Figma.
+            </GoACallout>
           </GoATab>
         </GoATabs>
       </ComponentContent>

--- a/src/routes/components/Tooltip.tsx
+++ b/src/routes/components/Tooltip.tsx
@@ -7,32 +7,36 @@ import {
 } from "@components/component-properties/ComponentProperties.tsx";
 
 import {
-  GoAIcon,
   GoABadge,
+  GoAIcon,
   GoATab,
   GoATabs,
   GoATooltip,
   GoATooltipProps,
+  GoACallout,
 } from "@abgov/react-components";
 import { ComponentContent } from "@components/component-content/ComponentContent";
 
 // == Page props ==
-
+const FIGMA_LINK =
+  "https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=21932-557049";
 const componentName = "Tooltip";
 const description = "A small popover that displays more information about an item.";
+const category = Category.FEEDBACK_AND_ALERTS;
 const relatedComponents = [
   { link: "/components/details", name: "Details" },
   { link: "/components/form-item", name: "Helper text" },
   { link: "/components/icon-button", name: "Icon button" },
-  { link: "/components/popover", name: "Popover" }
+  { link: "/components/popover", name: "Popover" },
 ];
+
 type ComponentPropsType = GoATooltipProps;
 type CastingType = {
   content: string;
   [key: string]: unknown;
 };
 
-export default function TEMPLATE_Page() {
+export default function TooltipPage() {
   const [componentProps, setComponentProps] = useState<ComponentPropsType>({
     content: "Tooltip",
   });
@@ -69,7 +73,7 @@ export default function TEMPLATE_Page() {
     {
       name: "position",
       type: "top | bottom | left | right",
-      description: "Position wrt the child element",
+      description: "Position relative to the child element.",
       defaultValue: "top",
     },
     {
@@ -94,32 +98,80 @@ export default function TEMPLATE_Page() {
     <>
       <ComponentHeader
         name={componentName}
-        category={Category.FEEDBACK_AND_ALERTS}
+        category={category}
         description={description}
         relatedComponents={relatedComponents}
+        githubLink={componentName}
+        figmaLink={FIGMA_LINK}
       />
 
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
-
         <GoATabs>
-          <GoATab heading="Code examples">
-            <h2 id="component" style={{display: "none"}}>Component</h2>
+          <GoATab heading="Code playground">
+            {/* Tooltip Sandbox */}
+            <h2 id="component" style={{ display: "none" }}>
+              Playground
+            </h2>
             <Sandbox properties={componentBindings} onChange={onSandboxChange}>
               <GoATooltip {...componentProps}>
                 <GoAIcon type="information-circle" />
               </GoATooltip>
             </Sandbox>
+
+            {/* Tooltip Properties */}
             <ComponentProperties properties={componentProperties} />
           </GoATab>
+
+          {/* Since there are 0 examples, the "Examples" tab is omitted */}
 
           <GoATab
             heading={
               <>
-                Design guidelines
-                <GoABadge type="information" content="In progress" />
+                Examples
+                <GoABadge type="information" content="0" />
               </>
             }
-          ></GoATab>
+          >
+            <GoACallout heading="We are currently collecting design examples for this component" type="important" size="medium" maxWidth="540px">
+              {" "}
+              <a href="https://design.alberta.ca/get-started/support#:~:text=Raise%20an%20issue-,Talk%20to%20us,-Slack" target="_blank" rel="noreferrer">
+                Talk to the design system team
+              </a>{" "}
+              to contribute examples from your service.
+            </GoACallout>
+
+          </GoATab>
+
+          <GoATab heading="Design">
+            <GoACallout
+              heading="Design documentation in Figma"
+              type="important"
+              size="medium"
+              maxWidth="540px"
+            >
+              Detailed design documentation for this component can be found on the associated{" "}
+              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
+                component page
+              </a>{" "}
+              in the Component library in Figma.
+            </GoACallout>
+          </GoATab>
+
+          <GoATab heading="Accessibility">
+
+          <GoACallout
+              heading="Accessibility documentation in Figma"
+              type="important"
+              size="medium"
+              maxWidth="550px"
+            >
+              Detailed accessibility documentation for this component can be found on the associated{" "}
+              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
+                component page
+              </a>{" "}
+              in the Component library in Figma.
+            </GoACallout>
+          </GoATab>
         </GoATabs>
       </ComponentContent>
     </>

--- a/src/routes/components/Tooltip.tsx
+++ b/src/routes/components/Tooltip.tsx
@@ -13,9 +13,11 @@ import {
   GoATabs,
   GoATooltip,
   GoATooltipProps,
-  GoACallout,
 } from "@abgov/react-components";
 import { ComponentContent } from "@components/component-content/ComponentContent";
+import { ExamplesEmpty } from "@components/examples-empty/ExamplesEmpty.tsx";
+import { DesignEmpty } from "@components/design-empty/DesignEmpty.tsx";
+import { AccessibilityEmpty } from "@components/accessibility-empty/AccessibilityEmpty.tsx";
 
 // == Page props ==
 const FIGMA_LINK =
@@ -124,54 +126,19 @@ export default function TooltipPage() {
 
           {/* Since there are 0 examples, the "Examples" tab is omitted */}
 
-          <GoATab
-            heading={
-              <>
-                Examples
-                <GoABadge type="information" content="0" />
-              </>
-            }
+          <GoATab heading={<>Examples<GoABadge type="information" content="0" /></>}
           >
-            <GoACallout heading="We are currently collecting design examples for this component" type="important" size="medium" maxWidth="540px">
-              {" "}
-              <a href="https://design.alberta.ca/get-started/support#:~:text=Raise%20an%20issue-,Talk%20to%20us,-Slack" target="_blank" rel="noreferrer">
-                Talk to the design system team
-              </a>{" "}
-              to contribute examples from your service.
-            </GoACallout>
-
+            <ExamplesEmpty/>
           </GoATab>
 
           <GoATab heading="Design">
-            <GoACallout
-              heading="Design documentation in Figma"
-              type="important"
-              size="medium"
-              maxWidth="540px"
-            >
-              Detailed design documentation for this component can be found on the associated{" "}
-              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
-                component page
-              </a>{" "}
-              in the Component library in Figma.
-            </GoACallout>
+            <DesignEmpty figmaLink={FIGMA_LINK} />
           </GoATab>
 
           <GoATab heading="Accessibility">
-
-          <GoACallout
-              heading="Accessibility documentation in Figma"
-              type="important"
-              size="medium"
-              maxWidth="550px"
-            >
-              Detailed accessibility documentation for this component can be found on the associated{" "}
-              <a href={FIGMA_LINK} target="_blank" rel="noreferrer">
-                component page
-              </a>{" "}
-              in the Component library in Figma.
-            </GoACallout>
+            <AccessibilityEmpty figmaLink={FIGMA_LINK} />
           </GoATab>
+
         </GoATabs>
       </ComponentContent>
     </>

--- a/src/routes/components/Tooltip.tsx
+++ b/src/routes/components/Tooltip.tsx
@@ -21,7 +21,6 @@ import {
 } from "@abgov/react-components";
 import { CodeSnippet } from "@components/code-snippet/CodeSnippet.tsx";
 import { ComponentContent } from "@components/component-content/ComponentContent";
-import { ExamplesEmpty } from "@components/examples-empty/ExamplesEmpty.tsx";
 import { DesignEmpty } from "@components/design-empty/DesignEmpty.tsx";
 import { AccessibilityEmpty } from "@components/accessibility-empty/AccessibilityEmpty.tsx";
 
@@ -139,10 +138,13 @@ export default function TooltipPage() {
             {/* Tooltip Properties */}
             <ComponentProperties properties={componentProperties} />
             
-            <h2 id="component-examples" className="hidden" aria-hidden="true">
-              Examples
-            </h2>
-        
+
+          </GoATab>
+
+
+          <GoATab heading={<>Examples<GoABadge type="information" content="3" /></>}
+          >
+
             <h3 id="component-example-date-when-shortened">Use a tooltip to show a full date when shortened</h3>
             <Sandbox skipRender fullWidth>
               <CodeSnippet
@@ -189,7 +191,7 @@ export default function TooltipPage() {
                 type="non-interactive"
                 accent="thick"
                 heading={
-                <span>
+                  <span>
                   Joan Smith
                   <GoATooltip content="Nov 23, 2023 at 10:35 am">
                     <span style={{ color:"var(--goa-color-text-secondary)", font: "var(--goa-typography-body-xs)" }} >4 hours ago</span>
@@ -198,19 +200,19 @@ export default function TooltipPage() {
                 <p>Hover on the time it was added to see the full date and time.</p>
               </GoAContainer>
             </Sandbox>
-            
+
             <h3 id="component-example-label-icon-only">Show a label on an icon only button</h3>
             <Sandbox fullWidth>
               <GoAButtonGroup alignment="center">
-                  <GoATooltip content="Edit">
-                    <GoAIconButton icon="pencil" ariaLabel="Pencil icon"/>
-                  </GoATooltip>
-                  <GoATooltip content="Alerts">
-                    <GoAIconButton icon="notifications" ariaLabel="Alert icon"/>
-                  </GoATooltip>
-                  <GoATooltip content="Settings">
-                    <GoAIconButton icon="settings" ariaLabel="Settings icon"/>
-                  </GoATooltip>
+                <GoATooltip content="Edit">
+                  <GoAIconButton icon="pencil" ariaLabel="Pencil icon"/>
+                </GoATooltip>
+                <GoATooltip content="Alerts">
+                  <GoAIconButton icon="notifications" ariaLabel="Alert icon"/>
+                </GoATooltip>
+                <GoATooltip content="Settings">
+                  <GoAIconButton icon="settings" ariaLabel="Settings icon"/>
+                </GoATooltip>
               </GoAButtonGroup>
             </Sandbox>
 
@@ -310,13 +312,6 @@ export default function TooltipPage() {
                 </GoATooltip>
               </GoABlock>
             </Sandbox>
-          </GoATab>
-
-          {/* Since there are 0 examples, the "Examples" tab is omitted */}
-
-          <GoATab heading={<>Examples<GoABadge type="information" content="0" /></>}
-          >
-            <ExamplesEmpty/>
           </GoATab>
 
           <GoATab heading="Design">

--- a/src/routes/root.css
+++ b/src/routes/root.css
@@ -80,7 +80,7 @@ h4.heading {
 }
 
 code {
-  font: var(--goa-typography-number-m);
+  font: var(--goa-typography-number-s);
 }
 
 iframe {

--- a/src/routes/root.css
+++ b/src/routes/root.css
@@ -15,7 +15,7 @@
 }
 
 .content {
-  max-width: 1360px;
+  max-width: 1440px;
   width: 100%;
   margin: 0 auto;
   display: flex;
@@ -26,9 +26,8 @@
   Side Menu
 ==================*/
 .side-menu {
-  width: 192px;
+  width: 224px;
   border-right: 1px solid var(--goa-color-greyscale-200);
-  padding-bottom: var(--goa-space-l);
 }
 
 /*==================
@@ -57,41 +56,19 @@ h4.heading {
   margin-bottom: 0;
 }
 
-p.small {
+.small {
   font-size: var(--goa-typography-body-s);
+}
+.text-secondary {
   color: var(--goa-color-text-secondary);
 }
 
-span.grey-text {
-  margin-left: var(--goa-space-s);
-  font: var(--goa-typography-body-m);
-  color: var(--goa-color-greyscale-700);
+.x-small {
+  font-size: var(--goa-typography-body-xs);
 }
 
-div.hours {
-  align-items: center;
-  display: flex;
-  height: var(--goa-space-xl);
-  margin-bottom: var(--goa-space-2xs);
-}
-
-a.back {
-  display: inline-block;
-  margin-top: var(--goa-space-xl);
-}
-
-a.back::before {
-  content: "";
-  display: inline-block;
-  width: 28px;
-  height: 22px;
-  vertical-align: middle;
-  background: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 2 20 22" fill="none" stroke="%230070C4" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"></polyline></svg>') left center no-repeat;
-}
-
-a.back:visited::before,
-a.back:hover::before {
-  background: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 2 20 22" fill="none" stroke="%23004f84" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"></polyline></svg>') left center no-repeat;
+.greyscale {
+  color: var(--goa-color-greyscale-600);
 }
 
 .support-info {
@@ -104,6 +81,10 @@ a.back:hover::before {
 
 code {
   font: var(--goa-typography-number-m);
+}
+
+iframe {
+  border: none;
 }
 
 /*Tablet*/


### PR DESCRIPTION
This is to go with PR https://github.com/GovAlta/ui-components-docs/pull/300 - component status page.

### Changes
- breaks the component examples for each component onto it's own tab, and adds placeholder content for when no examples, design, and accessibility that links to a relevant place.
- component property inputs (controls) into an accordion that's open by default so a user can collapse when needed
- component properties now on the page outside of an accordion
- component property "default" on separate line for better visibility when scanning
- added links to Github issues (tagged as this component) and links to Figma page in component library (the relevant component) in component page header