### PR TITLE
chore: Updating Report Bug Github API call

### DIFF
--- a/src/routes/get-started/ReportBug.tsx
+++ b/src/routes/get-started/ReportBug.tsx
@@ -133,9 +133,7 @@ export default function ReportBugPage() {
         repo: "ui-components",
         title: "Reported Bug",
         body: body,
-        labels: [
-          "bug"
-        ],
+        type: "Bug",
         headers: {
           "X-Github-Api-Version": "2022-11-28"
         }


### PR DESCRIPTION
This needs to be tested. To test, create a bug using the Report Bug feature on the website. Then take a look at the created bug in Github issues.

1. No more bug label should exist
2. The type should be set to Bug

This may not work, I suspect it might also need an update to the token used, but I don't know.