### PR TITLE
chore: update links in the User Experience Guidelines page

### DIFF
--- a/src/routes/get-started/UserExperienceGuidelines.tsx
+++ b/src/routes/get-started/UserExperienceGuidelines.tsx
@@ -17,19 +17,22 @@ export default function UserExperienceGuidelinesPage() {
           <li>Repeated test cycles as products mature and user needs change over time.</li>
           <li>Testing of complete services end-to-end, not just technology in isolation.</li>
         </ul>
-        
+
         <p>
           For more details on the process of usability testing, refer to our&nbsp;
-          <a href="https://abgov.sharepoint.com/sites/S600D27-DDDUXT/SitePages/Understanding-Usability.aspx" target="_blank">
-            usability field guide.
-          </a>
+          <a href="https://abgov.sharepoint.com/sites/S600D27-DDDUXT#usability-field-guide" target="_blank">
+            usability field guide
+          </a>.
         </p>
 
         <p>
           For more details on the process of assessing compliance to each guideline, refer to our&nbsp;
-          <a href="https://abgov.sharepoint.com/sites/S600D27-DDDUXT/SitePages/UX-Review-Process.aspx" target="_blank">
-            Heuristic Worksheet & UX Review Process.
-          </a>
+          <a href="https://abgov.sharepoint.com/sites/S600D27-DDDUXT/SitePages/User-Experience-Guidelines.aspx" target="_blank">
+            User Experience Guidelines
+          </a> and&nbsp;
+          <a href="https://abgov.sharepoint.com/:x:/r/sites/S600D27-DDDUXT/Shared%20Documents/User%20Experience%20Review%20and%20Support/Template%20-%20User%20Experience%20Worksheet.xlsx?d=wca1b397b18c44f33bed42119ea2a48c0&csf=1&web=1&e=yCFDxn" target="_blank">
+            User Experience Worksheet
+          </a>.
         </p>
 
         <h3>Guidelines:</h3>

--- a/src/routes/get-started/UserExperienceGuidelines.tsx
+++ b/src/routes/get-started/UserExperienceGuidelines.tsx
@@ -2,28 +2,17 @@ export default function UserExperienceGuidelinesPage() {
   return (
     <>
       <h1>User experience guidelines</h1>
-      <h3>Digital products built for the Government of Alberta should look to comply with these guidelines to ensure a quality user experience for Albertans.</h3>
+      <h3>Digital products built for the Government of Alberta should comply with these guidelines to ensure a quality user experience for Albertans.</h3>
 
       <div className="max-width-72ch">
-
-        <p>
-          Usability testing is our preferred method to understand user needs as they relate to each guideline. Suitable usability testing includes:
-        </p>
         
         <ul>
-          <li>Users of diverse demographic and behavioural backgrounds that will experience the problem or benefit the product is looking to improve upon.</li>
-          <li>Users with varying levels of physical and or cognitive limitations, literacy, and technical capability.</li>
-          <li>A diverse range of devices that reflect our users' preferred choice when interacting with government.</li>
-          <li>Repeated test cycles as products mature and user needs change over time.</li>
-          <li>Testing of complete services end-to-end, not just technology in isolation.</li>
+          <li><strong>User-centered</strong>: Designed with a clear understanding of users, their goals, tasks, environments, and context of use, using user-centered design methods.</li>
+          <li><strong>Usable</strong>: Interfaces will be easy to use, enabling users to find the information they need and complete tasks successfully.</li>
+          <li><strong>Accessible</strong>: Digital products will be inclusive, ensuring usability for everyone, regardless of physical or cognitive ability.</li>
+          <li><strong>Trustworthy</strong>: Experiences will feel familiar and recognizable as a Government of Alberta product, ensuring users' security and privacy.</li>
+          <li><strong>Modern</strong>: Digital experiences will meet present-day user expectations and preferences for aesthetics and interaction.</li>
         </ul>
-
-        <p>
-          For more details on the process of usability testing, refer to our&nbsp;
-          <a href="https://abgov.sharepoint.com/sites/S600D27-DDDUXT#usability-field-guide" target="_blank">
-            usability field guide
-          </a>.
-        </p>
 
         <p>
           For more details on the process of assessing compliance to each guideline, refer to our&nbsp;
@@ -35,15 +24,26 @@ export default function UserExperienceGuidelinesPage() {
           </a>.
         </p>
 
-        <h3>Guidelines:</h3>
+        <h2>Usability testing</h2>
 
-        <ol>
-          <li><strong>Usable:&nbsp;</strong>Using human-centered design to understand users’ context of use, goals, tasks, and environments.</li>
-          <li><strong>Accessible:&nbsp;</strong>Digital products will be usable for the broadest range of intended users, regardless of physical or cognitive limitations, literacy level, or technical capability.</li>
-          <li><strong>Understandable:&nbsp;</strong>Digital products will be understood by the broadest range of intended users by presenting information in plain language, and reducing cognitive load when it comes to understanding the system and making decisions.</li>
-          <li><strong>Compliant:&nbsp;</strong>Digital products will align as much as possible to organizational policies such as brand, information management, cyber security, and other Government of Alberta recommended practices.</li>
-          <li><strong>Iterative:&nbsp;</strong>Products are continuously tested, resourced, and improved upon with user input and usage data to ensure lasting effectiveness, efficiency, and usability.</li>
-        </ol>
+        <p>Usability testing is our preferred method to understand user needs as they relate to each guideline.</p>
+        <p>Suitable usability testing includes:</p>
+        
+        <ul>
+          <li><strong>Diverse user group</strong>: Real users from different demographic, behavioural backgrounds, and geographical regions within Alberta that will experience the problem or benefit of the product.</li>
+          <li><strong>Inclusive testing</strong>: Users with various physical and/or cognitive abilities, literacy levels, and tech savviness.</li>
+          <li><strong>Device variety</strong>: A diverse range of devices that reflect users' preferred choice when interacting with government services.</li>
+          <li><strong>Tasks</strong>: Activities that cover tasks and service process from end-to-end.</li>
+        </ul>
+
+        <p>Frequent usability testing should be conducted to maintain product usability, effectiveness and alignment to the user needs as they evolve over time.</p>
+
+        <p>
+          For guidance on the process of usability testing, refer to our&nbsp;
+          <a href="https://abgov.sharepoint.com/sites/S600D27-DDDUXT#usability-field-guide" target="_blank">
+            usability field guide
+          </a>.
+        </p>
         
       </div>
     </>


### PR DESCRIPTION
Updated URLs linked to the SharePoint site on User Experience Guidelines page as the current ones lead to a 404.

From: 
![image](https://github.com/user-attachments/assets/7ac74fe6-c1b1-4bb0-95cc-373667d821c9)
 
To:
![image](https://github.com/user-attachments/assets/9008b7c3-4b1d-4dd0-b3a1-9d84fd47d217)
