### PR TITLE
feat(#2136): add textarea example for long question

### DIFF
--- a/src/examples/textarea/TextAreaAskLongQuestionExample.tsx
+++ b/src/examples/textarea/TextAreaAskLongQuestionExample.tsx
@@ -1,0 +1,20 @@
+import { Sandbox } from "@components/sandbox";
+import {
+  GoabFormItem,
+  GoabTextarea
+} from "@abgov/react-components";
+
+export const TextAreaAskLongQuestionExample = () => {
+  const noop = () => {}
+  return (
+    <Sandbox fullWidth>
+
+        <GoabFormItem
+          label="Provide more detail"
+          helpText="Do not include personal or financial information, like your National Insurance number or credit card details.">
+          <GoabTextarea name="program" onChange={noop} width="100%" rows={6} maxCount={500} countBy={"word"} />
+        </GoabFormItem>
+
+    </Sandbox>
+  )
+}

--- a/src/examples/textarea/TextAreaExamples.tsx
+++ b/src/examples/textarea/TextAreaExamples.tsx
@@ -1,6 +1,8 @@
 import {
   TextAreaAskQuestionMoreInformationExample
 } from "@examples/textarea/TextAreaAskQuestionMoreInformationExample.tsx";
+
+import { TextAreaAskLongQuestionExample } from "@examples/textarea/TextAreaAskLongQuestionExample.tsx";
 import { SandboxHeader } from "@components/sandbox/sandbox-header/sandboxHeader.tsx";
 
 export const TextAreaExamples = () => {
@@ -11,6 +13,12 @@ export const TextAreaExamples = () => {
         figmaExample="https://www.figma.com/design/aIRjvBzpIUH0GbkffjbL04/%E2%9D%96-Patterns-library-%7C-DDD?node-id=6311-137633&t=X0IQW5flDDaj8Vyg-4">
       </SandboxHeader>
       <TextAreaAskQuestionMoreInformationExample/>
+
+      <SandboxHeader
+        exampleTitle="Ask a long-answer question"
+        figmaExample="https://www.figma.com/design/aIRjvBzpIUH0GbkffjbL04/%E2%9D%96-Patterns-library-%7C-DDD?node-id=6674-70199&t=hnUe1OTZr4PmE2Ka-1">
+      </SandboxHeader>
+      <TextAreaAskLongQuestionExample />
     </>
   )
 }

--- a/src/routes/components/TextArea.tsx
+++ b/src/routes/components/TextArea.tsx
@@ -506,7 +506,7 @@ export default function TextAreaPage() {
             heading={
               <>
                 Examples
-                <GoabBadge type="information" content="1" />
+                <GoabBadge type="information" content="2" />
               </>
             }
           >


### PR DESCRIPTION
This PR adds a  `textarea` example for asking a question with a long response.

<img width="858" alt="image" src="https://github.com/user-attachments/assets/7e927b35-8630-4def-81aa-71e77fbe3068" />