### PR TITLE
fix(#2829): remove role attribute from modal

### DIFF
--- a/src/examples/add-another-item-in-a-modal.tsx
+++ b/src/examples/add-another-item-in-a-modal.tsx
@@ -41,7 +41,6 @@ export const AddAnotherItemInAModal = () => {
 
         <GoabModal
           heading="Add a new item"
-          role="dialog"
           open={addItemModalOpen}
           actions={
             <GoabButtonGroup alignment="end">
@@ -143,7 +142,7 @@ export const AddAnotherItemInAModal = () => {
         allowCopy={true}
         code={`
                   <goa-button type="tertiary" leadingicon="add" (_click)="toggleModal()">Add another item</goa-button>
-                  <goa-modal [open]="open" role="dialog"
+                  <goa-modal [open]="open"
                     (_close)="toggleModal()" heading="Add a new item">
                     <p>Fill in the information to create a new item</p>
                     <goa-form-item label="Type" mt="xs">
@@ -174,7 +173,7 @@ export const AddAnotherItemInAModal = () => {
         allowCopy={true}
         code={`
         <goab-button type="tertiary" leadingIcon="add" (onClick)="toggleModal()">Add another item</goab-button>
-        <goab-modal [open]="open" role="dialog"
+        <goab-modal [open]="open"
            (onClose)="toggleModal()" heading="Add a new item" [actions]="actions">
           <p>Fill in the information to create a new item</p>
           <goab-form-item label="Type" mt="xs">
@@ -259,7 +258,6 @@ export const AddAnotherItemInAModal = () => {
                   </GoAButton>
                    <GoAModal
                     heading="Add a new item"
-                    role="dialog"
                     open={open}
                     actions={
                       <GoAButtonGroup alignment="end">
@@ -297,7 +295,6 @@ export const AddAnotherItemInAModal = () => {
                   </GoabButton>
                    <GoabModal
                     heading="Add a new item"
-                    role="dialog"
                     open={open}
                     actions={
                       <GoabButtonGroup alignment="end">

--- a/src/examples/confirm-a-change.tsx
+++ b/src/examples/confirm-a-change.tsx
@@ -29,7 +29,6 @@ export const ConfirmAChange = () => {
 
         <GoabModal
           heading="Address has changed"
-          role="dialog"
           open={inputModalOpen}
           actions={
             <GoabButtonGroup alignment="end">
@@ -120,7 +119,7 @@ export const ConfirmAChange = () => {
         allowCopy={true}
         code={`
                   <goa-button (_click)="toggleModal()">Save and continue</goa-button>
-                  <goa-modal [open]="open" role="dialog"
+                  <goa-modal [open]="open"
                     (_close)="toggleModal()" heading="Address has changed">
                       <goa-container type="non-interactive" accent="filled" padding="compact" width="full">
                         <dl class="address-change-example--description">
@@ -156,7 +155,7 @@ export const ConfirmAChange = () => {
         allowCopy={true}
         code={`
           <goab-button (onClick)="toggleModal()">Save and continue</goab-button>
-          <goab-modal [open]="open" role="dialog"
+          <goab-modal [open]="open"
            (onClose)="toggleModal()" heading="Address has changed" [actions]="actions">
             <goab-container type="non-interactive" accent="filled" padding="compact" width="full">
               <dl class="address-change-example--description">
@@ -221,7 +220,6 @@ export const ConfirmAChange = () => {
                   <GoAButton onClick={() => setOpen(true)}>Save and continue</GoAButton>
                   <GoAModal
                     heading="Address has changed"
-                    role="dialog"
                     open={open}
                     onClose={() => setOpen(false)}
                     actions={
@@ -262,7 +260,6 @@ export const ConfirmAChange = () => {
                   <GoabButton onClick={() => setOpen(true)}>Save and continue</GoabButton>
                   <GoabModal
                     heading="Address has changed"
-                    role="dialog"
                     open={open}
                     onClose={() => setOpen(false)}
                     actions={

--- a/src/examples/confirm-a-destructive-action.tsx
+++ b/src/examples/confirm-a-destructive-action.tsx
@@ -18,7 +18,6 @@ export const ConfirmADestructiveAction = () => {
       <GoabModal
         heading="Are you sure you want to delete this record?"
         open={destructiveModalOpen}
-        role="alertdialog"
         actions={
           <GoabButtonGroup alignment="end">
             <GoabButton type="tertiary" onClick={() => setDestructiveModalOpen(false)}>
@@ -57,7 +56,7 @@ export const ConfirmADestructiveAction = () => {
           allowCopy={true}
           code={`
                   <goa-button type="tertiary" leadingIcon="trash" (_click)="toggleModal()">Delete record</goa-button>
-                  <goa-modal [open]="open" role="alertdialog" (_close)="toggleModal()" heading="Are you sure you want to delete this record?">
+                  <goa-modal [open]="open" (_close)="toggleModal()" heading="Are you sure you want to delete this record?">
                       <p>This action cannot be undone.</p>
                     <div slot="actions">
                       <goa-button-group alignment="end">
@@ -76,7 +75,7 @@ export const ConfirmADestructiveAction = () => {
           allowCopy={true}
           code={`
             <goab-button type="tertiary" leadingIcon="trash" (onClick)="toggleModal()">Delete record</goab-button>
-            <goab-modal [open]="open" role="alertdialog" (onClose)="toggleModal()" heading="Are you sure you want to delete this record?" [actions]="actions">
+            <goab-modal [open]="open" (onClose)="toggleModal()" heading="Are you sure you want to delete this record?" [actions]="actions">
               <p>This action cannot be undone.</p>
               <ng-template #actions>
                 <goab-button-group alignment="end">
@@ -109,7 +108,6 @@ export const ConfirmADestructiveAction = () => {
                   <GoAModal
                     heading="Are you sure you want to delete this record?"
                     open={open}
-                    role="alertdialog"
                     onClose={() => setOpen(false)}
                     actions={
                       <GoAButtonGroup alignment="end">
@@ -138,7 +136,6 @@ export const ConfirmADestructiveAction = () => {
                   <GoabModal
                     heading="Are you sure you want to delete this record?"
                     open={open}
-                    role="alertdialog"
                     onClose={() => setOpen(false)}
                     actions={
                       <GoabButtonGroup alignment="end">

--- a/src/examples/confirm-before-navigating-away.tsx
+++ b/src/examples/confirm-before-navigating-away.tsx
@@ -45,7 +45,7 @@ export const ConfirmBeforeNavigatingAway = () => {
           allowCopy={true}
           code={`
                   <goa-button (_click)="onOpen();">Open</goa-button>
-                  <goa-modal [open]="open" role="alertdialog" heading="Are you sure you want to change route?">
+                  <goa-modal [open]="open" heading="Are you sure you want to change route?">
                     <div slot="actions">
                       <goa-button-group alignment="end">
                         <goa-button type="secondary" (_click)="onClose()">Cancel</goa-button>
@@ -62,7 +62,7 @@ export const ConfirmBeforeNavigatingAway = () => {
           allowCopy={true}
           code={`
                   <goab-button (onClick)="onOpen();">Open</goab-button>
-                  <goab-modal [open]="open" role="alertdialog" heading="Are you sure you want to change route?" [actions]="actions">
+                  <goab-modal [open]="open" heading="Are you sure you want to change route?" [actions]="actions">
                     <ng-template #actions>
                       <goab-button-group alignment="end">
                         <goab-button type="secondary" (onClick)="onClose()">Cancel</goab-button>
@@ -98,7 +98,6 @@ export const ConfirmBeforeNavigatingAway = () => {
                   <GoAModal
                     heading="Are you sure you want to change route?"
                     open={open}
-                    role="alertdialog"
                     onClose={() => setOpen(false)}
                     actions={
                       <GoAButtonGroup alignment="end">
@@ -127,7 +126,6 @@ export const ConfirmBeforeNavigatingAway = () => {
                   <GoabModal
                     heading="Are you sure you want to change route?"
                     open={open}
-                    role="alertdialog"
                     onClose={() => setOpen(false)}
                     actions={
                       <GoabButtonGroup alignment="end">

--- a/src/examples/require-user-action-before-continuing.tsx
+++ b/src/examples/require-user-action-before-continuing.tsx
@@ -12,7 +12,6 @@ export const RequireUserActionBeforeContinuing = () => {
       <GoabButton onClick={() => setBasicModalOpen(true)}>Open Basic Modal</GoabButton>
       <GoabModal
         heading="Are you sure you want to continue?"
-        role="dialog"
         open={basicModalOpen}
         onClose={() => setBasicModalOpen(false)}
         actions={
@@ -101,7 +100,6 @@ export const RequireUserActionBeforeContinuing = () => {
                   <GoAButton onClick={() => setOpen(true)}>Open Basic Modal</GoAButton>
                   <GoAModal
                     heading="Are you sure you want to continue?"
-                    role="dialog"
                     open={open}
                     onClose={() => setOpen(false)}
                     actions={
@@ -130,7 +128,6 @@ export const RequireUserActionBeforeContinuing = () => {
                   <GoabButton onClick={() => setOpen(true)}>Open Basic Modal</GoabButton>
                   <GoabModal
                     heading="Are you sure you want to continue?"
-                    role="dialog"
                     open={open}
                     onClose={() => setOpen(false)}
                     actions={

--- a/src/examples/warn-a-user-of-a-deadline.tsx
+++ b/src/examples/warn-a-user-of-a-deadline.tsx
@@ -8,19 +8,13 @@ export const WarnAUserOfADeadline = () => {
   const {version} = useContext(LanguageVersionContext);
   const [warnCalloutModalOpen, setWarnCalloutModalOpen] = useState<boolean>();
   return (
-    <Sandbox skipRender
-             note={{
-               type: "important",
-               heading: "AlertDialog Accessibility",
-               content: "Do not make the modal closeable or add any focusable elements before the action button when using an AlertDialog. This ensures that the screen reader will announce the full content."
-             }}>
+    <Sandbox skipRender>
       <GoabButton type="secondary" onClick={() => setWarnCalloutModalOpen(true)}>
         Save for later
       </GoabButton>
       <GoabModal
         heading="Complete submission prior to 1PM"
         calloutVariant="important"
-        role="alertdialog"
         open={warnCalloutModalOpen}
         onClose={() => setWarnCalloutModalOpen(false)}
         actions={
@@ -58,7 +52,7 @@ export const WarnAUserOfADeadline = () => {
           allowCopy={true}
           code={`
                   <goa-button type="secondary" (_click)="toggleModal()">Save for later</goa-button>
-                  <goa-modal [open]="open" role="alertdialog" calloutvariant="important"
+                  <goa-modal [open]="open" calloutvariant="important"
                     (_close)="toggleModal()" heading="Complete submission prior to 1PM">
                       <p>You’ve selected to adjourn a matter that is required to appear today. This Calgary court location does not accept adjournment requests past 1PM MST. Please submit your adjournment request as soon as possible.</p>
                     <div slot="actions">
@@ -79,7 +73,7 @@ export const WarnAUserOfADeadline = () => {
           allowCopy={true}
           code={`
           <goab-button type="secondary" (onClick)="toggleModal()">Save for later</goab-button>
-          <goab-modal [open]="open" role="alertdialog" calloutVariant="important"
+          <goab-modal [open]="open" calloutVariant="important"
             (onClose)="toggleModal()" heading="Complete submission prior to 1PM" [actions]="actions">
             <p>You’ve selected to adjourn a matter that is required to appear today. This Calgary court location does not accept adjournment requests past 1PM MST. Please submit your adjournment request as soon as possible.</p>
             <ng-template #actions>
@@ -115,7 +109,6 @@ export const WarnAUserOfADeadline = () => {
                     heading="Complete submission prior to 1PM"
                     open={open}
                     calloutVariant="important"
-                    role="alertdialog"
                     onClose={() => setOpen(false)}
                     actions={
                       <GoAButtonGroup alignment="end">
@@ -140,7 +133,6 @@ export const WarnAUserOfADeadline = () => {
                     heading="Complete submission prior to 1PM"
                     open={open}
                     calloutVariant="important"
-                    role="alertdialog"
                     onClose={() => setOpen(false)}
                     actions={
                       <GoabButtonGroup alignment="end">

--- a/src/routes/components/Modal.tsx
+++ b/src/routes/components/Modal.tsx
@@ -44,7 +44,6 @@ export default function ModalPage() {
   const {language} = useContext(LanguageVersionContext);
   const [componentProps, setComponentProps] = useState<ComponentPropsType>({
     heading: "Are you sure you want to exit your application?",
-    role: "alertdialog",
   });
 
   useEffect(() => {
@@ -87,14 +86,6 @@ export default function ModalPage() {
       type: "boolean",
       name: "closable",
       value: false,
-    },
-    {
-      label: "Role",
-      type: "list",
-      name: "role",
-      options: ["", "dialog", "alertdialog"],
-      value: "alertdialog",
-      helpText: "Select an ARIA role to determine what is announced by the screen reader.",
     },
     {
       label: "Open",
@@ -159,13 +150,6 @@ export default function ModalPage() {
       lang: "angular",
     },
     {
-      name: "role",
-      type: "dialog | alertdialog",
-      description:
-        "'dialog' will announce header and the 1st input element, and requires at least one interactive element. 'alert-dialog' will read the entire contents of the modal. If the modal does not include any interactive elements, use the 'alertdialog' role.",
-      defaultValue: "dialog",
-    },
-    {
       name: "_close",
       type: "CustomEvent",
       description: "",
@@ -225,13 +209,6 @@ export default function ModalPage() {
       type: "boolean",
       description: "Show close icon and allow clicking the background to close the modal",
       defaultValue: "false",
-    },
-    {
-      name: "role",
-      type: "dialog | alertdialog",
-      description:
-        "'dialog' will announce header and the 1st input element, and requires at least one interactive element. 'alert-dialog' will read the entire contents of the modal. If the modal does not include any interactive elements, use the 'alertdialog' role.",
-      defaultValue: "dialog",
     },
     TestIdProperty,
     {


### PR DESCRIPTION
Follow up the story #2829 remove role="alertdialog" from the modal