### PR TITLE
fix(#2764): docs mistype in upgrade guide

### DIFF
--- a/src/routes/get-started/developers/upgrade-guide/components.ts
+++ b/src/routes/get-started/developers/upgrade-guide/components.ts
@@ -1231,7 +1231,7 @@ export const components: UpgradedComponent[] = [
       {
         name: "onChange",
         v5: "(name: string, value: string) => void;",
-        v6: "(details: GoabTextAreaOnKeyPressDetail) => void;",
+        v6: "(details: GoabTextAreaOnChangeDetail) => void;",
       },
       {
         name: "onKeyPress",


### PR DESCRIPTION
Story https://github.com/GovAlta/ui-components/issues/2764