### PR TITLE
feat: style of sandbox note

### DIFF
--- a/src/components/sandbox/Sandbox.css
+++ b/src/components/sandbox/Sandbox.css
@@ -1,5 +1,8 @@
 .sandbox-note {
   color: #666;
+  margin-top: var(--goa-space-m);
+  margin-bottom: var(--goa-space-2xl);
+  font: var(--goa-typography-body-s);
 }
 
 .sandbox-render {

--- a/src/components/sandbox/Sandbox.tsx
+++ b/src/components/sandbox/Sandbox.tsx
@@ -1,5 +1,6 @@
 import { ReactElement, ReactNode, useContext, useEffect, useState } from "react";
 import { GoabCallout } from "@abgov/react-components";
+import { GoabCalloutType } from "@abgov/ui-components-common";
 
 import SandboxProperties from "./SandboxProperties";
 import { CodeSnippet } from "@components/code-snippet/CodeSnippet";
@@ -23,7 +24,7 @@ type Serializer = (el: any, properties: ComponentBinding[]) => string;
 interface SandboxProps {
   properties?: ComponentBinding[];
   formItemProperties?: ComponentBinding[];
-  note?: string | { type?: "important" | "success" | "information" | "emergency"; heading?: string; content: string };
+  note?: string | { type?: GoabCalloutType; heading?: string; content: string };
   fullWidth?: boolean;
   onChange?: (bindings: ComponentBinding[], props: Record<string, unknown>) => void;
   onChangeFormItemBindings?: (bindings: ComponentBinding[], props: Record<string, unknown>) => void;

--- a/src/components/sandbox/Sandbox.tsx
+++ b/src/components/sandbox/Sandbox.tsx
@@ -1,4 +1,5 @@
 import { ReactElement, ReactNode, useContext, useEffect, useState } from "react";
+import { GoabCallout } from "@abgov/react-components";
 
 import SandboxProperties from "./SandboxProperties";
 import { CodeSnippet } from "@components/code-snippet/CodeSnippet";
@@ -22,7 +23,7 @@ type Serializer = (el: any, properties: ComponentBinding[]) => string;
 interface SandboxProps {
   properties?: ComponentBinding[];
   formItemProperties?: ComponentBinding[];
-  note?: string;
+  note?: string | { type?: "important" | "success" | "information" | "emergency"; heading?: string; content: string };
   fullWidth?: boolean;
   onChange?: (bindings: ComponentBinding[], props: Record<string, unknown>) => void;
   onChangeFormItemBindings?: (bindings: ComponentBinding[], props: Record<string, unknown>) => void;
@@ -140,7 +141,21 @@ export const Sandbox = (props: SandboxProps) => {
         </GoabAccordion>
       )}
       <SandboxCode props={props} formatLang={formatLang} lang={lang} serializers={serializers} version={version} />
-      {props.note && (<div className="sandbox-note">{props.note}</div>)}
+      {props.note &&
+        (typeof props.note === "string" ? (
+          <p className="sandbox-note">{props.note}</p>
+        ) : (
+          <GoabCallout
+            type={props.note.type || "important"}
+            size="medium"
+            heading={props.note.heading}
+            maxWidth="596px"
+            mt="m"
+            mb="2xl"
+          >
+            {props.note.content}
+          </GoabCallout>
+        ))}
     </>
   );
 };

--- a/src/examples/modal/ModalWarnUserDeadlineExample.tsx
+++ b/src/examples/modal/ModalWarnUserDeadlineExample.tsx
@@ -8,7 +8,12 @@ export const ModalWarnUserDeadlineExample = () => {
   const {version} = useContext(LanguageVersionContext);
   const [warnCalloutModalOpen, setWarnCalloutModalOpen] = useState<boolean>();
   return (
-    <Sandbox skipRender>
+    <Sandbox skipRender
+             note={{
+               type: "important",
+               heading: "AlertDialog Accessibility",
+               content: "Do not make the modal closeable or add any focusable elements before the action button when using an AlertDialog. This ensures that the screen reader will announce the full content."
+             }}>
       <GoabButton type="secondary" onClick={() => setWarnCalloutModalOpen(true)}>
         Save for later
       </GoabButton>


### PR DESCRIPTION
## Updated styling to the "note" in the sandbox
- Added properties and styling to sandbox note to be able to use a callout or basic text
- Added callout note to ["Warn user of a deadline" example](https://deploy-preview-351--abgov-ui-component-docs.netlify.app/components/modal#tab-1) on Modal component page

### Can now use type, heading, and content properties to add a note as a callout
```
<Sandbox
             note={{
               type: "important",
               heading: "AlertDialog Accessibility",
               content: "Do not make the modal closeable or add any focusable elements before the action button when using an AlertDialog. This ensures that the screen reader will announce the full content."
             }}>
```
<img width="907" alt="image" src="https://github.com/user-attachments/assets/893da2bc-f8bf-4319-a9bd-7ce6532db0d8" />


### Can still use default note styling without callout
```
<Sandbox
             note={
               "Do not make the modal closeable or add any focusable elements before the action button when using an AlertDialog. This ensures that the screen reader will announce the full content."
             }>
```

<img width="907" alt="image" src="https://github.com/user-attachments/assets/77c969df-a092-44c1-a709-80b6638ff598" />
