### PR TITLE
feat(#2594): document link component

### DIFF
--- a/src/examples/link/LinkExamples.tsx
+++ b/src/examples/link/LinkExamples.tsx
@@ -1,0 +1,18 @@
+import { Sandbox } from "@components/sandbox";
+import { SandboxHeader } from "@components/sandbox/sandbox-header/sandboxHeader.tsx";
+import { GoabLink } from "@abgov/react-components";
+
+export const LinkExamples = () => {
+  return (
+    <>
+      <SandboxHeader exampleTitle="Link to an external page">
+      </SandboxHeader>
+
+      <Sandbox>
+        <GoabLink trailingIcon="open">
+          <a href="#external-url">External link</a>
+        </GoabLink>
+      </Sandbox>
+    </>
+  );
+}

--- a/src/routes/components/AllComponents.tsx
+++ b/src/routes/components/AllComponents.tsx
@@ -372,6 +372,13 @@ const AllComponents = () => {
         status: "Published",
       },
       {
+        name: "link",
+        groups: ["Utilities"],
+        tags: ["utilities"],
+        description: "Wraps an anchor element to add icons or margins.",
+        status: "Published",
+      },
+      {
         name: "spacer",
         groups: ["Utilities"],
         tags: ["gap", "margin", "padding", "space", "utilities"],

--- a/src/routes/components/Components.tsx
+++ b/src/routes/components/Components.tsx
@@ -104,6 +104,7 @@ export function Components() {
               <Link to={getUrl("form-item")}>Form item</Link>
               <Link to={getUrl("grid")}>Grid</Link>
               <Link to={getUrl("icons")}>Icons</Link>
+              <Link to={getUrl("link")}>Link</Link>
               <Link to={getUrl("spacer")}>Spacer</Link>
             </GoabSideMenuGroup>
           </GoabSideMenu>

--- a/src/routes/components/Link.tsx
+++ b/src/routes/components/Link.tsx
@@ -1,0 +1,134 @@
+import { useState } from "react";
+import { ComponentBinding, Sandbox } from "@components/sandbox";
+import {
+  ComponentProperties,
+  ComponentProperty,
+} from "@components/component-properties/ComponentProperties.tsx";
+import { Category, ComponentHeader } from "@components/component-header/ComponentHeader.tsx";
+import { GoabBadge, GoabTab, GoabTabs, GoabLink } from "@abgov/react-components";
+import { LinkExamples } from "@examples/link/LinkExamples.tsx";
+import { DesignEmpty } from "@components/empty-states/design-empty/DesignEmpty.tsx";
+import { AccessibilityEmpty } from "@components/empty-states/accessibility-empty/AccessibilityEmpty.tsx";
+import ICONS from "@routes/components/icons.json";
+
+
+export default function LinkPage() {
+  const FIGMA_LINK = "https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=27301-303448";
+  const [linkProps, setLinkProps] = useState({});
+
+  const [linkBindings, setLinkBindings] = useState<ComponentBinding[]>([
+    {
+      label: "Leading Icon",
+      type: "combobox",
+      name: "leadingIcon",
+      options: [""].concat(ICONS),
+      value: "",
+    },
+    {
+      label: "Trailing Icon",
+      type: "combobox",
+      name: "trailingIcon",
+      options: [""].concat(ICONS),
+      value: "",
+    },
+    {
+      label: "Top Margin",
+      type: "list",
+      name: "mt",
+      options: ["none", "3xs", "2xs", "xs", "s", "m", "l", "xl", "2xl", "3xl", "4xl"],
+      value: "none",
+    },
+    {
+      label: "Bottom Margin",
+      type: "list",
+      name: "mb",
+      options: ["none", "3xs", "2xs", "xs", "s", "m", "l", "xl", "2xl", "3xl", "4xl"],
+      value: "none",
+    },
+  ]);
+
+  const componentProperties: ComponentProperty[] = [
+    {
+      name: "leadingIcon",
+      type: "GoAIconType",
+      lang: "react",
+      description: "Shows an icon to the left of the link.",
+    },
+    {
+      name: "leadingicon",
+      type: "GoAIconType",
+      lang: "angular",
+      description: "Shows an icon to the left of the link.",
+    },
+    {
+      name: "trailingIcon",
+      type: "GoAIconType",
+      lang: "react",
+      description: "Shows an icon to the right of the link.",
+    },
+    {
+      name: "trailingicon",
+      type: "GoAIconType",
+      lang: "angular",
+      description: "Shows an icon to the right of the link.",
+    },
+    {
+      name: "mt,mr,mb,ml",
+      type: "none | 3xs | 2xs | xs | s | m | l | xl | 2xl | 3xl | 4xl",
+      description: "Apply margin to the top, right, bottom, and/or left of the component.",
+    },
+  ];
+
+  function onSandboxChange(bindings: ComponentBinding[], props: Record<string, unknown>) {
+    setLinkBindings(bindings);
+    setLinkProps(props);
+  }
+
+  return (
+    <>
+      <ComponentHeader
+        name="Link"
+        figmaLink={FIGMA_LINK}
+        githubLink="Link"
+        category={Category.UTILITIES}
+        description="Wraps an anchor element to add icons or margins."
+        relatedComponents={[
+          { link: "/components/button", name: "Button" },
+        ]}
+      />
+
+      <GoabTabs>
+        <GoabTab heading="Code playground">
+          <Sandbox properties={linkBindings} onChange={onSandboxChange}>
+
+            <GoabLink {...linkProps}>
+              <a href="#url">Link</a>
+            </GoabLink>
+
+          </Sandbox>
+          <ComponentProperties properties={componentProperties} />
+        </GoabTab>
+
+        
+        <GoabTab
+            heading={
+              <>
+                Examples
+                <GoabBadge type="information" content="1" />
+              </>
+            }
+          >
+          <LinkExamples />
+        </GoabTab>
+
+        <GoabTab heading="Design">
+          <DesignEmpty figmaLink={FIGMA_LINK} />
+        </GoabTab>
+        
+        <GoabTab heading="Accessibility">
+          <AccessibilityEmpty figmaLink={FIGMA_LINK} />
+        </GoabTab>
+      </GoabTabs>
+    </>
+  );
+}

--- a/src/versioned-router.tsx
+++ b/src/versioned-router.tsx
@@ -56,6 +56,7 @@ import PublicFormPage from "@routes/patterns/PublicFormPage.tsx";
 import FilterChipPage from "@routes/components/FilterChip.tsx";
 import TextPage from "@routes/components/Text.tsx";
 import { DrawerPage } from "@routes/components/Drawer.tsx";
+import LinkPage from "@routes/components/Link.tsx";
 
 const ComponentRoute: React.FC<{
   versionedPaths: Record<string, React.ReactElement>;
@@ -126,6 +127,7 @@ export const ComponentsRouter = () => {
     "text-field": <TextFieldPage />,
     "header": <AppHeaderPage />,
     "footer": <AppFooterPage />,
+    "link": <LinkPage />,
   };
 
   return (


### PR DESCRIPTION
This PR adds documentation for the Link component which now works with our `alpha` Angular and React components. (Implemented in https://github.com/GovAlta/ui-components/issues/2522)