### PR TITLE
fix: small issues for website release

### DIFF
--- a/src/components/component-header/ComponentHeader.tsx
+++ b/src/components/component-header/ComponentHeader.tsx
@@ -58,6 +58,7 @@ export const ComponentHeader: React.FC<Props> = (props) => {
                      )}%22`}
                      target="_blank"
                      rel="noopener noreferrer"
+                     style={{ whiteSpace: "nowrap" }}
                   >
                     GitHub issues{issueCount !== null ? ` (${issueCount})` : ""}
                   </a>

--- a/src/components/version-language-switcher/version-language-constants.ts
+++ b/src/components/version-language-switcher/version-language-constants.ts
@@ -2,7 +2,7 @@ export type LanguageVersion = "old" | "new";
 export type Language = "react" | "angular";
 export const ANGULAR_VERSIONS = {
   OLD: {
-    label: "v3.2.2 (lts)",
+    label: "v3.2.2 (LTS)",
     value: "old"
   },
   NEW: {
@@ -12,7 +12,7 @@ export const ANGULAR_VERSIONS = {
 }
 export const REACT_VERSIONS = {
   OLD: {
-    label: "v5.4.1 (lts)",
+    label: "v5.4.1 (LTS)",
     value: "old"
   },
   NEW: {

--- a/src/components/version-language-switcher/version-language-switcher.css
+++ b/src/components/version-language-switcher/version-language-switcher.css
@@ -4,6 +4,8 @@
     gap: var(--goa-space-2xs);
     font-size: var(--goa-font-size-2);
     margin-left: var(--goa-space-m);
+    white-space: nowrap;
+    height: 20px;
 }
 .version-language-switcher__menu {
     display: block;
@@ -11,6 +13,7 @@
     padding: var(--goa-space-s) var(--goa-space-s) var(--goa-space-s) var(--goa-space-s);
     text-decoration: none;
     color: var(--goa-color-text-default)!important;
+    white-space: nowrap;
 }
 .version-language-switcher__menu:hover:not(.version-language-switcher__menu--current) {
     background: #cedfee;
@@ -18,4 +21,11 @@
 .version-language-switcher__menu--current {
     color: var(--goa-color-text-light)!important;;
     background-color: var(--goa-color-interactive-default);
+}
+
+[slot="version"] {
+    height: 20px;
+    margin-top: 4px;
+    display: flex; /* if needed to align items horizontally */
+    align-items: center; /* vertically align content */
 }

--- a/src/examples/accordion/AccordionExamples.tsx
+++ b/src/examples/accordion/AccordionExamples.tsx
@@ -8,13 +8,13 @@ export default function AccordionExamples() {
     <>
       <SandboxHeader
         exampleTitle="Expand or collapse part of a form"
-        figmaExample="https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=48375-268093&t=Qn4eyi9UxONVqqY7-4">
+        figmaExample="https://www.figma.com/design/aIRjvBzpIUH0GbkffjbL04/%E2%9D%96-Patterns-library-%7C-DDD?node-id=6302-491810&t=X0IQW5flDDaj8Vyg-4">
       </SandboxHeader>
       <AccordionExpandOrCollapseExample/>
 
       <SandboxHeader
         exampleTitle="Hide and show many sections of information (FAQ)"
-        figmaExample="https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=15932-571271&t=svCeesMW3bnHA7sm-4">
+        figmaExample="https://www.figma.com/design/aIRjvBzpIUH0GbkffjbL04/%E2%9D%96-Patterns-library-%7C-DDD?node-id=6469-76255&t=X0IQW5flDDaj8Vyg-4">
       </SandboxHeader>
       <AccordionHideOrShowSectionExample/>
     </>

--- a/src/examples/app-footer/AppFooterExamples.tsx
+++ b/src/examples/app-footer/AppFooterExamples.tsx
@@ -7,13 +7,13 @@ export const AppFooterExamples = () => {
     <>
       <SandboxHeader
         exampleTitle="Show quick links"
-        figmaExample="https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=59337-150473&t=Zhk6rgZlHuDDA1M3-4">
+        figmaExample="https://www.figma.com/design/aIRjvBzpIUH0GbkffjbL04/%E2%9D%96-Patterns-library-%7C-DDD?node-id=6309-60928&t=X0IQW5flDDaj8Vyg-4">
       </SandboxHeader>
       <AppFooterShowQuickLinkExample />
 
       <SandboxHeader
         exampleTitle="Show links to navigation items"
-        figmaExample="https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=59340-67128&t=Zhk6rgZlHuDDA1M3-4">
+        figmaExample="https://www.figma.com/design/aIRjvBzpIUH0GbkffjbL04/%E2%9D%96-Patterns-library-%7C-DDD?node-id=6309-65947&t=X0IQW5flDDaj8Vyg-4">
       </SandboxHeader>
       <AppFooterShowNavigationItemsExample/>
     </>

--- a/src/examples/app-header/AppHeaderExamples.tsx
+++ b/src/examples/app-header/AppHeaderExamples.tsx
@@ -7,7 +7,7 @@ export const AppHeaderExamples = () => {
     <>
       <SandboxHeader
         exampleTitle="Header with navigation"
-        figmaExample="https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=59342-88128&t=Zhk6rgZlHuDDA1M3-4">
+        figmaExample="https://www.figma.com/design/aIRjvBzpIUH0GbkffjbL04/%E2%9D%96-Patterns-library-%7C-DDD?node-id=6309-90004&t=X0IQW5flDDaj8Vyg-4">
       </SandboxHeader>
       <AppHeaderWithNavigationExample/>
 

--- a/src/examples/badge/BadgeExamples.tsx
+++ b/src/examples/badge/BadgeExamples.tsx
@@ -13,13 +13,13 @@ export default function BadgeExamples() {
 
       <SandboxHeader
         exampleTitle="Show status in a table"
-        figmaExample="https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=60735-350834&t=Zhk6rgZlHuDDA1M3-4">
+        figmaExample="https://www.figma.com/design/aIRjvBzpIUH0GbkffjbL04/%E2%9D%96-Patterns-library-%7C-DDD?node-id=6304-22364&t=X0IQW5flDDaj8Vyg-4">
       </SandboxHeader>
       <BadgeShowStatusInTableExample />
 
       <SandboxHeader
         exampleTitle="Show multiple tags together"
-        figmaExample="https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=60735-375460&t=Zhk6rgZlHuDDA1M3-4">
+        figmaExample="https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=60735-375622&t=tGwTYaG8Orm4iOm7-4">
       </SandboxHeader>
       <Sandbox>
         <GoabBlock gap="xs">
@@ -31,7 +31,7 @@ export default function BadgeExamples() {
 
       <SandboxHeader
         exampleTitle="Show a status on a card"
-        figmaExample="https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=60735-375649&t=Zhk6rgZlHuDDA1M3-4">
+        figmaExample="https://www.figma.com/design/aIRjvBzpIUH0GbkffjbL04/%E2%9D%96-Patterns-library-%7C-DDD?node-id=6304-22768&t=X0IQW5flDDaj8Vyg-4">
       </SandboxHeader>
       <BadgeShowStatusOnCardExample/>
     </>

--- a/src/examples/button/ButtonExamples.tsx
+++ b/src/examples/button/ButtonExamples.tsx
@@ -9,14 +9,14 @@ export const ButtonExamples = () => {
     {/*Button Example 1*/}
     <SandboxHeader
       exampleTitle="Ask a user for an address"
-      figmaExample="https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=59124-34121&t=Zhk6rgZlHuDDA1M3-4">
+      figmaExample="https://www.figma.com/design/aIRjvBzpIUH0GbkffjbL04/%E2%9D%96-Patterns-library-%7C-DDD?node-id=6304-43250&t=X0IQW5flDDaj8Vyg-4">
     </SandboxHeader>
     <ButtonAskUserAddressExample/>
 
     {/*Button example 2*/}
     <SandboxHeader
       exampleTitle="Confirm a destructive action"
-      figmaExample="https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=59124-33444&t=Zhk6rgZlHuDDA1M3-4">
+      figmaExample="https://www.figma.com/design/aIRjvBzpIUH0GbkffjbL04/%E2%9D%96-Patterns-library-%7C-DDD?node-id=6307-43038&t=X0IQW5flDDaj8Vyg-4">
     </SandboxHeader>
     <ButtonConfirmDestructiveActionExample/>
 

--- a/src/examples/callout/CalloutExamples.tsx
+++ b/src/examples/callout/CalloutExamples.tsx
@@ -11,7 +11,7 @@ export const CalloutExamples = () => {
     <>
       <SandboxHeader
         exampleTitle="Confirm that an application was submitted"
-        figmaExample="https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=48481-156993&t=GS4XDg4VdrwarZux-4">
+        figmaExample="https://www.figma.com/design/aIRjvBzpIUH0GbkffjbL04/%E2%9D%96-Patterns-library-%7C-DDD?node-id=6307-125026&t=X0IQW5flDDaj8Vyg-4">
       </SandboxHeader>
       <Sandbox fullWidth allow={['h2', 'h3', 'p']} skipRender>
         {/*Angular code*/}

--- a/src/examples/checkbox/CheckboxExamples.tsx
+++ b/src/examples/checkbox/CheckboxExamples.tsx
@@ -11,7 +11,7 @@ export default function CheckboxExamples () {
     <>
       <SandboxHeader
         exampleTitle="Include descriptions for items in a checkbox list"
-        figmaExample="https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=48483-492922&t=Zhk6rgZlHuDDA1M3-4">
+        figmaExample="https://www.figma.com/design/aIRjvBzpIUH0GbkffjbL04/%E2%9D%96-Patterns-library-%7C-DDD?node-id=6307-131778&t=X0IQW5flDDaj8Vyg-4">
       </SandboxHeader>
       <Sandbox fullWidth skipRender>
         {/*Angular*/}

--- a/src/examples/container/ContainerExamples.tsx
+++ b/src/examples/container/ContainerExamples.tsx
@@ -11,25 +11,25 @@ export default function ContainerExamples() {
 
       <SandboxHeader
         exampleTitle="User information"
-        figmaExample="https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=59124-148878&t=Zhk6rgZlHuDDA1M3-4">
+        figmaExample="https://www.figma.com/design/aIRjvBzpIUH0GbkffjbL04/%E2%9D%96-Patterns-library-%7C-DDD?node-id=6307-154067&t=X0IQW5flDDaj8Vyg-4">
       </SandboxHeader>
       <ContainerUserInformationExample/>
 
       <SandboxHeader
         exampleTitle="Card view of case files"
-        figmaExample="https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=59124-183806&t=Zhk6rgZlHuDDA1M3-4">
+        figmaExample="https://www.figma.com/design/aIRjvBzpIUH0GbkffjbL04/%E2%9D%96-Patterns-library-%7C-DDD?node-id=6307-161012&t=X0IQW5flDDaj8Vyg-4">
       </SandboxHeader>
       <ContainerCaseFilesExample/>
 
       <SandboxHeader
         exampleTitle="Card grid"
-        figmaExample="https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=59124-185614&t=Zhk6rgZlHuDDA1M3-4">
+        figmaExample="https://www.figma.com/design/aIRjvBzpIUH0GbkffjbL04/%E2%9D%96-Patterns-library-%7C-DDD?node-id=6307-165873&t=X0IQW5flDDaj8Vyg-4">
       </SandboxHeader>
       <ContainerCardGridExample/>
 
       <SandboxHeader
         exampleTitle="Review and action"
-        figmaExample="https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=59124-197773&t=Zhk6rgZlHuDDA1M3-4">
+        figmaExample="https://www.figma.com/design/aIRjvBzpIUH0GbkffjbL04/%E2%9D%96-Patterns-library-%7C-DDD?node-id=6307-173587&t=X0IQW5flDDaj8Vyg-4">
       </SandboxHeader>
 
       <ContainerReviewActionExample/>

--- a/src/examples/details/DetailsExamples.tsx
+++ b/src/examples/details/DetailsExamples.tsx
@@ -14,19 +14,19 @@ export const DetailsExamples = () => {
     <>
       <SandboxHeader
         exampleTitle="Show more information to help answer a question"
-        figmaExample="https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=59148-252228&t=Zhk6rgZlHuDDA1M3-4">
+        figmaExample="https://www.figma.com/design/aIRjvBzpIUH0GbkffjbL04/%E2%9D%96-Patterns-library-%7C-DDD?node-id=6307-197360&t=X0IQW5flDDaj8Vyg-4">
       </SandboxHeader>
       <DetailsMoreInformationBasicQuestionExample />
 
       <SandboxHeader
-        exampleTitle="Show lists as more information to help answer a question "
-        figmaExample="https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=59148-252532&t=Zhk6rgZlHuDDA1M3-4">
+        exampleTitle="Show lists as more information to help answer a question"
+        figmaExample="https://www.figma.com/design/aIRjvBzpIUH0GbkffjbL04/%E2%9D%96-Patterns-library-%7C-DDD?node-id=6307-198753&t=X0IQW5flDDaj8Vyg-4">
       </SandboxHeader>
       <DetailsAdditionalInformationHelpUserExample />
 
       <SandboxHeader
-        exampleTitle="Show more information to help a user fill out direct deposit information"
-        figmaExample="https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=59148-251933&t=Zhk6rgZlHuDDA1M3-4">
+        exampleTitle="Ask a user for direct deposit information"
+        figmaExample="https://www.figma.com/design/aIRjvBzpIUH0GbkffjbL04/%E2%9D%96-Patterns-library-%7C-DDD?node-id=6307-202678&t=X0IQW5flDDaj8Vyg-4">
       </SandboxHeader>
       <DetailsShowDirectDepositInformationExample/>
     </>

--- a/src/examples/drawer/DrawerAddRecordExample.tsx
+++ b/src/examples/drawer/DrawerAddRecordExample.tsx
@@ -15,7 +15,7 @@ export const DrawerAddRecordExample = () => {
   return (
     <>
       {/*Don't use a Sandbox because the animation slowing displaying the drawer isn't working if it is inside sandbox*/}
-      <GoabContainer mt="m" mb="none">
+      <GoabContainer mt="none" mb="none">
         <div style={{ display: "flex", justifyContent: "center" }}>
           <GoabButton leadingIcon={"add"} onClick={() => setOpen(true)}>
             Add Record

--- a/src/examples/drawer/DrawerExamples.tsx
+++ b/src/examples/drawer/DrawerExamples.tsx
@@ -1,16 +1,18 @@
 import { DrawerFiltersExample } from "@examples/drawer/DrawerFiltersExample.tsx";
 import { DrawerAddRecordExample } from "@examples/drawer/DrawerAddRecordExample.tsx";
+import { SandboxHeader } from "@components/sandbox/sandbox-header/sandboxHeader.tsx";
 
 export const DrawerExamples = () => {
   return (
     <>
-      <h2 id="component-examples" className="hidden" aria-hidden="true">
-        Examples
-      </h2>
-      <h3 id="component-example-filters">Filters</h3>
+      <SandboxHeader
+        exampleTitle="Filters">
+      </SandboxHeader>
       <DrawerFiltersExample />
 
-      <h3 id="component-example-add-record">Add record</h3>
+      <SandboxHeader
+        exampleTitle="Add record">
+      </SandboxHeader>
       <DrawerAddRecordExample/>
     </>
   );

--- a/src/examples/drawer/DrawerFiltersExample.tsx
+++ b/src/examples/drawer/DrawerFiltersExample.tsx
@@ -18,7 +18,7 @@ export const DrawerFiltersExample = () => {
   return (
     <>
       {/*Don't use a Sandbox because the animation slowing displaying the drawer isn't working if it is inside sandbox*/}
-      <GoabContainer mt="m" mb="none">
+      <GoabContainer mt="none" mb="none">
         <div style={{ display: "flex", justifyContent: "center" }}>
           <GoabButton onClick={() => setOpen(true)}>Filters</GoabButton>
         </div>

--- a/src/examples/filter-chip/FilterChipExamples.tsx
+++ b/src/examples/filter-chip/FilterChipExamples.tsx
@@ -9,7 +9,7 @@ export const FilterChipExamples = () => {
     <>
       <SandboxHeader
         exampleTitle="Remove a filter"
-        figmaExample="https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=59337-131907&t=Zhk6rgZlHuDDA1M3-4">
+        figmaExample="https://www.figma.com/design/aIRjvBzpIUH0GbkffjbL04/%E2%9D%96-Patterns-library-%7C-DDD?node-id=6309-59262&t=X0IQW5flDDaj8Vyg-4">
       </SandboxHeader>
       <FilterChipDeleteEventExample />
 
@@ -21,13 +21,15 @@ export const FilterChipExamples = () => {
 
 
       <SandboxHeader
-        exampleTitle="Type to create a new filter chip"
-        figmaExample="https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=59337-138121&t=Zhk6rgZlHuDDA1M3-4">
+        exampleTitle="Type to create a new filter"
+        figmaExample="https://www.figma.com/design/aIRjvBzpIUH0GbkffjbL04/%E2%9D%96-Patterns-library-%7C-DDD?node-id=6308-51849&t=X0IQW5flDDaj8Vyg-4">
       </SandboxHeader>
 
       <FilterChipTypedChipExample/>
 
-      <h3 id="component-filter-table-data-example">Filter data in a table</h3>
+      <SandboxHeader
+        exampleTitle="Filter data in a table">
+      </SandboxHeader>
       <TableWithGlobalFiltersExample />
     </>
   )

--- a/src/examples/form-stepper/FormStepperControlledNavigationExample.tsx
+++ b/src/examples/form-stepper/FormStepperControlledNavigationExample.tsx
@@ -23,20 +23,13 @@ export const FormStepperControlledNavigationExample = () => {
 
   return (
     <>
-      <p>
-        The user needs to partially or completely finish a step to be able to move forward to
-        the next step. In this case:</p>
-        <ul>
-          <li>A step that is “Not started” will not be clickable.</li>
-          <li>A user cannot use the stepper to navigate to another page.</li>
-          <li>
-            Clicking the Active step when you are on that step will do nothing. (no page
-            refresh).
-          </li>
-        </ul>
-      <p>To use the controlled type you must set a step value ≥ 1</p>
 
-      <Sandbox fullWidth skipRender allow={["div"]} variableNames={["step"]}>
+      <Sandbox fullWidth skipRender allow={["div"]} variableNames={["step"]} note={`The user needs to partially or completely finish a step to be able to move forward to the next step.\n
+• A step that is “Not started” will not be clickable.\n
+• A user cannot use the stepper to navigate to another page.\n
+• Clicking the Active step when you are on that step will do nothing. (no page refresh).\n
+\n
+To use the controlled type you must set a step value ≥ 1.`}>
         {/*Must skipRender because we must illustrate the Prev and Next button click logic which cannot be rendered by sandbox*/}
         {/*Angular code*/}
         {version === "old" && <CodeSnippet

--- a/src/examples/form-stepper/FormStepperStepStatusExample.tsx
+++ b/src/examples/form-stepper/FormStepperStepStatusExample.tsx
@@ -23,9 +23,9 @@ export const FormStepperStepStatusExample = () => {
   }
   return (
     <>
-      The status of each step can be configured to either “complete” or “incomplete” using the
-      status property.
-      <Sandbox fullWidth skipRender allow={["div"]}>
+
+      <Sandbox fullWidth skipRender allow={["div"]}
+               note={"The status of each step can be configured to either “complete” or “incomplete” using the status property."}>
         {/*Angular code*/}
         {version === "old" && <CodeSnippet
           lang="typescript"

--- a/src/examples/microsite-header/MicrositeHeaderExamples.tsx
+++ b/src/examples/microsite-header/MicrositeHeaderExamples.tsx
@@ -15,7 +15,7 @@ export default function MicrositeHeaderExamples() {
     <>
       <SandboxHeader
         exampleTitle="Link to give feedback to the service"
-        figmaExample="https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=59350-40601&t=Zhk6rgZlHuDDA1M3-4">
+        figmaExample="https://www.figma.com/design/aIRjvBzpIUH0GbkffjbL04/%E2%9D%96-Patterns-library-%7C-DDD?node-id=6311-92884&t=X0IQW5flDDaj8Vyg-4">
       </SandboxHeader>
       <Sandbox skipRender fullWidth>
         <GoabMicrositeHeader type="alpha" onFeedbackClick={onClick} />
@@ -137,7 +137,7 @@ export default function MicrositeHeaderExamples() {
 
       <SandboxHeader
         exampleTitle="Show version number"
-        figmaExample="https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=59354-89591&t=Zhk6rgZlHuDDA1M3-4">
+        figmaExample="https://www.figma.com/design/aIRjvBzpIUH0GbkffjbL04/%E2%9D%96-Patterns-library-%7C-DDD?node-id=6311-92885&t=X0IQW5flDDaj8Vyg-4">
       </SandboxHeader>
       <Sandbox fullWidth skipRender>
         {/*Angular*/}

--- a/src/examples/modal/ModalExamples.tsx
+++ b/src/examples/modal/ModalExamples.tsx
@@ -12,32 +12,31 @@ export default function ModalExamples() {
     <>
 
         <SandboxHeader
-          exampleTitle="Basic Modal"
-          figmaExample="https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=59354-104688&t=Zhk6rgZlHuDDA1M3-4">
+          exampleTitle="Basic Modal">
         </SandboxHeader>
       <ModalBasicExample/>
 
         <SandboxHeader
           exampleTitle="Confirm a destructive action"
-          figmaExample="https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=48478-52391&t=Zhk6rgZlHuDDA1M3-4">
+          figmaExample="https://www.figma.com/design/aIRjvBzpIUH0GbkffjbL04/%E2%9D%96-Patterns-library-%7C-DDD?node-id=6307-43038&t=X0IQW5flDDaj8Vyg-4">
         </SandboxHeader>
       <ModalConfirmDestructiveActionExample/>
 
         <SandboxHeader
           exampleTitle="Warn a user of a deadline"
-          figmaExample="https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=48478-52380&t=Zhk6rgZlHuDDA1M3-4">
+          figmaExample="https://www.figma.com/design/aIRjvBzpIUH0GbkffjbL04/%E2%9D%96-Patterns-library-%7C-DDD?node-id=6307-43225&t=X0IQW5flDDaj8Vyg-4">
         </SandboxHeader>
       <ModalWarnUserDeadlineExample/>
 
         <SandboxHeader
           exampleTitle="Confirm a change"
-          figmaExample="https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=48478-52402&t=Zhk6rgZlHuDDA1M3-4">
+          figmaExample="https://www.figma.com/design/aIRjvBzpIUH0GbkffjbL04/%E2%9D%96-Patterns-library-%7C-DDD?node-id=6307-44272&t=X0IQW5flDDaj8Vyg-4">
         </SandboxHeader>
       <ModalConfirmRecordChangeExample/>
 
         <SandboxHeader
           exampleTitle="Add another item"
-          figmaExample="https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=48478-52413&t=Zhk6rgZlHuDDA1M3-4">
+          figmaExample="https://www.figma.com/design/aIRjvBzpIUH0GbkffjbL04/%E2%9D%96-Patterns-library-%7C-DDD?node-id=6307-50217&t=X0IQW5flDDaj8Vyg-4">
         </SandboxHeader>
       <ModalAddAnotherItemExample/>
 

--- a/src/examples/pagination/PaginationExamples.tsx
+++ b/src/examples/pagination/PaginationExamples.tsx
@@ -62,7 +62,7 @@ export const PaginationExamples = () => {
 
       <SandboxHeader
         exampleTitle="Show # results per page"
-        figmaExample="https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=59354-192194&t=Zhk6rgZlHuDDA1M3-4">
+        figmaExample="https://www.figma.com/design/aIRjvBzpIUH0GbkffjbL04/%E2%9D%96-Patterns-library-%7C-DDD?node-id=6311-118312&t=X0IQW5flDDaj8Vyg-4">
       </SandboxHeader>
       <Sandbox fullWidth skipRender>
         {/*============= React code ==============*/}

--- a/src/examples/radio/RadioExamples.tsx
+++ b/src/examples/radio/RadioExamples.tsx
@@ -8,13 +8,13 @@ export default function RadioExamples () {
     <>
       <SandboxHeader
         exampleTitle="Include a link in the helper text of an option"
-        figmaExample="https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=59357-25318&t=Zhk6rgZlHuDDA1M3-4">
+        figmaExample="https://www.figma.com/design/aIRjvBzpIUH0GbkffjbL04/%E2%9D%96-Patterns-library-%7C-DDD?node-id=6311-133375&t=X0IQW5flDDaj8Vyg-4">
       </SandboxHeader>
       <RadioSlottedDescriptionExample/>
 
       <SandboxHeader
         exampleTitle="Max width on long radio items"
-        figmaExample="https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=59357-75250&t=Zhk6rgZlHuDDA1M3-4">
+        figmaExample="https://www.figma.com/design/aIRjvBzpIUH0GbkffjbL04/%E2%9D%96-Patterns-library-%7C-DDD?node-id=6311-133539&t=X0IQW5flDDaj8Vyg-4">
       </SandboxHeader>
       <RadioMaxWidthExample/>
     </>

--- a/src/examples/tabs/TabsExamples.tsx
+++ b/src/examples/tabs/TabsExamples.tsx
@@ -7,7 +7,7 @@ export const TabsExamples = () => {
     <>
       <SandboxHeader
         exampleTitle="Show different views of data in a table"
-        figmaExample="">
+        figmaExample="https://www.figma.com/design/aIRjvBzpIUH0GbkffjbL04/%E2%9D%96-Patterns-library-%7C-DDD?node-id=6311-135722&t=X0IQW5flDDaj8Vyg-4">
       </SandboxHeader>
       <TabsDifferentViewsTableExample />
 

--- a/src/examples/text-field/TextFieldAskBirthdayExample.tsx
+++ b/src/examples/text-field/TextFieldAskBirthdayExample.tsx
@@ -28,9 +28,9 @@ export const TextFieldAskBirthdayExample = () => {
         tags="react"
         allowCopy={true}
         code={`
-           <GoabFormItem label="When is your birthday?" labelSize="large" helpText={<>For example, 27 November 2004</>}>
+           <GoabFormItem label="What is your date of birth?" >
             <GoabBlock gap="m" direction="row">
-            <GoabFormItem label="Month">
+            <GoabFormItem helpText={"Month"}>
                 <GoabDropdown onChange={(event: GoabDropdownOnChangeDetail) => setMonth(event.value)} name="month" value={month}>
                   <GoabDropdownItem label="January" value="January"></GoabDropdownItem>
                   <GoabDropdownItem label="February" value="February"></GoabDropdownItem>
@@ -46,10 +46,11 @@ export const TextFieldAskBirthdayExample = () => {
                   <GoabDropdownItem label="December" value="December"></GoabDropdownItem>
                 </GoabDropdown>
               </GoabFormItem>
-              <GoabFormItem label="Day">
+              
+              <GoabFormItem  helpText={"Day (DD)"}>
                 <GoabInput onChange={(event: GoabInputOnChangeDetail) => setDay(event.value)} value={day} name="day" width="2ch"></GoabInput>
               </GoabFormItem>
-              <GoabFormItem label="Year">
+              <GoabFormItem helpText={"Year (YYYY)"}>
                 <GoabInput onChange={(event: GoabInputOnChangeDetail) => setYear(event.value)} value={year} name="year" width="4ch"></GoabInput>
               </GoabFormItem>
             </GoabBlock>
@@ -77,11 +78,11 @@ export const TextFieldAskBirthdayExample = () => {
       />}
 
       <GoabFormItem
-        label="When is your birthday?"
-        labelSize="large"
-        helpText={"For example, 27 November 2004"}>
+        label="What is your date of birth?">
         <GoabBlock gap="m" direction="row">
-          <GoabFormItem label="Month">
+          <GoabFormItem
+            helpText={"Month"}>
+
             <GoabDropdown onChange={noop} name="month" value="">
               <GoabDropdownItem label="January" value="January" />
               <GoabDropdownItem label="February" value="February" />
@@ -97,7 +98,9 @@ export const TextFieldAskBirthdayExample = () => {
               <GoabDropdownItem label="December" value="December" />
             </GoabDropdown>
           </GoabFormItem>
-          <GoabFormItem label="Day">
+
+          <GoabFormItem
+            helpText={"Day (DD)"}>
             <GoabInput
               onChange={noop}
               value=""
@@ -105,7 +108,9 @@ export const TextFieldAskBirthdayExample = () => {
               width="2ch"
             />
           </GoabFormItem>
-          <GoabFormItem label="Year">
+
+          <GoabFormItem
+            helpText={"Year (YYYY)"}>
             <GoabInput
               onChange={noop}
               value=""
@@ -113,6 +118,7 @@ export const TextFieldAskBirthdayExample = () => {
               width="4ch"
             />
           </GoabFormItem>
+
         </GoabBlock>
       </GoabFormItem>
     </Sandbox>

--- a/src/examples/text-field/TextFieldExamples.tsx
+++ b/src/examples/text-field/TextFieldExamples.tsx
@@ -14,31 +14,31 @@ export default function TextFieldExamples() {
       {/*Examples*/}
       <SandboxHeader
         exampleTitle="Ask a user for an address"
-        figmaExample="https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=59124-34121&t=Zhk6rgZlHuDDA1M3-4">
+        figmaExample="https://www.figma.com/design/aIRjvBzpIUH0GbkffjbL04/%E2%9D%96-Patterns-library-%7C-DDD?node-id=6304-43250&t=X0IQW5flDDaj8Vyg-4">
       </SandboxHeader>
       <ButtonAskUserAddressExample />
 
       <SandboxHeader
         exampleTitle="Ask a user for their birthday"
-        figmaExample="https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=59348-31582&t=Zhk6rgZlHuDDA1M3-4">
+        figmaExample="https://www.figma.com/design/aIRjvBzpIUH0GbkffjbL04/%E2%9D%96-Patterns-library-%7C-DDD?node-id=6334-80568&t=X0IQW5flDDaj8Vyg-44">
       </SandboxHeader>
       <TextFieldAskBirthdayExample/>
 
       <SandboxHeader
         exampleTitle="Search"
-        figmaExample="https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=59348-35365&t=Zhk6rgZlHuDDA1M3-4">
+        figmaExample="https://www.figma.com/design/aIRjvBzpIUH0GbkffjbL04/%E2%9D%96-Patterns-library-%7C-DDD?node-id=6311-68872&t=X0IQW5flDDaj8Vyg-4">
       </SandboxHeader>
       <TextFieldSearchExample/>
 
       <SandboxHeader
         exampleTitle="Ask a user for dollar amounts"
-        figmaExample="https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=59348-51406&t=Zhk6rgZlHuDDA1M3-4">
+        figmaExample="https://www.figma.com/design/aIRjvBzpIUH0GbkffjbL04/%E2%9D%96-Patterns-library-%7C-DDD?node-id=1896-179629&t=X0IQW5flDDaj8Vyg-4">
       </SandboxHeader>
       <TextFieldAskUserAmountExample/>
 
       <SandboxHeader
         exampleTitle="Ask a user for an indian registration number"
-        figmaExample="https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=59350-15813&t=Zhk6rgZlHuDDA1M3-4">
+        figmaExample="https://www.figma.com/design/aIRjvBzpIUH0GbkffjbL04/%E2%9D%96-Patterns-library-%7C-DDD?node-id=1896-179631&t=X0IQW5flDDaj8Vyg-4">
       </SandboxHeader>
       <TextFieldAskUserIndianRegistrationExample/>
     </>

--- a/src/examples/textarea/TextAreaExamples.tsx
+++ b/src/examples/textarea/TextAreaExamples.tsx
@@ -8,7 +8,7 @@ export const TextAreaExamples = () => {
     <>
       <SandboxHeader
         exampleTitle="Ask a question and give more information"
-        figmaExample="https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=59437-356012&t=Zhk6rgZlHuDDA1M3-4">
+        figmaExample="https://www.figma.com/design/aIRjvBzpIUH0GbkffjbL04/%E2%9D%96-Patterns-library-%7C-DDD?node-id=6311-137633&t=X0IQW5flDDaj8Vyg-4">
       </SandboxHeader>
       <TextAreaAskQuestionMoreInformationExample/>
     </>

--- a/src/examples/tooltip/TooltipExamples.tsx
+++ b/src/examples/tooltip/TooltipExamples.tsx
@@ -16,7 +16,7 @@ export const TooltipExamples = () => {
 
       <SandboxHeader
         exampleTitle="Show a label on an icon only button"
-        figmaExample="https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=60735-395436&t=Zhk6rgZlHuDDA1M3-4">
+        figmaExample="https://www.figma.com/design/aIRjvBzpIUH0GbkffjbL04/%E2%9D%96-Patterns-library-%7C-DDD?node-id=6311-138133&t=X0IQW5flDDaj8Vyg-4">
       </SandboxHeader>
       <TooltipShowLabelForIconOnlyButtonExample />
 

--- a/src/routes/components/AllComponents.tsx
+++ b/src/routes/components/AllComponents.tsx
@@ -193,7 +193,7 @@ const AllComponents = () => {
       {
         name: "drawer",
         groups: ["Structure and navigation"],
-        tags: ["sections", "structure and navigation", "tabbed interface"],
+        tags: ["sections", "structure and navigation", "Sheet", "Sidesheet", "Sidepanel"],
         description:
           "A panel that slides in from the side of the screen to display additional content or actions without navigating away from the current view.",
         status: "Published",
@@ -405,13 +405,6 @@ const AllComponents = () => {
         tags: ["breadcrumb"],
         description: "Currently tracking this need in services.",
         status: "Not Published",
-      },
-      {
-        name: "drawer",
-        groups: ["Structure and navigation"],
-        tags: ["Drawer", "Sheet", "Sidesheet", "Sidepanel"],
-        description: "There is currently an experimental drawer in development.",
-        status: "In Progress",
       },
       {
         name: "error summary",

--- a/src/routes/components/Components.tsx
+++ b/src/routes/components/Components.tsx
@@ -41,13 +41,14 @@ export function Components() {
     <>
       {version === "old" && (
         <GoabNotification type="important" maxContentWidth={MAX_CONTENT_WIDTH}>
-          Support for the Long Term Support (LTS) version of the Design system will be available until September 2025. <a href="/get-started/developers/update">View the upgrade guide</a>
+          Support for the Long Term Support (LTS) version of the Design system will be available until September
+          2025. <a href="/get-started/developers/update">View&nbsp;the&nbsp;upgrade&nbsp;guide</a>
         </GoabNotification>
       )}
       {version === "new" && (
         <GoabNotification type="information" maxContentWidth={MAX_CONTENT_WIDTH}>
           Upgrading to the latest version of the design system?{" "}
-          <a href="/get-started/developers/update">View the upgrade guide</a>
+          <a href="/get-started/developers/update">View&nbsp;the&nbsp;upgrade&nbsp;guide</a>
         </GoabNotification>
       )}
       <section className="content">

--- a/src/routes/components/Drawer.tsx
+++ b/src/routes/components/Drawer.tsx
@@ -25,8 +25,8 @@ import { AccessibilityEmpty } from "@components/empty-states/accessibility-empty
 
 // == Page props ==
 
-const FIGMA_LINK = "https://www.figma.com/design/XwdpAM2ejssrXlzSuPiycT/Component---Drawer?node-id=2332-98665&m=dev";
-const ACCESSIBILITY_FIGMA_LINK = "https://www.figma.com/design/XwdpAM2ejssrXlzSuPiycT/Component---Drawer?node-id=2488-93239&m=dev";
+const FIGMA_LINK = "https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=61514-308154";
+const ACCESSIBILITY_FIGMA_LINK = "https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=61514-308154";
 const componentName = "Drawer";
 const description =
   "A panel that slides in from the side of the screen to display additional content or actions without navigating away from the current view.";
@@ -133,6 +133,8 @@ export const DrawerPage = () => {
     <>
       <ComponentHeader
         name={componentName}
+        figmaLink={FIGMA_LINK}
+        githubLink={componentName}
         category={category}
         description={description}
         relatedComponents={relatedComponents}

--- a/src/routes/components/HeroBanner.tsx
+++ b/src/routes/components/HeroBanner.tsx
@@ -244,7 +244,7 @@ export default function HeroBannerPage() {
 
             <SandboxHeader
               exampleTitle="Hero Banner with actions"
-              figmaExample="https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=59343-90211&t=Zhk6rgZlHuDDA1M3-4">
+              figmaExample="https://www.figma.com/design/aIRjvBzpIUH0GbkffjbL04/%E2%9D%96-Patterns-library-%7C-DDD?node-id=6309-93120&t=X0IQW5flDDaj8Vyg-4">
             </SandboxHeader>
             <Sandbox skipRender fullWidth>
               {version === "old" && <CodeSnippet
@@ -252,8 +252,8 @@ export default function HeroBannerPage() {
                 tags="angular"
                 allowCopy={true}
                 code={`
-                  <goa-hero-banner heading="Supporting Businesses">
-                    Resources are available to help Alberta entrepreneurs and small businesses start, grow and succeed.
+                  <goa-hero-banner heading="Supporting public citizens">
+                    Digital services help to support Albertan citizens receive government services.
                     <div slot="actions">
                       <goa-button type="start" (_click)="onClick($event)">Call to action</goa-button>
                     </div>

--- a/src/routes/components/IconButton.tsx
+++ b/src/routes/components/IconButton.tsx
@@ -243,7 +243,7 @@ export default function IconButtonPage() {
 
             <SandboxHeader
               exampleTitle="Show multiple actions in a compact table"
-              figmaExample="https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=59346-93042&t=Zhk6rgZlHuDDA1M3-4">
+              figmaExample="https://www.figma.com/design/aIRjvBzpIUH0GbkffjbL04/%E2%9D%96-Patterns-library-%7C-DDD?node-id=6309-127620&t=X0IQW5flDDaj8Vyg-4">
             </SandboxHeader>
             <Sandbox fullWidth>
               <GoabTable width="100%">

--- a/src/routes/components/Link.tsx
+++ b/src/routes/components/Link.tsx
@@ -97,7 +97,7 @@ export default function LinkPage() {
         ]}
       />
 
-      <GoabTabs>
+      <GoabTabs initialTab={1}>
         <GoabTab heading="Code playground">
           <Sandbox properties={linkBindings} onChange={onSandboxChange}>
 

--- a/src/routes/components/List.tsx
+++ b/src/routes/components/List.tsx
@@ -30,8 +30,7 @@ export default function ListPage() {
             }
           >
             <SandboxHeader
-              exampleTitle="Ordered list"
-              figmaExample="https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=21567-616878&t=Zhk6rgZlHuDDA1M3-4">
+              exampleTitle="Ordered list">
             </SandboxHeader>
             <GoabContainer mt="none" mb="none">
               <ol className="goa-ordered-list">
@@ -145,8 +144,7 @@ export default function ListPage() {
             />
 
             <SandboxHeader
-              exampleTitle="Unordered list"
-              figmaExample="https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=21567-616878&t=Zhk6rgZlHuDDA1M3-4">
+              exampleTitle="Unordered list">
             </SandboxHeader>
             <GoabContainer mt="none" mb="none">
               <ul className="goa-unordered-list">

--- a/src/routes/components/Table.tsx
+++ b/src/routes/components/Table.tsx
@@ -253,8 +253,8 @@ export default function TablePage() {
 
 
               <SandboxHeader
-                exampleTitle="Sortable columns"
-                figmaExample="https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=59357-207598&t=Zhk6rgZlHuDDA1M3-4">
+                exampleTitle="Sort data in a table"
+                figmaExample="https://www.figma.com/design/aIRjvBzpIUH0GbkffjbL04/%E2%9D%96-Patterns-library-%7C-DDD?node-id=6312-97462&t=X0IQW5flDDaj8Vyg-4">
               </SandboxHeader>
               <Sandbox fullWidth>
                 <GoabTable onSort={sortData} width="100%">
@@ -596,8 +596,8 @@ export default function TablePage() {
             )}
 
               <SandboxHeader
-                exampleTitle="Number column"
-                figmaExample="https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=59357-222010&t=Zhk6rgZlHuDDA1M3-4">
+                exampleTitle="Display numbers in a table so they can be scanned easily"
+                figmaExample="https://www.figma.com/design/aIRjvBzpIUH0GbkffjbL04/%E2%9D%96-Patterns-library-%7C-DDD?node-id=6312-97673&t=X0IQW5flDDaj8Vyg-4">
               </SandboxHeader>
             <Sandbox fullWidth>
               <GoabTable width="100%">
@@ -623,7 +623,9 @@ export default function TablePage() {
               </GoabTable>
             </Sandbox>
 
-						<h3 id="component-filter-table-data-example">Filter data in a table</h3>
+              <SandboxHeader
+                exampleTitle="Sort data in a table">
+              </SandboxHeader>
             <TableWithGlobalFiltersExample />
           </GoabTab>
 

--- a/src/routes/get-started/Support.tsx
+++ b/src/routes/get-started/Support.tsx
@@ -76,13 +76,13 @@ export default function SupportPage() {
         <p>
           Mark Elamatha | <a href="mailto:mark.elamatha@gov.ab.ca">mark.elamatha@gov.ab.ca</a>
         </p>
-        <GoabText tag="h3" mb="2xs">Scrum master and DevOps</GoabText>
-        <p>
-          Dustin Nielsen | <a href="mailto:dustin.nielsen@gov.ab.ca">dustin.nielsen@gov.ab.ca</a>
-        </p>
         <GoabText tag="h3" mb="2xs">Digital architect and Lead developer</GoabText>
         <p>
           Chris Olsen | <a href="mailto:chris.olsen@gov.ab.ca">chris.olsen@gov.ab.ca</a>
+        </p>
+        <GoabText tag="h3" mb="2xs">Scrum master and DevOps</GoabText>
+        <p>
+          Dustin Nielsen | <a href="mailto:dustin.nielsen@gov.ab.ca">dustin.nielsen@gov.ab.ca</a>
         </p>
         <GoabText tag="h3" mb="2xs">Developers</GoabText>
         <p>
@@ -90,19 +90,9 @@ export default function SupportPage() {
           <br />
           Syed Zeeshan | <a href="mailto:syed.zeeshan@gov.ab.ca">syed.zeeshan@gov.ab.ca</a>
         </p>
-        <GoabText tag="h3" mb="2xs">QA Automation Developer</GoabText>
-        <p>
-          Ken Li | <a href="mailto:ken.li@gov.ab.ca">ken.li@gov.ab.ca</a>
-        </p>
-        <GoabText tag="h3" mb="2xs">Service designer</GoabText>
-        <p>
-          Ali Nicholls Asikinack | <a href="mailto:ali.nicholls-asikinack@gov.ab.ca">ali.nicholls-asikinack@gov.ab.ca</a>
-        </p>
-        <GoabText tag="h3" mb="2xs">UX designers</GoabText>
+        <GoabText tag="h3" mb="2xs">Designer</GoabText>
         <p>
           Thomas Jeffery | <a href="mailto:thomas.jeffery@gov.ab.ca">thomas.jeffery@gov.ab.ca</a>
-          <br />
-          Rianna Alizadeh | <a href="mailto:rianna.alizadeh@gov.ab.ca">rianna.alizadeh@gov.ab.ca</a>
         </p>
       </div>
     </ComponentContent>

--- a/src/routes/root.css
+++ b/src/routes/root.css
@@ -112,10 +112,16 @@ code {
   .content {
     margin: 0;
   }
+
+  .main {
+    padding: 0 1rem;
+    margin-right: 2rem;
+    margin-left: 2rem;
+  }
 }
 
 /*Mobile*/
-@media screen and (max-width: 623px) {
+@media screen and (max-width: 896px) {
   .container {
     flex-wrap: wrap;
   }
@@ -128,8 +134,8 @@ code {
   }
 
   .main {
-    margin-right: 1rem;
-    padding: 0 1rem;
+    padding: 0 2rem;
+    margin: 0;
   }
 
   .content {
@@ -139,5 +145,11 @@ code {
   .side-menu {
     padding-bottom: 1.5rem;
     border-bottom: 1px solid var(--goa-color-greyscale-200);
+  }
+}
+
+@media screen and (max-width: 623px) {
+  .main {
+    padding: 0 1rem;
   }
 }

--- a/src/routes/root.tsx
+++ b/src/routes/root.tsx
@@ -56,7 +56,7 @@ export default function Root() {
             maxContentWidth={MAX_CONTENT_WIDTH}
             version={<VersionLanguageSwitcher/>}
           />
-          <GoabAppHeader heading="Design system" maxContentWidth={MAX_CONTENT_WIDTH} url={"/"} fullMenuBreakpoint={1140}>
+          <GoabAppHeader heading="Design system" maxContentWidth={MAX_CONTENT_WIDTH} url={"/"} fullMenuBreakpoint={978}>
             <Link to="/get-started">Get started</Link>
             <Link to="/patterns">Patterns</Link>
             <Link to="/components">Components</Link>
@@ -78,11 +78,11 @@ export default function Root() {
               <Link to="/get-started">Get started</Link>
               <Link to="/patterns">Patterns</Link>
               <Link to="/components">Components</Link>
-              <Link to="/design-tokens">Tokens</Link>
+              <Link to="/design-tokens">Design tokens</Link>
               <Link to="/content/capitalization">Content</Link>
             </GoabAppFooterNavSection>
             <GoabAppFooterNavSection heading="Get support">
-              <Link to="https://design.alberta.ca/get-started/support/report-bug" target="_blank">Submit an issue</Link>
+              <Link to="/get-started/support/report-bug" target="_blank">Submit an issue</Link>
               <Link to="https://goa-dio.slack.com/archives/C02PLLT9HQ9">#design-system-support</Link>
             </GoabAppFooterNavSection>
             <GoabAppFooterMetaSection>


### PR DESCRIPTION
### (fixed) typing anything into the component search brings up the drawer (and sometimes multiple drawers….)

Before:
![image](https://github.com/user-attachments/assets/b7de3f0f-9ef3-4e7f-b421-dfd5a980cdb1)
After:
<img width="924" alt="image" src="https://github.com/user-attachments/assets/def39849-1c8a-496a-8816-9321cc6b6f16" />

### (fixed) links to Figma examples needed to be updated after Figma library update and small updates to component example names and formatting

<img width="943" alt="image" src="https://github.com/user-attachments/assets/f5ee2e58-e90a-49c8-a89c-c9d8a31daf33" />

### (fixed) stop text from wrapping on “view the upgrade guide” link
Before:
![image](https://github.com/user-attachments/assets/e6c43286-05fd-4e65-bcc3-004c6781cb7b)
After:
<img width="1210" alt="image" src="https://github.com/user-attachments/assets/fe150675-a5c8-49e3-87e3-53d64117c217" />

### (fixed) link not showing active tab on load
Before:
![image](https://github.com/user-attachments/assets/3758e8e2-f239-4cea-8019-a0ebccd7c3fe)
After:
<img width="1210" alt="image" src="https://github.com/user-attachments/assets/2029556c-4137-4ff2-9fdb-bea15a2a3dd8" />

### (fixed) update to component header to prevent wrapping on github issue count
Before:
<img width="442" alt="image" src="https://github.com/user-attachments/assets/d5d6f3a9-9f9a-47e2-a3e7-38e0bf485d9b" />

### (fixed) updated breakpoint for side menu and page content to stack before breaking
Before:

https://github.com/user-attachments/assets/bd85b4e1-256d-4ed5-b42b-5041e20ade74

After:

https://github.com/user-attachments/assets/bc4d6a75-c22b-419d-a81c-93752e44525a


### (fixed) adjusted header menu for breakpoint based on current nav items
Before:

https://github.com/user-attachments/assets/5e3d32f3-ea64-420e-b7ae-a4bde47275f9

After:

https://github.com/user-attachments/assets/81cbe682-7786-43a4-b964-e22ccd50cb06

### updated label on version control to capital "LTS"
Before:
<img width="576" alt="image" src="https://github.com/user-attachments/assets/db53d832-a2b0-4e42-9ceb-4f1494f30500" />
After:
<img width="310" alt="image" src="https://github.com/user-attachments/assets/1433151f-d1f7-4b88-8900-4d5e99706fc5" />

### updated team info
Before:
<img width="459" alt="image" src="https://github.com/user-attachments/assets/689478bc-6e06-4c47-9b35-b164c6007a15" />
After:
<img width="459" alt="image" src="https://github.com/user-attachments/assets/7acc7d1b-e2dc-428e-a77e-9c2d303af904" />
