### PR TITLE
feat(#2129): add none or many checkbox example

### DIFF
--- a/src/examples/checkbox/CheckboxDescriptionExample.tsx
+++ b/src/examples/checkbox/CheckboxDescriptionExample.tsx
@@ -1,0 +1,96 @@
+import { GoabCheckbox, GoabFormItem } from "@abgov/react-components";
+import { Sandbox } from "@components/sandbox";
+import { CodeSnippet } from "@components/code-snippet/CodeSnippet.tsx";
+import { useContext } from "react";
+import { LanguageVersionContext } from "@contexts/LanguageVersionContext.tsx";
+
+export default function CheckboxDescriptionExample () {
+  const {version} = useContext(LanguageVersionContext);
+  return (
+    <>
+      <Sandbox fullWidth skipRender>
+        {/*Angular*/}
+
+        {version === "old" && <CodeSnippet
+        lang="typescript"
+        tags="angular"
+        allowCopy={true}
+        code={`
+              <goa-form-item label="How would you like to be contacted?">
+                <goa-checkbox checked="true" name="optionOne" text="Email">
+                  <span slot="description">Help text with a <a href="#">link</a>.</span>
+                </goa-checkbox>
+                <goa-checkbox checked="false" name="optionTwo" text="Phone" />
+                <goa-checkbox checked="false" name="optionThree" text="Text message" />
+              </goa-form-item>
+            `}
+        />}
+
+        {version === "new" && <CodeSnippet
+          lang="typescript"
+          tags="angular"
+          allowCopy={true}
+          code={`
+              <goab-form-item label="How would you like to be contacted?">
+                <goab-checkbox [checked]="true" name="optionOne" text="Email" [description]="descriptionTemplate">
+                  <ng-template #descriptionTemplate>
+                    <span>Help text with a <a href="#">link</a>.</span>
+                  </ng-template>
+                </goab-checkbox>
+                <goab-checkbox [checked]="false" name="optionTwo" text="Phone" />
+                <goab-checkbox [checked]="false" name="optionThree" text="Text message" />
+              </goab-form-item>
+            `}
+        />}
+
+        {/*React*/}
+        {version === "old" && <CodeSnippet
+        lang="typescript"
+        tags="react"
+        allowCopy={true}
+        code={`
+              <GoAFormItem label="How would you like to be contacted?">
+                <GoACheckbox
+                  checked={true}
+                  name="optionOne"
+                  text="Email"
+                  description={<span>Help text with a <a href="#">link</a>.</span>}
+                  />
+                <GoACheckbox checked={false} name="optionTwo" text="Phone" />
+                <GoACheckbox checked={false} name="optionThree" text="Text message" />
+              </GoAFormItem>
+            `}
+        />}
+
+        {version === "new" && <CodeSnippet
+          lang="typescript"
+          tags="react"
+          allowCopy={true}
+          code={`
+              <GoabFormItem label="How would you like to be contacted?">
+                <GoabCheckbox
+                  checked={true}
+                  name="optionOne"
+                  text="Email"
+                  description={<span>Help text with a <a href="#">link</a>.</span>}
+                  />
+                <GoabCheckbox checked={false} name="optionTwo" text="Phone" />
+                <GoabCheckbox checked={false} name="optionThree" text="Text message" />
+              </GoabFormItem>
+            `}
+        />}
+
+        <GoabFormItem label="How would you like to be contacted?">
+          <GoabCheckbox
+            checked={true}
+            name="optionOne"
+            text="Email"
+            description={<span>Help text with a <a href="#">link</a>.</span>}
+            />
+          <GoabCheckbox checked={false} name="optionTwo" text="Phone" />
+          <GoabCheckbox checked={false} name="optionThree" text="Text message" />
+        </GoabFormItem>
+      </Sandbox>
+    </>
+  );
+}

--- a/src/examples/checkbox/CheckboxExamples.tsx
+++ b/src/examples/checkbox/CheckboxExamples.tsx
@@ -1,101 +1,21 @@
-import { GoabCheckbox, GoabFormItem } from "@abgov/react-components";
-import { Sandbox } from "@components/sandbox";
-import { CodeSnippet } from "@components/code-snippet/CodeSnippet.tsx";
-import { useContext } from "react";
-import { LanguageVersionContext } from "@contexts/LanguageVersionContext.tsx";
+import CheckboxDescriptionExample from "@examples/checkbox/CheckboxDescriptionExample.tsx";
+import CheckboxNoneOrManyExample from "@examples/checkbox/CheckboxNoneOrManyExample.tsx";
 import { SandboxHeader } from "@components/sandbox/sandbox-header/sandboxHeader.tsx";
 
-export default function CheckboxExamples () {
-  const {version} = useContext(LanguageVersionContext);
-  return (
-    <>
-      <SandboxHeader
-        exampleTitle="Include descriptions for items in a checkbox list"
-        figmaExample="https://www.figma.com/design/aIRjvBzpIUH0GbkffjbL04/%E2%9D%96-Patterns-library-%7C-DDD?node-id=6307-131778&t=X0IQW5flDDaj8Vyg-4">
-      </SandboxHeader>
-      <Sandbox fullWidth skipRender>
-        {/*Angular*/}
+export const CheckboxExamples = () => {
+  return <>
+    {/*Checkbox example 1*/}
+    <SandboxHeader
+      exampleTitle="Include descriptions for items in a checkbox list"
+      figmaExample="https://www.figma.com/design/aIRjvBzpIUH0GbkffjbL04/%E2%9D%96-Patterns-library-%7C-DDD?node-id=6307-131778&t=X0IQW5flDDaj8Vyg-4">
+    </SandboxHeader>
+    <CheckboxDescriptionExample/>
 
-        {version === "old" && <CodeSnippet
-        lang="typescript"
-        tags="angular"
-        allowCopy={true}
-        code={`
-              <goa-form-item label="How would you like to be contacted?">
-                <goa-checkbox checked="true" name="optionOne" text="Email">
-                  <span slot="description">Help text with a <a href="#">link</a>.</span>
-                </goa-checkbox>
-                <goa-checkbox checked="false" name="optionTwo" text="Phone" />
-                <goa-checkbox checked="false" name="optionThree" text="Text message" />
-              </goa-form-item>
-            `}
-        />}
-
-        {version === "new" && <CodeSnippet
-          lang="typescript"
-          tags="angular"
-          allowCopy={true}
-          code={`
-              <goab-form-item label="How would you like to be contacted?">
-                <goab-checkbox [checked]="true" name="optionOne" text="Email" [description]="descriptionTemplate">
-                  <ng-template #descriptionTemplate>
-                    <span>Help text with a <a href="#">link</a>.</span>
-                  </ng-template>
-                </goab-checkbox>
-                <goab-checkbox [checked]="false" name="optionTwo" text="Phone" />
-                <goab-checkbox [checked]="false" name="optionThree" text="Text message" />
-              </goab-form-item>
-            `}
-        />}
-
-        {/*React*/}
-        {version === "old" && <CodeSnippet
-        lang="typescript"
-        tags="react"
-        allowCopy={true}
-        code={`
-              <GoAFormItem label="How would you like to be contacted?">
-                <GoACheckbox
-                  checked={true}
-                  name="optionOne"
-                  text="Email"
-                  description={<span>Help text with a <a href="#">link</a>.</span>}
-                  />
-                <GoACheckbox checked={false} name="optionTwo" text="Phone" />
-                <GoACheckbox checked={false} name="optionThree" text="Text message" />
-              </GoAFormItem>
-            `}
-        />}
-
-        {version === "new" && <CodeSnippet
-          lang="typescript"
-          tags="react"
-          allowCopy={true}
-          code={`
-              <GoabFormItem label="How would you like to be contacted?">
-                <GoabCheckbox
-                  checked={true}
-                  name="optionOne"
-                  text="Email"
-                  description={<span>Help text with a <a href="#">link</a>.</span>}
-                  />
-                <GoabCheckbox checked={false} name="optionTwo" text="Phone" />
-                <GoabCheckbox checked={false} name="optionThree" text="Text message" />
-              </GoabFormItem>
-            `}
-        />}
-
-        <GoabFormItem label="How would you like to be contacted?">
-          <GoabCheckbox
-            checked={true}
-            name="optionOne"
-            text="Email"
-            description={<span>Help text with a <a href="#">link</a>.</span>}
-            />
-          <GoabCheckbox checked={false} name="optionTwo" text="Phone" />
-          <GoabCheckbox checked={false} name="optionThree" text="Text message" />
-        </GoabFormItem>
-      </Sandbox>
-    </>
-  );
+    {/*Checkbox example 2*/}
+    <SandboxHeader
+      exampleTitle="Select one, any, all, or no options from a list"
+      figmaExample="https://www.figma.com/design/aIRjvBzpIUH0GbkffjbL04/%E2%9D%96-Patterns-library-%7C-DDD?node-id=6564-70176&t=kFEYlzR03SibmVz9-1">
+    </SandboxHeader>
+    <CheckboxNoneOrManyExample/>
+  </>;
 }

--- a/src/examples/checkbox/CheckboxNoneOrManyExample.tsx
+++ b/src/examples/checkbox/CheckboxNoneOrManyExample.tsx
@@ -1,0 +1,87 @@
+import { GoabCheckbox, GoabFormItem } from "@abgov/react-components";
+import { Sandbox } from "@components/sandbox";
+import { CodeSnippet } from "@components/code-snippet/CodeSnippet.tsx";
+import { useContext } from "react";
+import { LanguageVersionContext } from "@contexts/LanguageVersionContext.tsx";
+
+export default function CheckboxNoneOrManyExample () {
+  const {version} = useContext(LanguageVersionContext);
+  return (
+    <>
+      <Sandbox fullWidth skipRender>
+        {/*Angular*/}
+
+        {version === "old" && <CodeSnippet
+        lang="typescript"
+        tags="angular"
+        allowCopy={true}
+        code={`
+              <goa-form-item
+                label="How would you like to be contacted?"
+                helpText="Choose all that apply"
+              >
+                <goa-checkbox checked="false" name="optionOne" text="Email" />
+                <goa-checkbox checked="false" name="optionTwo" text="Phone" />
+                <goa-checkbox checked="false" name="optionThree" text="Text message" />
+              </goa-form-item>
+            `}
+        />}
+
+        {version === "new" && <CodeSnippet
+          lang="typescript"
+          tags="angular"
+          allowCopy={true}
+          code={`
+              <goab-form-item
+                label="How would you like to be contacted?"
+                helpText="Choose all that apply"
+              >
+                <goab-checkbox [checked]="false" name="optionOne" text="Email" />
+                <goab-checkbox [checked]="false" name="optionTwo" text="Phone" />
+                <goab-checkbox [checked]="false" name="optionThree" text="Text message" />
+              </goab-form-item>
+            `}
+        />}
+
+        {/*React*/}
+        {version === "old" && <CodeSnippet
+        lang="typescript"
+        tags="react"
+        allowCopy={true}
+        code={`
+              <GoAFormItem
+                label="How would you like to be contacted?"
+                helpText="Choose all that apply"
+              >
+                <GoACheckbox checked={false} name="optionOne" text="Email" />
+                <GoACheckbox checked={false} name="optionTwo" text="Phone" />
+                <GoACheckbox checked={false} name="optionThree" text="Text message" />
+              </GoAFormItem>
+            `}
+        />}
+
+        {version === "new" && <CodeSnippet
+          lang="typescript"
+          tags="react"
+          allowCopy={true}
+          code={`
+              <GoabFormItem
+                label="How would you like to be contacted?"
+                helpText="Choose all that apply"
+              >
+                <GoabCheckbox checked={false} name="optionOne" text="Email" />
+                <GoabCheckbox checked={false} name="optionTwo" text="Phone" />
+                <GoabCheckbox checked={false} name="optionThree" text="Text message" />
+              </GoabFormItem>
+            `}
+        />}
+
+        <GoabFormItem label="How would you like to be contacted?" helpText="Choose all that apply">
+          <GoabCheckbox checked={false} name="optionOne" text="Email" />
+          <GoabCheckbox checked={false} name="optionTwo" text="Phone" />
+          <GoabCheckbox checked={false} name="optionThree" text="Text message" />
+        </GoabFormItem>
+      </Sandbox>
+    </>
+  );
+}

--- a/src/routes/components/Checkbox.tsx
+++ b/src/routes/components/Checkbox.tsx
@@ -9,7 +9,7 @@ import {
 import { Category, ComponentHeader } from "@components/component-header/ComponentHeader.tsx";
 import { useSandboxFormItem } from "@hooks/useSandboxFormItem.tsx";
 import { ComponentContent } from "@components/component-content/ComponentContent";
-import CheckboxExamples from "@examples/checkbox/CheckboxExamples.tsx";
+import { CheckboxExamples } from "@examples/checkbox/CheckboxExamples.tsx";
 import { LanguageVersionContext } from "@contexts/LanguageVersionContext.tsx";
 import {
   LegacyTestIdProperties,
@@ -328,7 +328,7 @@ export default function CheckboxPage() {
             heading={
               <>
                 Examples
-                <GoabBadge type="information" content="1" />
+                <GoabBadge type="information" content="2" />
               </>
             }
           >


### PR DESCRIPTION
This PR adds a checkbox example for selecting one, any or all items.

<img width="744" alt="image" src="https://github.com/user-attachments/assets/d6e30d27-9a45-46a5-9c6c-367b87949c73" />
