### PR TITLE
fix(#2003): popover remove relative prop

### DIFF
--- a/src/routes/components/DatePicker.tsx
+++ b/src/routes/components/DatePicker.tsx
@@ -109,12 +109,6 @@ export default function DatePickerPage() {
       defaultValue: "false",
       description: "Disables the date picker.",
     },
-    {
-      name: "relative",
-      type: "boolean",
-      description: "Set to true if a parent element has a css position of relative.",
-      defaultValue: "false",
-    },
   ];
 
   function onSandboxChange(bindings: ComponentBinding[], props: Record<string, unknown>) {

--- a/src/routes/components/Dropdown.tsx
+++ b/src/routes/components/Dropdown.tsx
@@ -132,12 +132,6 @@ export default function DropdownPage() {
       defaultValue: "false",
     },
     {
-      name: "relative",
-      type: "boolean",
-      description: "Set to true if a parent element has a css positive of relative.",
-      defaultValue: "false",
-    },
-    {
       name: "error",
       type: "boolean",
       description: "Show an error state",

--- a/src/routes/components/Popover.tsx
+++ b/src/routes/components/Popover.tsx
@@ -94,12 +94,6 @@ export default function PopoverPage() {
       lang: "react",
     },
     {
-      name: "relative",
-      type: "boolean",
-      description: "Set to true if a parent element has a css position of relative.",
-      defaultValue: "false",
-    },
-    {
       name: "testId",
       type: "string",
       lang: "react",


### PR DESCRIPTION
Related to https://github.com/GovAlta/ui-components/pull/2358

Removes "relative" prop from Popover, Dropdown and DatePicker