### PR TITLE
fix(#1321): docs button deprecate submit type

### DIFF
--- a/src/routes/components/Button.tsx
+++ b/src/routes/components/Button.tsx
@@ -33,7 +33,7 @@ export default function ButtonPage() {
       label: "Type",
       type: "list",
       name: "type",
-      options: ["primary", "submit", "secondary", "tertiary", "start"],
+      options: ["primary", "secondary", "tertiary", "start"],
       value: "",
       defaultValue: "primary",
     },
@@ -71,7 +71,7 @@ export default function ButtonPage() {
   const oldComponentProperties: ComponentProperty[] = [
     {
       name: "type",
-      type: "primary | submit | secondary | tertiary | start",
+      type: "primary | secondary | tertiary | start",
       description: "Sets the type of button.",
       defaultValue: "primary",
     },
@@ -140,7 +140,7 @@ export default function ButtonPage() {
   const componentProperties: ComponentProperty[] = [
     {
       name: "type",
-      type: "GoabButtonType (primary | submit | secondary | tertiary | start)",
+      type: "GoabButtonType (primary | secondary | tertiary | start)",
       description: "Sets the type of button.",
       defaultValue: "primary",
     },


### PR DESCRIPTION
<img width="470" height="173" alt="image" src="https://github.com/user-attachments/assets/9135d325-3a01-466a-879d-d38a88566db4" />

Remove type submit

UI changes: https://github.com/GovAlta/ui-components/pull/2988
Story: https://github.com/GovAlta/ui-components/issues/1321