### PR TITLE
fix(#2577): Change all references to Simple Form to Public Form

### DIFF
--- a/src/routes/patterns/PatternsLayout.tsx
+++ b/src/routes/patterns/PatternsLayout.tsx
@@ -19,7 +19,7 @@ export default function PatternsLayout() {
         <GoabSideMenu>
           <GoabSpacer vSpacing="m"></GoabSpacer>
           <Link to="">All</Link>
-          <Link to="simple-form">Simple form</Link>
+          <Link to="public-form">Public form</Link>
           <GoabSpacer vSpacing="m"></GoabSpacer>
           <GoabSideMenuHeading>Pages</GoabSideMenuHeading>
           <Link to={getUrl('layout')}>Basic page layout</Link>

--- a/src/routes/patterns/PatternsOverview.tsx
+++ b/src/routes/patterns/PatternsOverview.tsx
@@ -13,7 +13,7 @@ export default function PatternsOverviewPage() {
         <h3>Patterns</h3>
         <ul>
           <li>
-            <Link to="/patterns/simple-form">Public form</Link>
+            <Link to="/patterns/public-form">Public form</Link>
           </li>
         </ul>
       </div>

--- a/src/routes/patterns/PublicFormPage.tsx
+++ b/src/routes/patterns/PublicFormPage.tsx
@@ -3,7 +3,7 @@ import { GoabDetails } from "@abgov/react-components";
 import css from "./patterns.module.css";
 import { Link } from "react-router-dom";
 
-export default function SimpleFormPage() {
+export default function PublicFormPage() {
   return (
     <ComponentContent contentClassName="simple-form-page" tocCssQuery={":is(h2[id], h3[id])"}>
       <h1>Public form</h1>
@@ -11,7 +11,7 @@ export default function SimpleFormPage() {
         Design forms that help Albertan citizens understand the task, focus on the question and its
         answer, and complete the form.
       </h3>
-      <GoabDetails mt="xl" heading={"Who are the primary users for the simple form pattern?"}>
+      <GoabDetails mt="xl" heading={"Who are the primary users for the public form pattern?"}>
         <p>
           <strong>Primary users:</strong> citizens, public, external
           <br />

--- a/src/versioned-router.tsx
+++ b/src/versioned-router.tsx
@@ -52,7 +52,7 @@ import TaskListPage from "@routes/patterns/TaskListPage.tsx";
 import QuestionPage from "@routes/patterns/QuestionPage.tsx";
 import ReviewPage from "@routes/patterns/ReviewPage.tsx";
 import ResultPage from "@routes/patterns/ResultPage.tsx";
-import SimpleFormPage from "@routes/patterns/SimpleFormPage.tsx";
+import PublicFormPage from "@routes/patterns/PublicFormPage.tsx";
 import FilterChipPage from "@routes/components/FilterChip.tsx";
 import TextPage from "@routes/components/Text.tsx";
 
@@ -155,7 +155,7 @@ export const PatternsRouter = () => {
       <Route path="/" element={<PatternsLayout />} errorElement={<ComponentNotFoundPage />}>
         {/* Non-versioned paths components */}
         <Route index element={<PatternsOverviewPage />} />
-        <Route path="/simple-form" element={<SimpleFormPage/>} />
+        <Route path="/public-form" element={<PublicFormPage/>} />
         <Route path=":component" element={<ComponentRoute versionedPaths={patternsPaths} />} />
         {/* Versioned paths components */}
         <Route path=":version/:component" element={<VersionedComponentRoute versionedPaths={patternsPaths} />} />


### PR DESCRIPTION
All references to Simple form should be changed to Public form, including filenames and links.