### PR TITLE
fix(#2433): make copy link & toc items to handle tab position

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,9 @@
       "name": "code-sandbox",
       "version": "0.0.0",
       "dependencies": {
-        "@abgov/react-components": "6.3.0-alpha.5",
+        "@abgov/react-components": "6.3.0-alpha.6",
         "@abgov/ui-components-common": "1.3.0-alpha.2",
-        "@abgov/web-components": "1.33.0-alpha.15",
+        "@abgov/web-components": "1.33.0-alpha.17",
         "@faker-js/faker": "^8.3.1",
         "highlight.js": "^11.8.0",
         "js-cookie": "^3.0.5",
@@ -67,9 +67,9 @@
       }
     },
     "node_modules/@abgov/react-components": {
-      "version": "6.3.0-alpha.5",
-      "resolved": "https://registry.npmjs.org/@abgov/react-components/-/react-components-6.3.0-alpha.5.tgz",
-      "integrity": "sha512-5pI2o3g4FHI5ejcuFS2Ot7mtjWjoit9j1KMbxt2gbLiQWRET4g8SgkMwavmaK5nGRPDC3GRgE21S25XyaNVyjw==",
+      "version": "6.3.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/@abgov/react-components/-/react-components-6.3.0-alpha.6.tgz",
+      "integrity": "sha512-XQeNm6U47zfoAL23jIib23oH2zdxXAoflUUsD50MS7lucQz7/2VFftRinXpG+9m8Gk5km8+g7NKS2XMmwB1m7g==",
       "peerDependencies": {
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
@@ -82,9 +82,9 @@
       "integrity": "sha512-UtoqKgjRq+JkGO8dC5/WE6roaaOsf0NRvGE2Njlyf+I2Mx8LlrwFuYOGJ1ehLBwUkzn1bMT70x7YFDVrCIWJog=="
     },
     "node_modules/@abgov/web-components": {
-      "version": "1.33.0-alpha.15",
-      "resolved": "https://registry.npmjs.org/@abgov/web-components/-/web-components-1.33.0-alpha.15.tgz",
-      "integrity": "sha512-p02+brvCylVDFUxUMwJY1ryLtKuvNED5Npu532c1tlFpBn0NRVYMWxG1bR7S2Tpy/f+X2Bq+tZnbMHPd8uHD8g==",
+      "version": "1.33.0-alpha.17",
+      "resolved": "https://registry.npmjs.org/@abgov/web-components/-/web-components-1.33.0-alpha.17.tgz",
+      "integrity": "sha512-/eydqQahruF455ktVQsMDXkOKYG9akdQ90KQ5SNCppG8R/doPQ7gW0o08hWe35UQPRmGu7mfTyhhTYmin9abiQ==",
       "peerDependencies": {
         "@sveltejs/vite-plugin-svelte": "3.x",
         "glob": "10.x",

--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
     "prettier": "npx prettier . --write"
   },
   "dependencies": {
-    "@abgov/react-components": "6.3.0-alpha.5",
+    "@abgov/react-components": "6.3.0-alpha.6",
     "@abgov/ui-components-common": "1.3.0-alpha.2",
-    "@abgov/web-components": "1.33.0-alpha.15",
+    "@abgov/web-components": "1.33.0-alpha.17",
     "@faker-js/faker": "^8.3.1",
     "highlight.js": "^11.8.0",
     "js-cookie": "^3.0.5",

--- a/src/components/sandbox/sandbox-header/sandboxHeader.tsx
+++ b/src/components/sandbox/sandbox-header/sandboxHeader.tsx
@@ -15,7 +15,9 @@ export function SandboxHeader(props: Props) {
   const anchorId = toKebabCase(props.exampleTitle);
 
   function copyAnchorLink() {
-    const url = `${window.location.origin}${window.location.pathname}#${anchorId}`;
+    const currentHash = window.location.hash;
+    const tabPart = currentHash.includes("#tab-") ? currentHash.split("#")[1]: "";
+    const url = `${window.location.origin}${window.location.pathname}${tabPart ? `#${tabPart}` : ''}#${anchorId}`;
     navigator.clipboard.writeText(url).then(() => {
       setIsCopied(true);
       setTimeout(() => setIsCopied(false), 2000); // Reset tooltip text after 2s

--- a/src/examples/tabs/TabsExamples.tsx
+++ b/src/examples/tabs/TabsExamples.tsx
@@ -5,7 +5,6 @@ import { SandboxHeader } from "@components/sandbox/sandbox-header/sandboxHeader.
 export const TabsExamples = () => {
   return (
     <>
-
       <SandboxHeader
         exampleTitle="Show different views of data in a table"
         figmaExample="">

--- a/src/examples/tabs/TabsSetSpecificTabActiveExample.tsx
+++ b/src/examples/tabs/TabsSetSpecificTabActiveExample.tsx
@@ -12,7 +12,7 @@ export const TabsSetSpecificTabActiveExample = () => {
     <>
       <GoabContainer mt="none" mb="none">
         <div style={{ padding: "40px" }}>
-            <GoabTabs initialTab={2}>
+            <GoabTabs initialTab={1}>
               <GoabTab heading="All">
                 <GoabTable width="100%">
                   <thead>
@@ -113,7 +113,7 @@ export const TabsSetSpecificTabActiveExample = () => {
           tags="angular"
           allowCopy={true}
           code={`
-            <goa-tabs initialTab={2}>
+            <goa-tabs initialTab={1}>
               <goa-tab>
                 <div slot="heading">All</div>
                 <goa-table width="100%">
@@ -208,7 +208,7 @@ export const TabsSetSpecificTabActiveExample = () => {
           tags="angular"
           allowCopy={true}
           code={`
-            <goab-tabs [initialTab]="2">
+            <goab-tabs [initialTab]="1">
               <goab-tab heading="All">
                 <goab-table width="100%">
                   <thead>
@@ -312,7 +312,7 @@ export const TabsSetSpecificTabActiveExample = () => {
           tags="react"
           allowCopy={true}
           code={`
-            <GoATabs initialTab={2}>
+            <GoATabs initialTab={1}>
               <GoATab heading="All">
                 <GoATable width="100%">
                   <thead>
@@ -411,7 +411,7 @@ export const TabsSetSpecificTabActiveExample = () => {
           tags="react"
           allowCopy={true}
           code={`
-            <GoabTabs initialTab={2}>
+            <GoabTabs initialTab={1}>
               <GoabTab heading="All">
                 <GoabTable width="100%">
                   <thead>

--- a/src/routes/components/Accordion.tsx
+++ b/src/routes/components/Accordion.tsx
@@ -232,7 +232,7 @@ export default function AccordionPage() {
       />
 
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
-        <GoabTabs>
+        <GoabTabs initialTab={1}>
           <GoabTab heading="Code playground">
             <h2 id="component" style={{ display: "none" }}>
               Playground

--- a/src/routes/components/AllComponents.tsx
+++ b/src/routes/components/AllComponents.tsx
@@ -622,7 +622,7 @@ const AllComponents = () => {
           onChange={({ value }) => setFilter(value || "")}        />
       </GoabFormItem>
 
-      <GoabTabs>
+      <GoabTabs initialTab={1}>
         <GoabTab heading="Cards">
           <GoabGrid minChildWidth="15rem" gap="xl">
             {filteredCards.map((card) => (

--- a/src/routes/components/AppFooter.tsx
+++ b/src/routes/components/AppFooter.tsx
@@ -104,7 +104,7 @@ export default function AppFooterPage() {
         githubLink="Footer"
       />
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
-        <GoabTabs>
+        <GoabTabs initialTab={1}>
           <GoabTab heading="Code playground">
             <h2 id="component" style={{ display: "none" }}>
               Playground

--- a/src/routes/components/AppHeader.tsx
+++ b/src/routes/components/AppHeader.tsx
@@ -164,7 +164,7 @@ export default function AppHeaderPage() {
       />
 
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
-        <GoabTabs>
+        <GoabTabs initialTab={1}>
           <GoabTab heading="Code playground">
             <h2 id="component" style={{ display: "none" }}>
               Playground

--- a/src/routes/components/Badge.tsx
+++ b/src/routes/components/Badge.tsx
@@ -177,7 +177,7 @@ export default function BadgePage() {
 
       />
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
-        <GoabTabs>
+        <GoabTabs initialTab={1}>
           <GoabTab heading="Code playground">
             <h2 id="component" style={{ display: "none" }}>Playground</h2>
             <Sandbox properties={badgeBindings} onChange={onSandboxChange}>

--- a/src/routes/components/Block.tsx
+++ b/src/routes/components/Block.tsx
@@ -116,7 +116,7 @@ export default function BlockPage() {
       />
 
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
-        <GoabTabs>
+        <GoabTabs initialTab={1}>
           <GoabTab heading="Code playground">
             <h2 id="component" style={{ display: "none" }}>Playground</h2>
             <Sandbox properties={blockBindings} onChange={onSandboxChange} fullWidth={sandboxFullWidth}>

--- a/src/routes/components/Button.tsx
+++ b/src/routes/components/Button.tsx
@@ -208,7 +208,7 @@ export default function ButtonPage() {
       />
 
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
-        <GoabTabs>
+        <GoabTabs initialTab={1}>
           <GoabTab heading="Code playground">
             <h2 id="component" style={{ display: "none" }}>Playground</h2>
             <Sandbox properties={buttonBindings} onChange={SandboxOnChange}>

--- a/src/routes/components/ButtonGroup.tsx
+++ b/src/routes/components/ButtonGroup.tsx
@@ -117,7 +117,7 @@ export default function ButtonGroupPage() {
 
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
 
-        <GoabTabs>
+        <GoabTabs initialTab={1}>
           <GoabTab heading="Code playground">
             <h2 id="component" style={{ display: "none" }}>Playground</h2>
             <Sandbox properties={buttonGroupBindings} onChange={onSandboxChange} fullWidth>

--- a/src/routes/components/Callout.tsx
+++ b/src/routes/components/Callout.tsx
@@ -180,7 +180,7 @@ export default function CalloutPage() {
       />
 
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
-        <GoabTabs>
+        <GoabTabs initialTab={1}>
           <GoabTab heading="Code playground">
             <h2 id="component" style={{ display: "none" }}>
               Playground

--- a/src/routes/components/Checkbox.tsx
+++ b/src/routes/components/Checkbox.tsx
@@ -236,7 +236,7 @@ export default function CheckboxPage() {
       />
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
 
-        <GoabTabs>
+        <GoabTabs initialTab={1}>
           <GoabTab heading="Code playground">
             <h2 id="component" style={{ display: "none" }}>Playground</h2>
             <Sandbox

--- a/src/routes/components/Container.tsx
+++ b/src/routes/components/Container.tsx
@@ -231,7 +231,7 @@ export default function ContainerPage() {
 
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
 
-        <GoabTabs>
+        <GoabTabs initialTab={1}>
           <GoabTab heading="Code playground">
             <h2 id="component" style={{ display: "none" }}>Playground</h2>
             <Sandbox properties={containerBindings} onChange={onSandboxChange} fullWidth>

--- a/src/routes/components/DatePicker.tsx
+++ b/src/routes/components/DatePicker.tsx
@@ -188,7 +188,7 @@ export default function DatePickerPage() {
 
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
 
-        <GoabTabs>
+        <GoabTabs initialTab={1}>
           <GoabTab heading="Code playground">
             <h2 id="component" style={{ display: "none" }}>Playground</h2>
             <Sandbox

--- a/src/routes/components/Details.tsx
+++ b/src/routes/components/Details.tsx
@@ -113,7 +113,7 @@ export default function DetailsPage() {
       />
 
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
-        <GoabTabs>
+        <GoabTabs initialTab={1}>
           <GoabTab heading="Code playground">
             <h2 id="component" style={{ display: "none" }}>
               Playground

--- a/src/routes/components/Divider.tsx
+++ b/src/routes/components/Divider.tsx
@@ -87,7 +87,7 @@ export default function DividerPage() {
 
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
 
-        <GoabTabs>
+        <GoabTabs initialTab={1}>
           <GoabTab heading="Code playground">
             <h2 id="component" style={{ display: "none" }}>Playground</h2>
             <Sandbox properties={dividerBindings} onChange={onSandboxChange} fullWidth>

--- a/src/routes/components/Dropdown.tsx
+++ b/src/routes/components/Dropdown.tsx
@@ -377,7 +377,7 @@ export default function DropdownPage() {
       />
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
 
-        <GoabTabs>
+        <GoabTabs initialTab={1}>
           <GoabTab heading="Code playground">
             <h2 id="component" style={{ display: "none" }}>Playground</h2>
             <Sandbox

--- a/src/routes/components/FileUploader.tsx
+++ b/src/routes/components/FileUploader.tsx
@@ -316,7 +316,7 @@ export default function FileUploaderPage() {
       />
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
 
-        <GoabTabs>
+        <GoabTabs initialTab={1}>
           <GoabTab heading="Code Playground">
             <h2 id="component" style={{ display: "none" }}>Playground</h2>
             <Sandbox properties={fileUploaderBindings} onChange={onSandboxChange} fullWidth skipRender>

--- a/src/routes/components/FilterChip.tsx
+++ b/src/routes/components/FilterChip.tsx
@@ -124,7 +124,7 @@ export default function FilterChipPage() {
         githubLink="Filter Chip"
       />
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
-        <GoabTabs>
+        <GoabTabs initialTab={1}>
           <GoabTab heading="Code playground">
             <h2 id="component" style={{ display: "none" }}>Playground</h2>
             <Sandbox properties={componentBindings} onChange={onSandboxChange}>

--- a/src/routes/components/FormItemPage.tsx
+++ b/src/routes/components/FormItemPage.tsx
@@ -227,7 +227,7 @@ export default function FormItemPage() {
       />
 
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
-        <GoabTabs>
+        <GoabTabs initialTab={1}>
           <GoabTab heading="Code playground">
             <h2 id="component" style={{ display: "none" }}>
               Playground

--- a/src/routes/components/FormStepper.tsx
+++ b/src/routes/components/FormStepper.tsx
@@ -116,7 +116,7 @@ export default function FormStepperPage() {
         githubLink="Form Stepper"
       />
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
-        <GoabTabs>
+        <GoabTabs initialTab={1}>
           <GoabTab heading="Code playground">
             <h2 id="component" style={{ display: "none" }}>
               Playground

--- a/src/routes/components/Grid.tsx
+++ b/src/routes/components/Grid.tsx
@@ -102,7 +102,7 @@ export default function GridPage() {
 
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
 
-        <GoabTabs>
+        <GoabTabs initialTab={1}>
           <GoabTab heading="Code playground">
             <h2 id="component" style={{ display: "none" }}>
               Playground

--- a/src/routes/components/HeroBanner.tsx
+++ b/src/routes/components/HeroBanner.tsx
@@ -218,7 +218,7 @@ export default function HeroBannerPage() {
       />
 
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
-        <GoabTabs>
+        <GoabTabs initialTab={1}>
           <GoabTab heading="Code playground">
             <h2 id="component" style={{ display: "none" }}>Playground</h2>
             <Sandbox properties={heroBannerBindings} fullWidth={true} onChange={onSandboxChange}>

--- a/src/routes/components/IconButton.tsx
+++ b/src/routes/components/IconButton.tsx
@@ -220,7 +220,7 @@ export default function IconButtonPage() {
 
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
 
-        <GoabTabs>
+        <GoabTabs initialTab={1}>
           <GoabTab heading="Code playground">
             <h2 id="component" style={{ display: "none" }}>Playground</h2>
             <Sandbox properties={iconButtonBindings} onChange={onSandboxChange}>

--- a/src/routes/components/Icons.tsx
+++ b/src/routes/components/Icons.tsx
@@ -217,7 +217,7 @@ export default function IconsPage() {
       />
 
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
-        <GoabTabs>
+        <GoabTabs initialTab={1}>
           <GoabTab heading="Code playground">
             {/*Icons Sandbox*/}
             <h2 id="component" style={{ display: "none" }}>

--- a/src/routes/components/List.tsx
+++ b/src/routes/components/List.tsx
@@ -20,7 +20,7 @@ export default function ListPage() {
           { link: "/components/details", name: "Details" },
         ]}      />
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
-        <GoabTabs>
+        <GoabTabs initialTab={1}>
           <GoabTab
             heading={
               <>

--- a/src/routes/components/MicrositeHeader.tsx
+++ b/src/routes/components/MicrositeHeader.tsx
@@ -236,7 +236,7 @@ export default function MicrositeHeaderPage() {
 
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
 
-        <GoabTabs>
+        <GoabTabs initialTab={1}>
           <GoabTab heading="Code playground">
             <h2 id="component" style={{ display: "none" }}>Playground</h2>
             <Sandbox properties={micrositeHeaderBindings} onChange={onSandboxChange} fullWidth>

--- a/src/routes/components/Modal.tsx
+++ b/src/routes/components/Modal.tsx
@@ -293,7 +293,7 @@ export default function ModalPage() {
       />
 
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
-        <GoabTabs>
+        <GoabTabs initialTab={1}>
           <GoabTab heading="Code playground">
             <h2 id="component" style={{ display: "none" }}>Playground</h2>
             <Sandbox properties={componentBindings} onChange={onSandboxChange} allow={["p"]}>

--- a/src/routes/components/Notificationbanner.tsx
+++ b/src/routes/components/Notificationbanner.tsx
@@ -148,7 +148,7 @@ export default function NotificationBannerPage() {
 
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
 
-        <GoabTabs>
+        <GoabTabs initialTab={1}>
           <GoabTab heading="Code playground">
             <h2 id="component" style={{ display: "none" }}>Playground</h2>
             <Sandbox properties={componentBindings} onChange={onSandboxChange} fullWidth={true}>

--- a/src/routes/components/Pagination.tsx
+++ b/src/routes/components/Pagination.tsx
@@ -221,7 +221,7 @@ export default function PaginationPage() {
       />
 
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
-        <GoabTabs>
+        <GoabTabs initialTab={1}>
           <GoabTab heading="Code playground">
             <h2 id="component" style={{ display: "none" }}>
               Playground

--- a/src/routes/components/Popover.tsx
+++ b/src/routes/components/Popover.tsx
@@ -184,7 +184,7 @@ export default function PopoverPage() {
 
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
 
-        <GoabTabs>
+        <GoabTabs initialTab={1}>
           <GoabTab heading="Code playground">
             <h2 id="component" style={{ display: "none" }}>Playground</h2>
             <Sandbox properties={popoverBindings} skipRender onChange={onSandboxChange}>

--- a/src/routes/components/ProgressIndicator.tsx
+++ b/src/routes/components/ProgressIndicator.tsx
@@ -169,7 +169,7 @@ export default function ProgressIndicatorPage() {
       />
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
 
-        <GoabTabs>
+        <GoabTabs initialTab={1}>
           <GoabTab heading="Code playground">
             <h2 id="component" style={{ display: "none" }}>Playground</h2>
             <Sandbox properties={componentBindings} onChange={onSandboxChange} variableNames={["visible"]}>

--- a/src/routes/components/Radio.tsx
+++ b/src/routes/components/Radio.tsx
@@ -299,7 +299,7 @@ export default function RadioPage() {
       />
 
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
-        <GoabTabs>
+        <GoabTabs initialTab={1}>
           <GoabTab heading="Code playground">
             {/*Radio sandbox*/}
             <h2 id="component" style={{ display: "none" }}>

--- a/src/routes/components/SideMenu.tsx
+++ b/src/routes/components/SideMenu.tsx
@@ -133,7 +133,7 @@ export default function SideMenuPage() {
 
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
 
-        <GoabTabs>
+        <GoabTabs initialTab={1}>
           <GoabTab heading="Code playground">
             <h2 id="component" style={{ display: "none" }}>Playground</h2>
             <Sandbox fullWidth allow={["div"]} skipRender>

--- a/src/routes/components/Skeleton.tsx
+++ b/src/routes/components/Skeleton.tsx
@@ -170,7 +170,7 @@ export default function SkeletonPage() {
       />
 
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
-        <GoabTabs>
+        <GoabTabs initialTab={1}>
           <GoabTab heading="Code playground">
             <h2 id="component" style={{ display: "none" }}>Playground</h2>
             <Sandbox properties={skeletonBindings} onChange={onSandboxChange} fullWidth>

--- a/src/routes/components/Spacer.tsx
+++ b/src/routes/components/Spacer.tsx
@@ -121,7 +121,7 @@ export default function SpacerPage() {
 
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
 
-        <GoabTabs>
+        <GoabTabs initialTab={1}>
           <GoabTab heading="Code playground">
             <h2 id="component" style={{ display: "none" }}>Playground</h2>
             <Sandbox properties={hSpacerBindings} onChange={onHSandboxChange}>

--- a/src/routes/components/Table.tsx
+++ b/src/routes/components/Table.tsx
@@ -176,7 +176,7 @@ export default function TablePage() {
       />
 
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
-        <GoabTabs>
+        <GoabTabs initialTab={1}>
           <GoabTab heading="Code playground">
             <h2 id="component" style={{ display: "none" }}>Playground</h2>
             <Sandbox properties={tableBindings} onChange={onSandboxChange} fullWidth>

--- a/src/routes/components/Tabs.tsx
+++ b/src/routes/components/Tabs.tsx
@@ -103,7 +103,7 @@ export default function TabsPage() {
       />
 
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
-        <GoabTabs>
+        <GoabTabs initialTab={1}>
           <GoabTab heading="Code playground">
             <h2 id="component" style={{ display: "none" }}>
               Playground

--- a/src/routes/components/TemporaryNotification.tsx
+++ b/src/routes/components/TemporaryNotification.tsx
@@ -59,7 +59,7 @@ export default function TEMPLATE_Page() {
         relatedComponents={relatedComponents}
       />
 
-      <GoabTabs>
+      <GoabTabs initialTab={1}>
         <GoabTab heading="Code examples">
           <Sandbox properties={componentBindings} onChange={onSandboxChange}>
             <></>

--- a/src/routes/components/Text.tsx
+++ b/src/routes/components/Text.tsx
@@ -105,7 +105,7 @@ export default function TextPage() {
         githubLink="Text"
       />
 
-      <GoabTabs>
+      <GoabTabs initialTab={1}>
         <GoabTab heading="Code playground">
           <h2 id="component" style={{ display: "none" }}>Playground</h2>
           <Sandbox properties={textBindings} onChange={onSandboxChange}>

--- a/src/routes/components/TextArea.tsx
+++ b/src/routes/components/TextArea.tsx
@@ -350,7 +350,7 @@ export default function TextAreaPage() {
       />
 
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
-        <GoabTabs>
+        <GoabTabs initialTab={1}>
           <GoabTab heading="Code playground">
             <h2 id="component" style={{ display: "none" }}>
               Playground

--- a/src/routes/components/TextField.tsx
+++ b/src/routes/components/TextField.tsx
@@ -600,7 +600,7 @@ export default function TextFieldPage() {
 
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
 
-        <GoabTabs>
+        <GoabTabs initialTab={1}>
           <GoabTab heading="Code playground">
             {/*Input sandbox*/}
             <h2 id="component" style={{ display: "none" }}>Playground</h2>

--- a/src/routes/components/Tooltip.tsx
+++ b/src/routes/components/Tooltip.tsx
@@ -130,7 +130,7 @@ export default function TooltipPage() {
 
       <ComponentContent tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
 
-        <GoabTabs>
+        <GoabTabs initialTab={1}>
           <GoabTab heading="Code playground">
             <h2 id="component" style={{ display: "none" }}>Playground</h2>
             <Sandbox properties={componentBindings} onChange={onSandboxChange}>

--- a/src/routes/patterns/LayoutPage.tsx
+++ b/src/routes/patterns/LayoutPage.tsx
@@ -18,7 +18,7 @@ export default function LayoutPage() {
       <h3>
         A structural template that supports consistency across applications by defining visual grids, spacing, and sections.
       </h3>
-      <GoabTabs>
+      <GoabTabs initialTab={1}>
         <GoabTab heading="Code examples">
           <h3>Basic page layout</h3>
           <Sandbox fullWidth allow={["Browser"]}>

--- a/src/routes/patterns/QuestionPage.tsx
+++ b/src/routes/patterns/QuestionPage.tsx
@@ -17,7 +17,7 @@ export default function QuestionPage() {
       <ComponentContent
         contentClassName="question-page"
         tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
-        <GoabTabs>
+        <GoabTabs initialTab={1}>
           <GoabTab heading="Code examples">
             <QuestionPageExamples />
           </GoabTab>

--- a/src/routes/patterns/ResultPage.tsx
+++ b/src/routes/patterns/ResultPage.tsx
@@ -16,7 +16,7 @@ export default function ResultPage() {
       <ComponentContent
         contentClassName="question-page"
         tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
-        <GoabTabs>
+        <GoabTabs initialTab={1}>
           <GoabTab heading="Code examples">
             <ResultPageExamples/>
           </GoabTab>

--- a/src/routes/patterns/ReviewPage.tsx
+++ b/src/routes/patterns/ReviewPage.tsx
@@ -14,7 +14,7 @@ export default function ReviewPage() {
       <ComponentContent
         contentClassName="question-page"
         tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
-        <GoabTabs>
+        <GoabTabs initialTab={1}>
           <GoabTab heading="Code examples">
             <ReviewPageExamples />
           </GoabTab>

--- a/src/routes/patterns/StartPage.tsx
+++ b/src/routes/patterns/StartPage.tsx
@@ -17,7 +17,7 @@ export default function StartPage() {
       <ComponentContent
         contentClassName="start-page"
         tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
-        <GoabTabs>
+        <GoabTabs initialTab={1}>
           <GoabTab heading="Code examples">
             <StartPageExamples />
           </GoabTab>

--- a/src/routes/patterns/TaskListPage.tsx
+++ b/src/routes/patterns/TaskListPage.tsx
@@ -19,7 +19,7 @@ export default function TaskListPage() {
       <ComponentContent
         contentClassName="task-list-page"
         tocCssQuery="goa-tab[open=true] :is(h2[id], h3[id])">
-        <GoabTabs>
+        <GoabTabs initialTab={1}>
           <GoabTab heading="Code examples">
             <TaskListPageExamples />
           </GoabTab>


### PR DESCRIPTION
What I have changed:
* Make all tabs to have `initialTab` as 1 so when we land on the page, first tab will be highlighted

Before: 
<img width="1252" alt="image" src="https://github.com/user-attachments/assets/f739507a-db33-412c-9de5-5b34f2bdbdd3" />

After: 
<img width="1503" alt="image" src="https://github.com/user-attachments/assets/240da4d3-b5a1-41ec-a885-2b4db48e4e2e" />

* Make the navigation right hand side navigate to the correct position (especially if you refresh the browser, 2nd tab (Code examples) will be opened, and scroll down to the example

Before: 
<img width="1706" alt="image" src="https://github.com/user-attachments/assets/9680bf67-84f6-4895-8d38-a99138ba64cd" />
(No `tab` position on the browser, so if you refresh it will come back to the first tab)

After:
<img width="1916" alt="image" src="https://github.com/user-attachments/assets/092291ed-afd1-4c29-83f2-a8ff4e7d4ce5" />

It has the tab position on the browser, refresh it, it will open the tab 2 and navigate to the example (refer story #2433 https://github.com/GovAlta/ui-components/issues/2433)

* Update the logic of "Copy link"
Before: 
<img width="834" alt="image" src="https://github.com/user-attachments/assets/6f9a3f3f-833c-4d2c-9efe-da0ce1eee715" />
will return : 
{URL}/components/v6.0.0+-react/accordion#hide-and-show-many-sections-of-information-(faq)
(without tab position so when you open a new tab and paste the link, it doesn't open 2nd tab (code examples) and scroll to the correct position)

After: 
{URL}/components/accordion#tab-1#hide-and-show-many-sections-of-information-(faq)
It will return as above. 
