### PR TITLE
feat(#2132): drop down - added more contextual examples

### DIFF
--- a/src/examples/basic-question-page-with-a-dropdown.tsx
+++ b/src/examples/basic-question-page-with-a-dropdown.tsx
@@ -1,0 +1,202 @@
+import { Sandbox } from "@components/sandbox";
+import "./question-page/question-page-examples.css";
+import { CodeSnippet } from "@components/code-snippet/CodeSnippet.tsx";
+import {
+  GoabButton,
+  GoabFormItem,
+  GoabDropdown,
+  GoabDropdownItem
+} from "@abgov/react-components";
+import { LanguageVersionContext } from "@contexts/LanguageVersionContext.tsx";
+import { useContext } from "react";
+
+export default function BasicPageWithDropdown() {
+  const { version } = useContext(LanguageVersionContext);
+  return (
+    <div className="question-page-example">
+
+      <Sandbox fullWidth allow={["h2", "h3", "a"]} skipRender>
+        {/*CSS Code Snippet*/}
+        <CodeSnippet
+          lang="css"
+          allowCopy={true}
+          code={`
+            a.back-link::before {
+              content: "";
+              display: inline-block;
+              width: 42px;
+              height: 24px;
+              vertical-align: middle;
+              background: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 2 22 22" fill="none" stroke="%230070C4" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"></polyline></svg>') center center no-repeat;
+            }
+
+            a.back-link:visited::before,
+            a.back-link:hover::before {
+              background: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 2 22 22" fill="none" stroke="%23004f84" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"></polyline></svg>') center center no-repeat;
+            }
+            
+            a.back-link {
+             margin-top: var(--goa-space-m);
+            }
+          `}
+        />
+
+        {/*Angular Code Snippet - need for leadingContent slot*/}
+
+        {version === "old" && <CodeSnippet
+          lang="typescript"
+          tags="angular"
+          allowCopy={true}
+          code={`
+            <a href="#" className="back-link">
+                Back
+            </a>
+
+            <goa-form-item label="Choose a location" mt="xl" labelSize="large">
+                <goa-dropdown onChange={() => {}} name="province-territory" ariaLabelledBy="provinceLabel">
+                    <goa-dropdown-item value="AB" label="Alberta"></goa-dropdown-item>
+                    <goa-dropdown-item value="BC" label="British Columbia"></goa-dropdown-item>
+                    <goa-dropdown-item value="MB" label="Manitoba"></goa-dropdown-item>
+                    <goa-dropdown-item value="NB" label="New Brunswick"></goa-dropdown-item>
+                    <goa-dropdown-item value="NL" label="Newfoundland and Labrador"></goa-dropdown-item>
+                    <goa-dropdown-item value="NS" label="Nova Scotia"></goa-dropdown-item>
+                    <goa-dropdown-item value="ON" label="Ontario"></goa-dropdown-item>
+                    <goa-dropdown-item value="PE" label="Prince Edward Island"></goa-dropdown-item>
+                    <goa-dropdown-item value="QC" label="Quebec"></goa-dropdown-item>
+                    <goa-dropdown-item value="SK" label="Saskatchewan"></goa-dropdown-item>
+                    <goa-dropdown-item value="NT" label="Northwest Territories"></goa-dropdown-item>
+                    <goa-dropdown-item value="NU" label="Nunavut"></goa-dropdown-item>
+                    <goa-dropdown-item value="YT" label="Yukon"></goa-dropdown-item>
+                </goa-dropdown>
+            </goa-form-item>
+            <goa-button type="submit" mt="2xl">
+                Continue
+            </goa-button>
+          `}
+        />}
+
+        {version === "new" && <CodeSnippet
+          lang="typescript"
+          tags="angular"
+          allowCopy={true}
+          code={`
+            <a href="#" className="back-link">
+                Back
+            </a>
+
+            <goab-form-item label="Choose a location" mt="xl" labelSize="large">
+                <goab-dropdown onChange={() => {}} name="province-territory" ariaLabelledBy="provinceLabel">
+                    <goab-dropdown-item value="AB" label="Alberta"></goab-dropdown-item>
+                    <goab-dropdown-item value="BC" label="British Columbia"></goab-dropdown-item>
+                    <goab-dropdown-item value="MB" label="Manitoba"></goab-dropdown-item>
+                    <goab-dropdown-item value="NB" label="New Brunswick"></goab-dropdown-item>
+                    <goab-dropdown-item value="NL" label="Newfoundland and Labrador"></goab-dropdown-item>
+                    <goab-dropdown-item value="NS" label="Nova Scotia"></goab-dropdown-item>
+                    <goab-dropdown-item value="ON" label="Ontario"></goab-dropdown-item>
+                    <goab-dropdown-item value="PE" label="Prince Edward Island"></goab-dropdown-item>
+                    <goab-dropdown-item value="QC" label="Quebec"></goab-dropdown-item>
+                    <goab-dropdown-item value="SK" label="Saskatchewan"></goab-dropdown-item>
+                    <goab-dropdown-item value="NT" label="Northwest Territories"></goab-dropdown-item>
+                    <goab-dropdown-item value="NU" label="Nunavut"></goab-dropdown-item>
+                    <goab-dropdown-item value="YT" label="Yukon"></goab-dropdown-item>
+                </goab-dropdown>
+            </goab-form-item>
+            <goab-button type="submit" mt="2xl">
+                Continue
+            </goab-button>
+          `}
+        />}
+
+        {/*React Code Snippet - need for leadingContent slot*/}
+        {version === "old" && <CodeSnippet
+          lang="typescript"
+          tags="react"
+          allowCopy={true}
+          code={`
+            <a href="#" className="back-link">
+                Back
+            </a>
+
+            <GoAFormItem label="Choose a location" mt="xl" labelSize="large">
+                <GoADropdown onChange={() => {}} name="province-territory" ariaLabelledBy="provinceLabel">
+                    <GoADropdownItem value="AB" label="Alberta" />
+                    <GoADropdownItem value="BC" label="British Columbia" />
+                    <GoADropdownItem value="MB" label="Manitoba" />
+                    <GoADropdownItem value="NB" label="New Brunswick" />
+                    <GoADropdownItem value="NL" label="Newfoundland and Labrador" />
+                    <GoADropdownItem value="NS" label="Nova Scotia" />
+                    <GoADropdownItem value="ON" label="Ontario" />
+                    <GoADropdownItem value="PE" label="Prince Edward Island" />
+                    <GoADropdownItem value="QC" label="Quebec" />
+                    <GoADropdownItem value="SK" label="Saskatchewan" />
+                    <GoADropdownItem value="NT" label="Northwest Territories" />
+                    <GoADropdownItem value="NU" label="Nunavut" />
+                    <GoADropdownItem value="YT" label="Yukon" />
+                </GoADropdown>
+            </GoAFormItem>
+            <GoAButton type="submit" mt="2xl">
+                Continue
+            </GoAButton>
+          `}
+        />}
+
+        {version === "new" && <CodeSnippet
+          lang="typescript"
+          tags="react"
+          allowCopy={true}
+          code={`
+            <a href="#" className="back-link">
+                Back
+            </a>
+
+            <GoabFormItem label="Choose a location" mt="xl" labelSize="large">
+                <GoabDropdown onChange={() => {}} name="province-territory" ariaLabelledBy="provinceLabel">
+                    <GoabDropdownItem value="AB" label="Alberta" />
+                    <GoabDropdownItem value="BC" label="British Columbia" />
+                    <GoabDropdownItem value="MB" label="Manitoba" />
+                    <GoabDropdownItem value="NB" label="New Brunswick" />
+                    <GoabDropdownItem value="NL" label="Newfoundland and Labrador" />
+                    <GoabDropdownItem value="NS" label="Nova Scotia" />
+                    <GoabDropdownItem value="ON" label="Ontario" />
+                    <GoabDropdownItem value="PE" label="Prince Edward Island" />
+                    <GoabDropdownItem value="QC" label="Quebec" />
+                    <GoabDropdownItem value="SK" label="Saskatchewan" />
+                    <GoabDropdownItem value="NT" label="Northwest Territories" />
+                    <GoabDropdownItem value="NU" label="Nunavut" />
+                    <GoabDropdownItem value="YT" label="Yukon" />
+                </GoabDropdown>
+            </GoabFormItem>
+            <GoabButton type="submit" mt="2xl">
+                Continue
+            </GoabButton>
+          `}
+        />}
+
+        <a href="#" className="back-link">
+            Back
+        </a>
+
+        <GoabFormItem label="Choose a location" mt="xl" labelSize="large">
+            <GoabDropdown onChange={() => {}} name="province-territory" ariaLabelledBy="provinceLabel">
+                <GoabDropdownItem value="AB" label="Alberta" />
+                <GoabDropdownItem value="BC" label="British Columbia" />
+                <GoabDropdownItem value="MB" label="Manitoba" />
+                <GoabDropdownItem value="NB" label="New Brunswick" />
+                <GoabDropdownItem value="NL" label="Newfoundland and Labrador" />
+                <GoabDropdownItem value="NS" label="Nova Scotia" />
+                <GoabDropdownItem value="ON" label="Ontario" />
+                <GoabDropdownItem value="PE" label="Prince Edward Island" />
+                <GoabDropdownItem value="QC" label="Quebec" />
+                <GoabDropdownItem value="SK" label="Saskatchewan" />
+                <GoabDropdownItem value="NT" label="Northwest Territories" />
+                <GoabDropdownItem value="NU" label="Nunavut" />
+                <GoabDropdownItem value="YT" label="Yukon" />
+            </GoabDropdown>
+        </GoabFormItem>
+        <GoabButton type="submit" mt="2xl">
+            Continue
+        </GoabButton>
+      </Sandbox>
+    </div>
+  );
+}

--- a/src/examples/basic-question-page-with-a-dropdown.tsx
+++ b/src/examples/basic-question-page-with-a-dropdown.tsx
@@ -5,7 +5,8 @@ import {
   GoabButton,
   GoabFormItem,
   GoabDropdown,
-  GoabDropdownItem
+  GoabDropdownItem,
+  GoabLink
 } from "@abgov/react-components";
 import { LanguageVersionContext } from "@contexts/LanguageVersionContext.tsx";
 import { useContext } from "react";
@@ -16,31 +17,6 @@ export default function BasicPageWithDropdown() {
     <div className="question-page-example">
 
       <Sandbox fullWidth allow={["h2", "h3", "a"]} skipRender>
-        {/*CSS Code Snippet*/}
-        <CodeSnippet
-          lang="css"
-          allowCopy={true}
-          code={`
-            a.back-link::before {
-              content: "";
-              display: inline-block;
-              width: 42px;
-              height: 24px;
-              vertical-align: middle;
-              background: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 2 22 22" fill="none" stroke="%230070C4" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"></polyline></svg>') center center no-repeat;
-            }
-
-            a.back-link:visited::before,
-            a.back-link:hover::before {
-              background: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 2 22 22" fill="none" stroke="%23004f84" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"></polyline></svg>') center center no-repeat;
-            }
-            
-            a.back-link {
-             margin-top: var(--goa-space-m);
-            }
-          `}
-        />
-
         {/*Angular Code Snippet - need for leadingContent slot*/}
 
         {version === "old" && <CodeSnippet
@@ -48,9 +24,9 @@ export default function BasicPageWithDropdown() {
           tags="angular"
           allowCopy={true}
           code={`
-            <a href="#" className="back-link">
-                Back
-            </a>
+            <goa-link action="back" leadingicon="chevron-back" mb="2xl">
+              <a href="#">Back</a>
+            </goa-link>
 
             <goa-form-item label="Choose a location" mt="xl" labelSize="large">
                 <goa-dropdown onChange={() => {}} name="province-territory" ariaLabelledBy="provinceLabel">
@@ -80,9 +56,9 @@ export default function BasicPageWithDropdown() {
           tags="angular"
           allowCopy={true}
           code={`
-            <a href="#" className="back-link">
-                Back
-            </a>
+            <goab-link action="back" leadingicon="chevron-back" mb="2xl">
+              <a href="#">Back</a>
+            </goab-link>
 
             <goab-form-item label="Choose a location" mt="xl" labelSize="large">
                 <goab-dropdown onChange={() => {}} name="province-territory" ariaLabelledBy="provinceLabel">
@@ -113,9 +89,9 @@ export default function BasicPageWithDropdown() {
           tags="react"
           allowCopy={true}
           code={`
-            <a href="#" className="back-link">
-                Back
-            </a>
+            <GoALink action="back" leadingIcon="chevron-back" mb="2xl">
+              <a href="#">Back</a>
+            </GoALink>
 
             <GoAFormItem label="Choose a location" mt="xl" labelSize="large">
                 <GoADropdown onChange={() => {}} name="province-territory" ariaLabelledBy="provinceLabel">
@@ -145,9 +121,9 @@ export default function BasicPageWithDropdown() {
           tags="react"
           allowCopy={true}
           code={`
-            <a href="#" className="back-link">
-                Back
-            </a>
+            <GoabLink action="back" leadingIcon="chevron-back" mb="2xl">
+              <a href="#">Back</a>
+            </GoabLink>
 
             <GoabFormItem label="Choose a location" mt="xl" labelSize="large">
                 <GoabDropdown onChange={() => {}} name="province-territory" ariaLabelledBy="provinceLabel">
@@ -172,9 +148,9 @@ export default function BasicPageWithDropdown() {
           `}
         />}
 
-        <a href="#" className="back-link">
-            Back
-        </a>
+        <GoabLink action="back" leadingIcon="chevron-back" mb="2xl">
+          <a href="#">Back</a>
+        </GoabLink>
 
         <GoabFormItem label="Choose a location" mt="xl" labelSize="large">
             <GoabDropdown onChange={() => {}} name="province-territory" ariaLabelledBy="provinceLabel">

--- a/src/examples/choose-one-option-from-a-list.tsx
+++ b/src/examples/choose-one-option-from-a-list.tsx
@@ -1,0 +1,120 @@
+import { GoabDropdown, GoabDropdownItem, GoabFormItem } from "@abgov/react-components";
+import { useContext } from "react";
+import { Sandbox } from "@components/sandbox";
+import { CodeSnippet } from "@components/code-snippet/CodeSnippet.tsx";
+import { LanguageVersionContext } from "@contexts/LanguageVersionContext.tsx";
+
+export const ChooseOneOptionFromList = () => {
+    const {version} = useContext(LanguageVersionContext);
+    const noop = () => {}
+    return (
+        
+        <Sandbox flags={["event"]} skipRender>
+
+            {version === "old" && <CodeSnippet
+                lang="typescript"
+                tags="angular"
+                allowCopy={true}
+                code={`
+                    export class SomeOtherComponent {
+                        dropdownOnChange(event: GoabDropdownOnChangeDetail) {
+                            console.log(event);
+                        }
+                    }
+                `}
+            />}
+            
+            {version === "old" && <CodeSnippet
+                lang="typescript"
+                tags="angular"
+                allowCopy={true}
+                code={`
+                    <goa-form-item label="Basic dropdown">
+                        <goa-dropdown (_change)="onChange($event) name="item" value="" placeholder="--Select--">
+                            <goa-dropdown-item value="add" label="Add"></goa-dropdown-item>
+                            <goa-dropdown-item value="remove" label="Remove"></goa-dropdown-item>
+                            <goa-dropdown-item value="modify" label="Modify"></goa-dropdown-item>
+                        </goa-dropdown>
+                    </goa-form-item>
+                `}
+            />}
+
+            {version === "new" && <CodeSnippet
+                lang="typescript"
+                tags="angular"
+                allowCopy={true}
+                code={`
+                    <goab-form-item label="Basic dropdown">
+                        <goab-dropdown (onChange)="dropdownOnChange($event)" name="item" value="" placeholder="--Select--">
+                            <goab-dropdown-item value="add" label="Add"></goab-dropdown-item>
+                            <goab-dropdown-item value="remove" label="Remove"></goab-dropdown-item>
+                            <goab-dropdown-item value="modify" label="Modify"></goab-dropdown-item>
+                        </goab-dropdown>
+                    </goab-form-item>
+                `}
+            />}
+
+            {version === "old" && <CodeSnippet
+                lang="typescript"
+                tags="react"
+                allowCopy={true}
+                code={`
+                    function onChange(name: string, value: Date) {
+                        console.log(name, value);
+                    }
+                `}
+            />}
+
+            {version === "old" && <CodeSnippet
+                lang="typescript"
+                tags="react"
+                allowCopy={true}
+                code={`
+                    <GoAFormItem label="Basic dropdown">
+                        <GoADropdown onChange={onChange} name="item" value="" placeholder="--Select--">
+                            <GoADropdownItem value="add" label="Add"></GoADropdownItem>
+                            <GoADropdownItem value="remove" label="Remove"></GoADropdownItem>
+                            <GoADropdownItem value="modify" label="Modify"></GoADropdownItem>
+                        </GoADropdown>
+                    </GoAFormItem>
+                `}
+            />}
+
+            {version === "new" && <CodeSnippet
+                lang="typescript"
+                tags="react"
+                allowCopy={true}
+                code={`
+                    function dropdownOnChange(event: GoabDropdownOnChangeDetail)) {
+                        console.log(event.value);
+                    }
+                `}
+            />}
+            
+            {version === "new" && <CodeSnippet
+                lang="typescript"
+                tags="react"
+                allowCopy={true}
+                code={`
+                    <GoabFormItem label="Basic dropdown">
+                        <GoabDropdown onChange={dropdownOnChange} name="item" value="" placeholder="--Select--">
+                            <GoabDropdownItem value="add" label="Add"></GoabDropdownItem>
+                            <GoabDropdownItem value="remove" label="Remove"></GoabDropdownItem>
+                            <GoabDropdownItem value="modify" label="Modify"></GoabDropdownItem>
+                        </GoabDropdown>
+                    </GoabFormItem>
+                `}
+            />}
+
+            <GoabFormItem label="Basic dropdown">
+                <GoabDropdown onChange={noop} name="item" value="" placeholder="--Select--">
+                    <GoabDropdownItem value="add" label="Add"></GoabDropdownItem>
+                    <GoabDropdownItem value="remove" label="Remove"></GoabDropdownItem>
+                    <GoabDropdownItem value="modify" label="Modify"></GoabDropdownItem>
+                </GoabDropdown>
+            </GoabFormItem>
+        </Sandbox>
+    );
+}
+
+export default ChooseOneOptionFromList;

--- a/src/examples/dropdown/DropdownExamples.tsx
+++ b/src/examples/dropdown/DropdownExamples.tsx
@@ -2,11 +2,27 @@ import { DynamicallyAddAnItemToADropdownList } from "@examples/dynamically-add-a
 import {
   DynamicallyChangeItemsInADropdownList
 } from "@examples/dynamically-change-items-in-a-dropdown-list.tsx";
+import { FilterItemsInADropdownList } from "@examples/filter-through-long-list-to-choose-an-option.tsx";
+import { ChooseOneOptionFromList } from "@examples/choose-one-option-from-a-list.tsx";
 import { SandboxHeader } from "@components/sandbox/sandbox-header/sandboxHeader.tsx";
+import BasicPageWithDropdown from "@examples/basic-question-page-with-a-dropdown.tsx";
+
 
 export const DropdownExamples = () => {
   return (
     <>
+      <SandboxHeader
+        exampleTitle="Choose one option from a list"
+        figmaExample="">
+      </SandboxHeader>
+      <ChooseOneOptionFromList />
+
+      <SandboxHeader
+        exampleTitle="Filter through a long list to choose an option"
+        figmaExample="">
+      </SandboxHeader>
+      <FilterItemsInADropdownList />
+      
       <SandboxHeader
         exampleTitle="Dynamically add an item to a dropdown list"
         figmaExample="">
@@ -18,6 +34,14 @@ export const DropdownExamples = () => {
         figmaExample="">
       </SandboxHeader>
       <DynamicallyChangeItemsInADropdownList />
+
+      <SandboxHeader
+        exampleTitle="Basic question page"
+        figmaExample="">
+      </SandboxHeader>
+      <BasicPageWithDropdown />
+      
+      
     </>
   );
 }

--- a/src/examples/filter-through-long-list-to-choose-an-option.tsx
+++ b/src/examples/filter-through-long-list-to-choose-an-option.tsx
@@ -1,0 +1,150 @@
+import { GoabDropdown, GoabDropdownItem, GoabFormItem } from "@abgov/react-components";
+import { useContext } from "react";
+import { Sandbox } from "@components/sandbox";
+import { CodeSnippet } from "@components/code-snippet/CodeSnippet.tsx";
+import { LanguageVersionContext } from "@contexts/LanguageVersionContext.tsx";
+
+export const FilterItemsInADropdownList = () => {
+    const {version} = useContext(LanguageVersionContext);
+    
+    return (
+        
+        <Sandbox flags={["event"]} skipRender>
+            
+            {version === "old" && <CodeSnippet
+                lang="typescript"
+                tags="angular"
+                allowCopy={true}
+                code={`
+                    export class SomeOtherComponent {
+                        dropdownOnChange(event: GoabDropdownOnChangeDetail) {
+                            console.log(event);
+                        }
+                    }
+                `}
+            />}
+
+            {version === "old" && <CodeSnippet
+                lang="typescript"
+                tags="angular"
+                allowCopy={true}
+                code={`
+                    <goa-form-item label="Filter dropdown">
+                        <goa-dropdown (_change)="onChange($event) name="item" leadingIcon="search" filterable="true">
+                            <goa-dropdown-item value="bus" label="Bus" />
+                            <goa-dropdown-item value="elephant" label="Elephant" />
+                            <goa-dropdown-item value="key" label="Key" />
+                            <goa-dropdown-item value="pen" label="Pen" />
+                            <goa-dropdown-item value="watch" label="Watch" />
+                            <goa-dropdown-item value="truck" label="Truck" />
+                            <goa-dropdown-item value="pencil" label="Pencil" />
+                            <goa-dropdown-item value="television" label="Television" />
+                            <goa-dropdown-item value="vehicle" label="Vehicle" />
+                        </goa-dropdown>
+                    </goa-form-item>
+                `}
+            />}
+
+            {version === "new" && <CodeSnippet
+                lang="typescript"
+                tags="angular"
+                allowCopy={true}
+                code={`
+                    <goab-form-item label="Filter dropdown">
+                        <goab-dropdown (onChange)="dropdownOnChange($event)" name="item" leadingIcon="search" [filterable]="true">
+                            <goab-dropdown-item value="bus" label="Bus" />
+                            <goab-dropdown-item value="elephant" label="Elephant" />
+                            <goab-dropdown-item value="key" label="Key" />
+                            <goab-dropdown-item value="pen" label="Pen" />
+                            <goab-dropdown-item value="watch" label="Watch" />
+                            <goab-dropdown-item value="truck" label="Truck" />
+                            <goab-dropdown-item value="pencil" label="Pencil" />
+                            <goab-dropdown-item value="television" label="Television" />
+                            <goab-dropdown-item value="vehicle" label="Vehicle" />
+                        </goab-dropdown>
+                    </goab-form-item>
+                `}
+            />}
+
+            {version === "old" && <CodeSnippet
+                lang="typescript"
+                tags="react"
+                allowCopy={true}
+                code={`
+                    function onChange(name: string, value: Date) {
+                        console.log(name, value);
+                    }
+                `}
+            />}
+
+            {version === "old" && <CodeSnippet
+                lang="typescript"
+                tags="react"
+                allowCopy={true}
+                code={`
+                    <GoAFormItem label="Filter dropdown">
+                        <GoADropdown onChange={onChange} name="item" value="" leadingIcon="search" filterable={true}>
+                            <GoADropdownItem value="bus" label="Bus" />
+                            <GoADropdownItem value="elephant" label="Elephant" />
+                            <GoADropdownItem value="key" label="Key" />
+                            <GoADropdownItem value="pen" label="Pen" />
+                            <GoADropdownItem value="watch" label="Watch" />
+                            <GoADropdownItem value="truck" label="Truck" />
+                            <GoADropdownItem value="pencil" label="Pencil" />
+                            <GoADropdownItem value="television" label="Television" />
+                            <GoADropdownItem value="vehicle" label="Vehicle" />
+                        </GoADropdown>
+                    </GoAFormItem>
+                `}
+            />}
+
+            {version === "new" && <CodeSnippet
+                lang="typescript"
+                tags="react"
+                allowCopy={true}
+                code={`
+                    function dropdownOnChange(event: GoabDropdownOnChangeDetail)) {
+                        console.log(event.value);
+                    }
+                `}
+            />}
+            
+            {version === "new" && <CodeSnippet
+                lang="typescript"
+                tags="react"
+                allowCopy={true}
+                code={`
+                    <GoabFormItem label="Filter dropdown">
+                        <GoabDropdown onChange={dropdownOnChange} name="item" value="" leadingIcon="search" filterable={true}>
+                            <GoabDropdownItem value="bus" label="Bus" />
+                            <GoabDropdownItem value="elephant" label="Elephant" />
+                            <GoabDropdownItem value="key" label="Key" />
+                            <GoabDropdownItem value="pen" label="Pen" />
+                            <GoabDropdownItem value="watch" label="Watch" />
+                            <GoabDropdownItem value="truck" label="Truck" />
+                            <GoabDropdownItem value="pencil" label="Pencil" />
+                            <GoabDropdownItem value="television" label="Television" />
+                            <GoabDropdownItem value="vehicle" label="Vehicle" />
+                        </GoabDropdown>
+                    </GoabFormItem>
+                `}
+            />}
+
+            <GoabFormItem label="Filter dropdown">
+                <GoabDropdown name="item" value="" leadingIcon="search" filterable={true}>
+                    <GoabDropdownItem value="bus" label="Bus" />
+                    <GoabDropdownItem value="elephant" label="Elephant" />
+                    <GoabDropdownItem value="key" label="Key" />
+                    <GoabDropdownItem value="pen" label="Pen" />
+                    <GoabDropdownItem value="watch" label="Watch" />
+                    <GoabDropdownItem value="truck" label="Truck" />
+                    <GoabDropdownItem value="pencil" label="Pencil" />
+                    <GoabDropdownItem value="television" label="Television" />
+                    <GoabDropdownItem value="vehicle" label="Vehicle" />
+                </GoabDropdown>
+            </GoabFormItem>
+        </Sandbox>
+    );
+}
+
+export default FilterItemsInADropdownList;

--- a/src/routes/components/Dropdown.tsx
+++ b/src/routes/components/Dropdown.tsx
@@ -426,7 +426,7 @@ export default function DropdownPage() {
             heading={
               <>
                 Examples
-                <GoabBadge type="information" content="2" />
+                <GoabBadge type="information" content="5" />
               </>
             }>
             <DropdownExamples />


### PR DESCRIPTION
Added the following examples to the dropdown page:

- Choose one option from a list
<img width="876" height="653" alt="image" src="https://github.com/user-attachments/assets/c39ee5f8-53bc-425a-933c-e19e8c928fb8" />

- Filter through a long list to choose an option
<img width="872" height="737" alt="image" src="https://github.com/user-attachments/assets/7976b3e6-eb9d-4cb6-a1e2-7be18ad8adbf" />

- Basic question page
<img width="863" height="531" alt="image" src="https://github.com/user-attachments/assets/625f83ea-589c-481a-9a07-aab229706282" />
