### PR TITLE
fix spacing inconsistencies across foundation and design token pages

### DIFF
--- a/src/components/empty-states/accessibility-empty/AccessibilityEmpty.tsx
+++ b/src/components/empty-states/accessibility-empty/AccessibilityEmpty.tsx
@@ -13,7 +13,7 @@ export function AccessibilityEmpty(props: Props) {
             component&nbsp;page&nbsp;in&nbsp;Figma.
           </a>{" "}
         </GoabText>
-        <GoabText size="body-m" mb="none" mt="m">
+        <GoabText size="body-m" mb="none" mt="none">
           More accessibility guidance for design and development is coming soon.
         </GoabText>
       </GoabContainer>

--- a/src/routes/design-tokens/border-radius/BorderRadius.tsx
+++ b/src/routes/design-tokens/border-radius/BorderRadius.tsx
@@ -1,5 +1,5 @@
 import { useContext } from "react";
-import { GoabContainer, GoabGrid, GoabTable } from "@abgov/react-components";
+import { GoabContainer, GoabGrid, GoabTable, GoabText } from "@abgov/react-components";
 import { TokenSnippet } from "@components/token-snippet/TokenSnippet";
 import "./BorderRadius.css";
 import { Token } from "../token";
@@ -120,7 +120,7 @@ export default function BorderRadiusPage() {
 
   return (
     <ComponentContent contentClassName="border-radius-page">
-      <h1>Border Radius</h1>
+      <GoabText size="heading-xl" mb="m" mt="xl">Border Radius</GoabText>
       {isDesktop ? renderDesktop() : renderMobile()}
     </ComponentContent>
   );

--- a/src/routes/design-tokens/border-width/BorderWidth.tsx
+++ b/src/routes/design-tokens/border-width/BorderWidth.tsx
@@ -1,5 +1,5 @@
 import { useContext } from "react";
-import { GoabContainer, GoabGrid, GoabTable } from "@abgov/react-components";
+import { GoabContainer, GoabGrid, GoabTable, GoabText } from "@abgov/react-components";
 import { TokenSnippet } from "@components/token-snippet/TokenSnippet";
 import "./BorderWidth.css";
 import { Token } from "../token";
@@ -118,7 +118,7 @@ export default function BorderWidthPage() {
 
   return (
     <ComponentContent contentClassName="border-width-page">
-      <h1>Border Width</h1>
+      <GoabText size="heading-xl" mb="m" mt="xl">Border Width</GoabText>
       {isDesktop ? renderDesktop() : renderMobile()}
     </ComponentContent>
   );

--- a/src/routes/design-tokens/color/Color.tsx
+++ b/src/routes/design-tokens/color/Color.tsx
@@ -110,7 +110,7 @@ export default function ColorPage() {
 
   return (
     <ComponentContent contentClassName="colors-page">
-      <h1>Color</h1>
+      <GoabText size="heading-xl" mb="none" mt="xl">Color</GoabText>
       {isDesktop ? renderDesktop() : renderTablet()}
     </ComponentContent>
   );

--- a/src/routes/design-tokens/icon-size/IconSize.tsx
+++ b/src/routes/design-tokens/icon-size/IconSize.tsx
@@ -1,4 +1,4 @@
-import { GoabContainer, GoabGrid, GoabIcon, GoabTable } from "@abgov/react-components";
+import { GoabContainer, GoabGrid, GoabIcon, GoabTable, GoabText } from "@abgov/react-components";
 import { TokenSnippet } from "@components/token-snippet/TokenSnippet";
 import "./IconSize.css";
 import { getTokenGroups } from "../getTokenGroups";
@@ -138,7 +138,7 @@ export default function IconSizePage() {
 
   return (
     <ComponentContent contentClassName="icon-size">
-      <h1>Icon size</h1>
+      <GoabText size="heading-xl" mb="m" mt="xl">Icon size</GoabText>
       {isDesktop ? renderDesktop() : renderMobile()}
     </ComponentContent>
   );

--- a/src/routes/design-tokens/opacity/Opacity.tsx
+++ b/src/routes/design-tokens/opacity/Opacity.tsx
@@ -1,4 +1,4 @@
-import { GoabContainer, GoabGrid, GoabTable } from "@abgov/react-components";
+import { GoabContainer, GoabGrid, GoabTable, GoabText } from "@abgov/react-components";
 import { TokenSnippet } from "@components/token-snippet/TokenSnippet";
 import "./Opacity.css";
 import { getTokenGroups } from "../getTokenGroups";
@@ -94,7 +94,7 @@ export default function OpacityPage() {
 
   return (
     <ComponentContent contentClassName="opacity-page">
-      <h1>Opacity</h1>
+      <GoabText size="heading-xl" mb="m" mt="xl">Opacity</GoabText>
       {isDesktop ? renderDesktop() : renderMobile()}
     </ComponentContent>
   );

--- a/src/routes/design-tokens/shadow/Shadow.tsx
+++ b/src/routes/design-tokens/shadow/Shadow.tsx
@@ -1,4 +1,4 @@
-import { GoabContainer, GoabGrid, GoabTable } from "@abgov/react-components";
+import { GoabContainer, GoabGrid, GoabTable, GoabText } from "@abgov/react-components";
 import { TokenSnippet } from "@components/token-snippet/TokenSnippet";
 import "./Shadow.css";
 import { getTokenGroups } from "../getTokenGroups";
@@ -110,7 +110,7 @@ export default function ShadowPage() {
 
   return (
     <ComponentContent contentClassName="shadow-page">
-      <h1>Shadow</h1>
+      <GoabText size="heading-xl" mb="m" mt="xl">Shadow</GoabText>
       {isDesktop ? renderDesktop() : renderMobile()}
     </ComponentContent>
   );

--- a/src/routes/design-tokens/spacing/Spacing.tsx
+++ b/src/routes/design-tokens/spacing/Spacing.tsx
@@ -1,4 +1,4 @@
-import { GoabContainer, GoabGrid, GoabTable } from "@abgov/react-components";
+import { GoabContainer, GoabGrid, GoabTable, GoabText } from "@abgov/react-components";
 import { TokenSnippet } from "@components/token-snippet/TokenSnippet";
 import "./Spacing.css";
 import SPACING_TOKENS from "./spacing.json";
@@ -90,7 +90,7 @@ export default function SpacingPage() {
 
   return (
     <ComponentContent contentClassName="spacing-page">
-      <h1>Spacing</h1>
+      <GoabText size="heading-xl" mb="m" mt="xl">Spacing</GoabText>
       {isDesktop ? renderDesktop() : renderMobile()}
     </ComponentContent>
   );

--- a/src/routes/design-tokens/typography/Typography.tsx
+++ b/src/routes/design-tokens/typography/Typography.tsx
@@ -1,4 +1,4 @@
-import { GoabContainer, GoabGrid, GoabTable } from "@abgov/react-components";
+import { GoabContainer, GoabGrid, GoabTable, GoabText } from "@abgov/react-components";
 import { TokenSnippet } from "@components/token-snippet/TokenSnippet";
 import TYPO_TOKENS from "./typography.json";
 import { getTokenGroups } from "../getTokenGroups";
@@ -81,7 +81,7 @@ export default function TypographyPage() {
   return (
     <ComponentContent>
       <div style={{ whiteSpace: "normal" }}>
-        <h1>Typography</h1>
+        <GoabText size="heading-xl" mb="m" mt="xl">Typography</GoabText>
         {isDesktop ? renderDesktop() : renderMobile()}
       </div>
     </ComponentContent>

--- a/src/routes/foundations/Accessibility.tsx
+++ b/src/routes/foundations/Accessibility.tsx
@@ -8,7 +8,7 @@ export default function AccessibilityPage() {
         <GoabText size="heading-xl" mb="m" mt="xl">
           Accessibility
         </GoabText>
-        <GoabText size="heading-m" mb="xl">
+        <GoabText size="body-l" mt="none" mb="xl">
           We aim to create digital products that everyone can use, no matter their abilities or situation. This guide
           outlines key principles, design tips, and tools to help create accessible and inclusive experiences.
         </GoabText>

--- a/src/routes/foundations/BrandGuidelines.tsx
+++ b/src/routes/foundations/BrandGuidelines.tsx
@@ -7,7 +7,7 @@ export default function BrandGuidelinesPage() {
         <GoabText size="heading-xl" mb="m" mt="xl">
           Brand guidelines
         </GoabText>
-        <GoabText size="heading-m" mb="xl">
+        <GoabText size="body-l" mt="none" mb="xl">
           Communications and Public Engagement (CPE) plays an important role in providing and maintaining brand identity
           guidelines across the Government of Alberta. These guidelines ensure all digital products are consistent and
           easily recognizable, building trust with users.

--- a/src/routes/foundations/Capitalization.tsx
+++ b/src/routes/foundations/Capitalization.tsx
@@ -8,10 +8,11 @@ export default function CapitalizationPage() {
   return (
     <ComponentContent tocCssQuery="h2[id], h3[id]">
 
-      <GoabText size="heading-xl" mb="m" mt="xl">
+      <GoabText size="heading-m" mt="xl" mb="xs">Content guidelines</GoabText>
+      <GoabText size="heading-xl" mb="m" mt="none">
         Capitalization
       </GoabText>
-      <GoabText size="heading-m" mb="xl">
+      <GoabText size="body-l" mt="none" mb="xl">
         Use sentence case for all headings, labels, and content.
       </GoabText>
 

--- a/src/routes/foundations/Color.tsx
+++ b/src/routes/foundations/Color.tsx
@@ -5,10 +5,11 @@ export default function FoundationsColorPage() {
   return (
       <ComponentContent tocCssQuery="h2[id], h3[id]">
 
-        <GoabText size="heading-xl" mb="m" mt="xl">
+        <GoabText size="heading-m" mt="xl" mb="xs">Style guide</GoabText>
+        <GoabText size="heading-xl" mb="m" mt="none">
           Color
         </GoabText>
-        <GoabText size="heading-m" mb="xl">
+        <GoabText size="body-l" mt="none" mb="xl">
           Colors play a major role in how the Government of Alberta communicates. They serve as a tool to convey
           clarity,
           express emotions, and promote inclusivity.

--- a/src/routes/foundations/DateFormat.tsx
+++ b/src/routes/foundations/DateFormat.tsx
@@ -7,10 +7,11 @@ const minGridWidth = "36ch";
 export default function DateFormatPage() {
   return (
     <ComponentContent tocCssQuery="h2[id], h3[id]">
-      <GoabText size="heading-xl" mb="m" mt="xl">
+      <GoabText size="heading-m" mt="xl" mb="xs">Content guidelines</GoabText>
+      <GoabText size="heading-xl" mb="m" mt="none">
         Date format
       </GoabText>
-      <GoabText size="heading-m" mb="xl">
+      <GoabText size="body-l" mt="none" mb="xl">
         Configuration which contains date information that includes the specification of the form and structure of the
         date data within the date format in different scenarios.
       </GoabText>

--- a/src/routes/foundations/DesignAtGoA.tsx
+++ b/src/routes/foundations/DesignAtGoA.tsx
@@ -7,7 +7,7 @@ export default function DesignAtGoAPage() {
         <GoabText size="heading-xl" mb="m" mt="xl">
           Design at the Government of Alberta
         </GoabText>
-        <GoabText size="body-l" mb="2xl">
+        <GoabText size="body-l" mt="none" mb="2xl">
           Citizens expect digital products that are modern, easy to use, and consistent. To meet these needs, our
           digital products must follow our user experience guidelines and should be tested frequently to make continuous
           improvement and stay relevant.

--- a/src/routes/foundations/ErrorMessages.tsx
+++ b/src/routes/foundations/ErrorMessages.tsx
@@ -18,11 +18,12 @@ export default function ErrorMessagesPage() {
   const noop = () => { };
   return (
     <ComponentContent tocCssQuery="h2[id], h3[id]">
-      <GoabText size="heading-xl" mb="m" mt="xl">
+      <GoabText size="heading-m" mt="xl" mb="xs">Content guidelines</GoabText>
+      <GoabText size="heading-xl" mb="m" mt="none">
         Error messages
       </GoabText>
-      <GoabText size="heading-m" mb="xl">
-        Error messages appear when the user’s proposed action fails.
+      <GoabText size="body-l" mt="none" mb="xl">
+        Error messages appear when the user's proposed action fails.
       </GoabText>
 
       <GoabDivider mb="2xl" mt="2xl"></GoabDivider>

--- a/src/routes/foundations/HelperText.tsx
+++ b/src/routes/foundations/HelperText.tsx
@@ -19,10 +19,11 @@ export default function HelperTextPage() {
   return (
     <ComponentContent tocCssQuery="h2[id], h3[id]">
 
-      <GoabText size="heading-xl" mb="m" mt="xl">
+      <GoabText size="heading-m" mt="xl" mb="xs">Content guidelines</GoabText>
+      <GoabText size="heading-xl" mb="m" mt="none">
         Helper text
       </GoabText>
-      <GoabText size="heading-m" mb="m">
+      <GoabText size="body-l" mt="none" mb="m">
         Additional context and guidance that is always visible below an input. The
         text instructs a user on what needs to be completed to move to the next question in the form
         or process.

--- a/src/routes/foundations/Iconography.tsx
+++ b/src/routes/foundations/Iconography.tsx
@@ -75,10 +75,11 @@ export default function IconographyPage() {
 
   return (
       <ComponentContent tocCssQuery="h2[id], h3[id]">
-        <GoabText size="heading-xl" mb="m" mt="xl">
+        <GoabText size="heading-m" mt="xl" mb="xs">Style guide</GoabText>
+        <GoabText size="heading-xl" mb="m" mt="none">
           Iconography
         </GoabText>
-        <GoabText size="heading-m" mb="xl">
+        <GoabText size="body-l" mt="none" mb="xl">
           Icons are simple and universal graphic symbols that communicate and enhance both the aesthetic and functional
           aspects
           of our products. While they can be used with descriptors, they can also be self-expressive and convey meaning

--- a/src/routes/foundations/Layout.tsx
+++ b/src/routes/foundations/Layout.tsx
@@ -6,10 +6,11 @@ export default function FoundationsLayoutPage() {
   return (
     
       <ComponentContent tocCssQuery="h2[id], h3[id]">
-        <GoabText size="heading-xl" mb="m" mt="xl">
+        <GoabText size="heading-m" mt="xl" mb="xs">Style guide</GoabText>
+        <GoabText size="heading-xl" mb="m" mt="none">
           Layout
         </GoabText>
-        <GoabText size="heading-m" mb="xl">
+        <GoabText size="body-l" mt="none" mb="xl">
           We use the layout as a structural template to support consistency across our products. By defining visual
           grids,
           spacing, and sections, we create intuitive products for our users.

--- a/src/routes/foundations/Logo.tsx
+++ b/src/routes/foundations/Logo.tsx
@@ -4,10 +4,11 @@ import { ComponentContent } from "@components/component-content/ComponentContent
 export default function LogoPage() {
   return (
       <ComponentContent tocCssQuery="h2[id], h3[id]">
-        <GoabText size="heading-xl" mb="m" mt="xl">
+        <GoabText size="heading-m" mt="xl" mb="xs">Style guide</GoabText>
+        <GoabText size="heading-xl" mb="m" mt="none">
           Logo
         </GoabText>
-        <GoabText size="heading-m" mb="xl">
+        <GoabText size="body-l" mt="none" mb="xl">
           Our logo is an important part of our brand identity and serves as a symbol that distinguishes our digital
           products
           from others. To keep our brand consistent and recognizable, we encourage following the guidelines for proper

--- a/src/routes/foundations/Photography.tsx
+++ b/src/routes/foundations/Photography.tsx
@@ -4,10 +4,11 @@ import { ComponentContent } from "@components/component-content/ComponentContent
 export default function ImagesPage() {
   return (
       <ComponentContent>
-        <GoabText size="heading-xl" mb="m" mt="xl">
+        <GoabText size="heading-m" mt="xl" mb="xs">Style guide</GoabText>
+        <GoabText size="heading-xl" mb="m" mt="none">
           Photography
         </GoabText>
-        <GoabText size="heading-m" mb="xl">
+        <GoabText size="body-l" mt="none" mb="xl">
           The Government of Alberta maintains a library of photos specifically taken for government use, ensuring they
           are
           relevant to our citizens. This collection meets our established criteria for quality and accessibility.

--- a/src/routes/foundations/Typography.tsx
+++ b/src/routes/foundations/Typography.tsx
@@ -6,10 +6,11 @@ export default function FoundationsTypographyPage() {
 
   return (
       <ComponentContent tocCssQuery="h2[id], h3[id]">
-        <GoabText size="heading-xl" mb="m" mt="xl">
+        <GoabText size="heading-m" mt="xl" mb="xs">Style guide</GoabText>
+        <GoabText size="heading-xl" mb="m" mt="none">
           Typography
         </GoabText>
-        <GoabText size="heading-m" mb="xl">
+        <GoabText size="body-l" mt="none" mb="xl">
           Our typography system is designed to create a consistent and accessible experience across all Government of
           Alberta
           digital products. When paired with an effective content strategy, it enhances accessibility and makes content

--- a/src/routes/get-started/ComponentLifecycle.tsx
+++ b/src/routes/get-started/ComponentLifecycle.tsx
@@ -7,7 +7,7 @@ export default function ComponentLifecyclePage() {
         <GoabText size="heading-xl" mb="m" mt="xl">
           Component lifecycle
         </GoabText>
-      <GoabText size="body-l" mb="none">
+      <GoabText size="body-l" mt="none" mb="none">
           This lifecycle defines the stages every component in the Design System undergoes, from Alpha to Production to Legacy. Each stage describes the component's maturity, adoption level, and support status.<br /><br />
       </GoabText>
       <GoabText size="body-m" mb="2xl">

--- a/src/routes/get-started/GetStartedOverview.tsx
+++ b/src/routes/get-started/GetStartedOverview.tsx
@@ -13,13 +13,13 @@ export default function GetStartedOverviewPage() {
       <GoabText size="heading-xl" mb="m" mt="xl">
         Starting with the design system
       </GoabText>
-      <GoabText size="heading-m" mb="xl">
+      <GoabText size="body-l" mt="none" mb="xl">
         Start with the design system to build on the research and experience of other service teams and avoid
         repeating work that's already been done.
       </GoabText>
 
       <GoabBlock gap="m" direction="row" mb="xl">
-        <GoabText size="heading-s" color="secondary">
+        <GoabText size="heading-s" color="secondary" mt="none">
           Design system by role:
         </GoabText>
         <GoabLink>

--- a/src/routes/get-started/LtsPolicyPage.tsx
+++ b/src/routes/get-started/LtsPolicyPage.tsx
@@ -6,7 +6,7 @@ export const LtsPolicyPage = () => {
     <>
       <GoabText size="heading-xl" mt="xl" mb="m">Long Term Support (LTS)</GoabText>
 
-      <GoabText size="body-l" tag="h3" mb="xl">
+      <GoabText size="body-l" tag="h3" mt="none" mb="xl">
         The Long Term Support (LTS) version will continue to be supported until September 30, 2025. Learn more about what you can expect.
       </GoabText>
 

--- a/src/routes/get-started/ReportBug.tsx
+++ b/src/routes/get-started/ReportBug.tsx
@@ -233,7 +233,7 @@ export default function ReportBugPage() {
         <GoabText size="heading-xl" mb="m" mt="l">
           Report a bug
         </GoabText>
-        <GoabText size="body-l" mb="xl">
+        <GoabText size="body-l" mt="none" mb="xl">
           Let us know if you find a problem or inconsistency in the design system. Providing complete details in your bug report
           helps our team understand, prioritize, and fix the issue faster.
         </GoabText>

--- a/src/routes/get-started/RequestFeature.tsx
+++ b/src/routes/get-started/RequestFeature.tsx
@@ -10,7 +10,7 @@ export default function RequestFeaturePage() {
       <GoabText size="heading-xl" mb="m" mt="l">
         Request a new feature
       </GoabText>
-      <GoabText size="body-l" mb="xl">
+      <GoabText size="body-l" mt="none" mb="xl">
         Anyone can propose a new component or pattern for the design
         system.
       </GoabText>

--- a/src/routes/get-started/Roadmap.tsx
+++ b/src/routes/get-started/Roadmap.tsx
@@ -6,7 +6,7 @@ export default function RoadmapPage() {
     <ComponentContent tocCssQuery="h2[id], h3[id]">
       <GoabText size="heading-xl" mt="xl" mb="m">Roadmap</GoabText>
 
-      <GoabText size="body-l" mb="m">
+      <GoabText size="body-l" mt="none" mb="m">
         A high-level summary of the work the design system team plans to focus on in 2025. Some initiatives span
         multiple phases, meaning they will be continuously worked on across the year.
       </GoabText>

--- a/src/routes/get-started/Support.tsx
+++ b/src/routes/get-started/Support.tsx
@@ -32,7 +32,7 @@ export default function SupportPage() {
       <GoabText size="heading-xl" mt="xl" mb="m">
         Get support
       </GoabText>
-      <GoabText size="body-l">
+      <GoabText size="body-l" mt="none">
         Get help from our team with using the design system, including components, guidelines, best practices, and accessibility.
       </GoabText>
 

--- a/src/routes/get-started/UserExperienceGuidelines.tsx
+++ b/src/routes/get-started/UserExperienceGuidelines.tsx
@@ -4,8 +4,8 @@ export default function UserExperienceGuidelinesPage() {
   return (
     <>
       <GoabText size="heading-m" mt="xl" mb={"xs"}>Designers</GoabText>
-      <GoabText size="heading-xl" mb="m">User experience guidelines</GoabText>
-      <GoabText size="body-l" mb="xl"> Digital products built for the Government of Alberta should comply with these
+      <GoabText size="heading-xl" mt="none" mb="m">User experience guidelines</GoabText>
+      <GoabText size="body-l" mt="none" mb="xl"> Digital products built for the Government of Alberta should comply with these
         guidelines to ensure a quality
         user experience for Albertans.</GoabText>
 

--- a/src/routes/get-started/designers/UxDesigner.tsx
+++ b/src/routes/get-started/designers/UxDesigner.tsx
@@ -6,8 +6,8 @@ export default function UxDesignerPage() {
   return ( <ComponentContent tocCssQuery="h2[id], h3[id]">
 
       <GoabText size="heading-m" mt="xl" mb={"xs"}>Designers</GoabText>
-      <GoabText size="heading-xl" mb="m">Overview</GoabText>
-      <GoabText size="body-l" mb="xl">As a designer, you can consume the design system through Figma. Through Figma you
+      <GoabText size="heading-xl" mt="none" mb="m">Overview</GoabText>
+      <GoabText size="body-l" mt="none" mb="xl">As a designer, you can consume the design system through Figma. Through Figma you
         can use tokens, components, and page templates.</GoabText>
 
 
@@ -65,7 +65,7 @@ export default function UxDesignerPage() {
       </GoabText>
 
       <GoabContainer type="non-interactive" accent="filled" padding="compact" width="content">
-        <GoabText size="body-m">
+        <GoabText size="body-m" mt="none" mb="none">
           <i>For example, you can communicate to your developer:</i> <br />
           The colour is:
           <code> --goa-color-info-default</code> <br />

--- a/src/routes/get-started/developers/BugVerification.tsx
+++ b/src/routes/get-started/developers/BugVerification.tsx
@@ -5,8 +5,8 @@ export default function BugVerificationPage() {
   return (
     <ComponentContent tocCssQuery="h2[id], h3[id]">
       <GoabText size="heading-m" mt="xl" mb={"xs"}>Developers</GoabText>
-      <GoabText size="heading-xl" mb="m">Verify a bug</GoabText>
-      <GoabText size="body-l" mb="xl">
+      <GoabText size="heading-xl" mt="none" mb="m">Verify a bug</GoabText>
+      <GoabText size="body-l" mt="none" mb="xl">
         How to resolve issues with design system components </GoabText>
 
       <GoabText size="body-m" mt="l" mb="l">

--- a/src/routes/get-started/developers/DevelopersOverview.tsx
+++ b/src/routes/get-started/developers/DevelopersOverview.tsx
@@ -7,8 +7,8 @@ export default function DevelopersOverviewPage() {
   return (
     <ComponentContent tocCssQuery="h2[id], h3[id]">
       <GoabText size="heading-m" mt="xl" mb={"xs"}>Developers</GoabText>
-      <GoabText size="heading-xl" mb="m">Overview</GoabText>
-      <GoabText size="body-l" mb="xl">As a developer, you can consume the design system using tokens, components,
+      <GoabText size="heading-xl" mt="none" mb="m">Overview</GoabText>
+      <GoabText size="body-l" mt="none" mb="xl">As a developer, you can consume the design system using tokens, components,
         templates, and the demo application.</GoabText>
 
       <GoabText size="body-m" mt="l" mb="l">

--- a/src/routes/get-started/developers/DevelopersSetup.tsx
+++ b/src/routes/get-started/developers/DevelopersSetup.tsx
@@ -8,8 +8,8 @@ export default function DevelopersSetupPage() {
     <div className="developer-setup">
     <ComponentContent tocCssQuery="h2[id], h3[id]">
       <GoabText size="heading-m" mt="xl" mb={"xs"}>Developers</GoabText>
-      <GoabText size="heading-xl" mb="m">Setup</GoabText>
-      <GoabText size="body-l" mb="m">Once you are setup, you can use the project template to quickly get
+      <GoabText size="heading-xl" mt="none" mb="m">Setup</GoabText>
+      <GoabText size="body-l" mt="none" mb="m">Once you are setup, you can use the project template to quickly get
         started.</GoabText>
       <GoabText size="body-m" mb="2xl"><a href="#templates">View project templates</a></GoabText>
 

--- a/src/routes/get-started/developers/DevelopersTechnologies.tsx
+++ b/src/routes/get-started/developers/DevelopersTechnologies.tsx
@@ -5,8 +5,8 @@ export default function DevelopersTechnologiesPage() {
   return (
     <ComponentContent tocCssQuery="h2[id], h3[id]">
       <GoabText size="heading-m" mt="xl" mb={"xs"}>Developers</GoabText>
-      <GoabText size="heading-xl" mb="m">Technologies</GoabText>
-      <GoabText size="body-l" mb="2xl">An overview of the technologies that make up the design system.</GoabText>
+      <GoabText size="heading-xl" mt="none" mb="m">Technologies</GoabText>
+      <GoabText size="body-l" mt="none" mb="2xl">An overview of the technologies that make up the design system.</GoabText>
 
       <div className="design-system-image">
         <img src="/images/component-thumbnails/design-system-technologies.png" />

--- a/src/routes/get-started/developers/DevelopersVSCode.tsx
+++ b/src/routes/get-started/developers/DevelopersVSCode.tsx
@@ -6,8 +6,8 @@ export default function DevelopersVSCodePage() {
   return (
     <ComponentContent>
       <GoabText size="heading-m" mt="xl" mb={"xs"}>Developers</GoabText>
-      <GoabText size="heading-xl" mb="m">VS Code</GoabText>
-      <GoabText size="body-l" mb="xl">
+      <GoabText size="heading-xl" mt="none" mb="m">VS Code</GoabText>
+      <GoabText size="body-l" mt="none" mb="xl">
         You can use VS Code's autocomplete suggestions for design system components and design tokens.
       </GoabText>
 

--- a/src/routes/get-started/developers/SupportedBrowsers.tsx
+++ b/src/routes/get-started/developers/SupportedBrowsers.tsx
@@ -6,8 +6,8 @@ export default function SupportedBrowsersPage() {
   return (
     <ComponentContent>
       <GoabText size="heading-m" mt="xl" mb={"xs"}>Developers</GoabText>
-      <GoabText size="heading-xl" mb="m">Supported browsers</GoabText>
-      <GoabText size="body-l" mb="2xl">The design system components are tested on the following browsers and devices:
+      <GoabText size="heading-xl" mt="none" mb="m">Supported browsers</GoabText>
+      <GoabText size="body-l" mt="none" mb="2xl">The design system components are tested on the following browsers and devices:
       </GoabText>
 
       <GoabTable width="564px">
@@ -82,13 +82,13 @@ export default function SupportedBrowsersPage() {
 
       <div className="max-width-72ch">
         <GoabContainer type="non-interactive" mt="2xl" width={"content"}>
-          <GoabText size="heading-m" mb="m">
+          <GoabText size="heading-m" mt="none" mb="m">
             Representative mobile OS used in testing
           </GoabText>
-          <GoabText size="body-m">
+          <GoabText size="body-m" mt="none" mb="2xs">
             <strong>Android OS:</strong> 10+
           </GoabText>
-          <GoabText size="body-m">
+          <GoabText size="body-m" mt="none" mb="none">
             <strong>iOS: </strong> 15+
           </GoabText>
         </GoabContainer>

--- a/src/routes/get-started/developers/upgrade-guide/DevelopersUpgrade.tsx
+++ b/src/routes/get-started/developers/upgrade-guide/DevelopersUpgrade.tsx
@@ -13,8 +13,8 @@ export default function DevelopersUpgradePage() {
       <ComponentContent tocCssQuery="h2[id], h3[id]">
 
         <GoabText size="heading-m" mt="xl" mb={"xs"}>Developers</GoabText>
-        <GoabText size="heading-xl" mb="m">Version update guide</GoabText>
-        <GoabText size="body-l" mb="2xl">Step-by-step guide to updating your code from DDD Design System v3 to v4
+        <GoabText size="heading-xl" mt="none" mb="m">Version update guide</GoabText>
+        <GoabText size="body-l" mt="none" mb="2xl">Step-by-step guide to updating your code from DDD Design System v3 to v4
           (Angular) and v5 to v6 (React)</GoabText>
 
         <GoabText size="heading-m" mt="l" mb="l">
@@ -38,8 +38,8 @@ export default function DevelopersUpgradePage() {
           The component is stable and supported in the latest major release. However, we recommend using the <a href="/patterns/public-form">public form pattern</a> for a more modular, flexible, and accessible approach.
         </GoabCallout>
 
-        <GoabContainer mt="xl">
-          <GoabText size="heading-m" mb="m">
+        <GoabContainer mt="xl" mb="l">
+          <GoabText size="heading-m" mt="none" mb="m">
             Major differences between current and new version
           </GoabText>
           <GoabText size="body-m" mt="l">

--- a/src/routes/get-started/qa-testing/QATestingOverview.tsx
+++ b/src/routes/get-started/qa-testing/QATestingOverview.tsx
@@ -8,7 +8,7 @@ export default function QATestingOverviewPage() {
       <GoabText size="heading-xl" mb="m" mt="xl">
         QA Testing
       </GoabText>
-      <GoabText size="body-l" mb="2xl">
+      <GoabText size="body-l" mt="none" mb="2xl">
         Outline of the testing procedure for the DDD design system. The procedure
         ensures that all components function correctly and integrate seamlessly within DDD products.
       </GoabText>

--- a/src/routes/home.tsx
+++ b/src/routes/home.tsx
@@ -80,7 +80,7 @@ const HomePage = () => {
         <GoabDivider mb="2xl" mt="3xl"></GoabDivider>
         <GoabGrid gap="xl" minChildWidth="320px">
           <div>
-            <GoabText size={"heading-l"} mb={"l"}><b> Start by using the design system in your service</b></GoabText>
+            <GoabText size={"heading-l"} mt="none" mb={"l"}><b> Start by using the design system in your service</b></GoabText>
             <GoabText size={"body-m"} mb={"m"}>
               Use the existing components and patterns in the design system to save time and build off of the current
               standard. Typically, these cover around 80% of your service's needs.
@@ -103,8 +103,8 @@ const HomePage = () => {
                            heading="What happens when I need a new or different component or pattern?"
                            headingSize="medium"
             >
-              <GoabText size={"body-m"} mb={"m"}>
-                If a component or pattern doesn’t exists in the design system or doesn’t meet the needs of your users,
+              <GoabText size={"body-m"} mt="none" mb={"m"}>
+                If a component or pattern doesn't exists in the design system or doesn't meet the needs of your users,
                 follow the process below:
               </GoabText>
 
@@ -135,10 +135,10 @@ const HomePage = () => {
         <GoabText size={"heading-l"} mt={"3xl"} mb={"xl"}><b> Additional resources</b></GoabText>
         <GoabGrid gap="xl" minChildWidth="320px">
           <GoabContainer type="non-interactive" accent="filled" padding="relaxed" width="full">
-            <GoabText size={"heading-m"} mb={"m"}>
+            <GoabText size={"heading-m"} mt="none" mb={"m"}>
               Common capabilities: Shared digital services
             </GoabText>
-            <GoabText size={"body-m"} mb={"m"}>
+            <GoabText size={"body-m"} mt="none" mb={"m"}>
               A directory of reusable backend services designed to help you and your team work more efficiently and
               align to government infrastructure standards.
             </GoabText>
@@ -152,10 +152,10 @@ const HomePage = () => {
             </GoabLink>
           </GoabContainer>
           <GoabContainer type="non-interactive" accent="filled" padding="relaxed" width="full">
-            <GoabText size={"heading-m"} mb={"m"}>
+            <GoabText size={"heading-m"} mt="none" mb={"m"}>
               User Experience best practices
             </GoabText>
-            <GoabText size={"body-m"} mb={"m"}>
+            <GoabText size={"body-m"} mt="none" mb={"m"}>
               These resources establish best practices to shape and guide the work of DDD user experience designers.
             </GoabText>
             <GoabLink>


### PR DESCRIPTION
With a recent change to the goa-text component, we have some spacing inconsistencies across foundation and design token pages.

### Changes
  - Add consistent subtitles to foundation pages (Content guidelines/Style guide)
  - Replace h1 tags with GoabText components in design token pages for uniform spacing
  - Adjust Color page title margin-bottom to improve section spacing
  - Remove excess margin-top from accessibility guidance component