### PR TITLE
feat(#2301): pagination - change example label

### DIFF
--- a/src/examples/pagination/PaginationExamples.tsx
+++ b/src/examples/pagination/PaginationExamples.tsx
@@ -61,7 +61,7 @@ export const PaginationExamples = () => {
     <>
 
       <SandboxHeader
-        exampleTitle="Show # results per page"
+        exampleTitle="Set items per page and navigate multiple pages in a table"
         figmaExample="https://www.figma.com/design/aIRjvBzpIUH0GbkffjbL04/%E2%9D%96-Patterns-library-%7C-DDD?node-id=6311-118312&t=X0IQW5flDDaj8Vyg-4">
       </SandboxHeader>
       <Sandbox fullWidth skipRender>


### PR DESCRIPTION
Change label of example from "Show # results per page" to "Set items per page and navigate multiple pages in a table"

From: 
![image](https://github.com/user-attachments/assets/640422f4-4ca5-43f3-bd8d-2428cbf2d907)

To:
![image](https://github.com/user-attachments/assets/60040c20-bbad-49e4-97d6-e9319bde2f7a)
