### PR TITLE
Bug fix: mobile language switcher controls breaking on mobile

### DIFF
--- a/src/components/version-language-switcher/HelpButton.tsx
+++ b/src/components/version-language-switcher/HelpButton.tsx
@@ -24,9 +24,9 @@ export function HelpButton() {
   };
 
   return (
-    <GoabTooltip content="More information">
-      <GoabIconButton ml={"s"}
-                      mr={"s"}
+    <GoabTooltip content="Version and framework info">
+      <GoabIconButton ml={"xs"}
+                      mb={"2xs"}
                       variant="color"
                       size="small"
                       icon="help-circle"

--- a/src/components/version-language-switcher/VersionLanguageSwitcher.tsx
+++ b/src/components/version-language-switcher/VersionLanguageSwitcher.tsx
@@ -1,6 +1,6 @@
 import {
   GoabIcon,
-  GoabPopover, GoabTooltip
+  GoabPopover
 } from "@abgov/react-components";
 import {
   ANGULAR_VERSIONS, getVersionedUrlPath, Language, LanguageVersion,
@@ -103,7 +103,7 @@ export const VersionLanguageSwitcher = () => {
 
   return (
     <>
-      <GoabTooltip content="Framework">
+      <div className="version-language-switcher">
       <GoabPopover
         target={
           <a className="version-language-switcher__heading" href="#" id="language-switcher" onClick={e => openLanguagePopOver(e)}>
@@ -119,9 +119,7 @@ export const VersionLanguageSwitcher = () => {
           }
         </>
       </GoabPopover>
-      </GoabTooltip>
 
-      <GoabTooltip content="Version">
       <GoabPopover target={
         <a className="version-language-switcher__heading" href="#"
            onClick={e => openVersionPopOver(e)}>
@@ -136,7 +134,7 @@ export const VersionLanguageSwitcher = () => {
           ))}
         </>
       </GoabPopover>
-      </GoabTooltip>
+      </div>
     </>
   );
 }

--- a/src/components/version-language-switcher/version-language-switcher.css
+++ b/src/components/version-language-switcher/version-language-switcher.css
@@ -3,7 +3,6 @@
     align-items: center;
     gap: var(--goa-space-2xs);
     font-size: var(--goa-font-size-2);
-    margin-left: var(--goa-space-m);
     white-space: nowrap;
     height: 20px;
 }
@@ -30,13 +29,30 @@
     align-items: center; /* vertically align content */
 }
 
+.version-language-switcher {
+    height: 20px;
+    display: flex;
+    flex-direction: row;
+    align-items: center; /* vertically align content */
+    gap: var(--goa-space-s);
+    margin-bottom: var(--goa-space-xs);
+}
+
 @media (max-width: 623px) {
     [slot="version"] {
         display: flex; /* if needed to align items horizontally */
+        flex-direction: row;
+        align-items: flex-start;
+        gap: 0;
+        margin-top: 0;
+        height: auto;
+    }
+
+    .version-language-switcher {
+        height: auto;
         flex-direction: column;
         align-items: flex-start;
-        gap: 2px;
-        margin-top: 0;
-
+        gap: 0;
+        margin-bottom: var(--goa-space-3xs);
     }
 }


### PR DESCRIPTION
### Bug: language switcher controls on mobile menu in microsite header  breaks on mobile, overlaps with app header menu

<img width="707" height="1191" alt="image" src="https://github.com/user-attachments/assets/da478455-6a4d-437a-9dce-158b225066dc" />

### Fix: language switcher controls on mobile menu in microsite header stacks correctly on mobile

<img width="707" height="1191" alt="image" src="https://github.com/user-attachments/assets/8ea0a445-fc82-4ae6-a0c7-0db9806e9a04" />
