### PR TITLE
feat(#2145): header - added contextual examples

### DIFF
--- a/src/examples/app-header/AppHeaderExamples.tsx
+++ b/src/examples/app-header/AppHeaderExamples.tsx
@@ -1,5 +1,7 @@
 import { HeaderWithNavigation } from "@examples/header-with-navigation.tsx";
 import { HeaderWithMenuClickEvent } from "@examples/header-with-menu-click-event.tsx";
+import { HeaderSignIn } from "@examples/header-with-sign-in.tsx";
+import { HeaderLoggedInMenu } from "@examples/header-logged-in-menu.tsx";
 import { SandboxHeader } from "@components/sandbox/sandbox-header/sandboxHeader.tsx";
 
 export const AppHeaderExamples = () => {
@@ -16,6 +18,18 @@ export const AppHeaderExamples = () => {
         figmaExample="">
       </SandboxHeader>
       <HeaderWithMenuClickEvent />
+
+      <SandboxHeader
+        exampleTitle="Sign in using the site header"
+        figmaExample="">
+      </SandboxHeader>
+      <HeaderSignIn />
+
+      <SandboxHeader
+        exampleTitle="Access user settings in the site header"
+        figmaExample="">
+      </SandboxHeader>
+      <HeaderLoggedInMenu />
     </>
   );
 };

--- a/src/examples/header-logged-in-menu.tsx
+++ b/src/examples/header-logged-in-menu.tsx
@@ -1,0 +1,126 @@
+import { Sandbox } from "@components/sandbox";
+import { CodeSnippet } from "@components/code-snippet/CodeSnippet.tsx";
+import { GoabAppHeader, GoabAppHeaderMenu, GoabMicrositeHeader } from "@abgov/react-components";
+import { useContext } from "react";
+import { LanguageVersionContext } from "@contexts/LanguageVersionContext.tsx";
+
+export const HeaderLoggedInMenu = () => {
+  const {version} = useContext(LanguageVersionContext);
+  return (
+    <Sandbox fullWidth skipRender>
+      <GoabMicrositeHeader type="live"></GoabMicrositeHeader>
+      <GoabAppHeader
+        url="https://example.com"
+        heading="Design System"
+        fullMenuBreakpoint={1500}>
+        <a href="#">Services</a>
+        <GoabAppHeaderMenu heading="John Smith" leadingIcon="person-circle">
+            <a href="#">Manage account</a>
+            <a href="#">Request new staff account</a>
+            <a href="#">System admin</a>
+            <a href="#" className="interactive">Sign out</a>
+        </GoabAppHeaderMenu>
+      </GoabAppHeader>
+
+      {version === "old" && (
+        <CodeSnippet
+          lang="html"
+          tags="angular"
+          allowCopy={true}
+          code={`
+                <goa-microsite-header type="live"></goa-microsite-header>
+                <goa-app-header
+                  url="https://example.com"
+                  heading="Design System"
+                  [fullmenubreakpoint]="1500"
+                  [hasmenuclickhandler]="true"
+                  (_menuClick)="handleMenuClick()"
+                >
+                  <a href="#">Services</a>
+                  <goa-app-header-menu heading="John Smith" leadingIcon="person-circle">
+                      <a href="#">Manage account</a>
+                      <a href="#">Request new staff account</a>
+                      <a href="#">System admin</a>
+                      <a href="#" className="interactive">Sign out</a>
+                  </goa-app-header-menu>
+                </goa-app-header>
+              `}
+        />
+      )}
+
+      {version === "new" && (
+        <CodeSnippet
+          lang="html"
+          tags="angular"
+          allowCopy={true}
+          code={`
+                <goab-microsite-header type="live"></goab-microsite-header>
+                <goab-app-header
+                  url="https://example.com"
+                  heading="Design System"
+                  [fullMenuBreakpoint]="1500"
+                  (onMenuClick)="handleMenuClick()"
+                >
+                  <a href="#">Services</a>
+                  <goab-app-header-menu heading="John Smith" leadingIcon="person-circle">
+                      <a href="#">Manage account</a>
+                      <a href="#">Request new staff account</a>
+                      <a href="#">System admin</a>
+                      <a href="#" className="interactive">Sign out</a>
+                  </goab-app-header-menu>
+                </goab-app-header>
+              `}
+        />
+      )}
+
+      {version === "old" && (
+        <CodeSnippet
+          lang="html"
+          tags="react"
+          allowCopy={true}
+          code={`
+                  <GoAMicrositeHeader type="live"></GoAMicrositeHeader>
+                  <GoAAppHeader
+                    url="https://example.com"
+                    heading="Design System"
+                    onMenuClick={handleMenuClick}
+                    fullMenuBreakpoint={1500}>
+                      <a href="#">Services</a>
+                      <GoAAppHeaderMenu heading="John Smith" leadingIcon="person-circle">
+                          <a href="#">Manage account</a>
+                          <a href="#">Request new staff account</a>
+                          <a href="#">System admin</a>
+                          <a href="#" className="interactive">Sign out</a>
+                      </GoAAppHeaderMenu>
+                  </GoAAppHeader>
+              `}
+        />
+      )}
+      {version === "new" && (
+        <CodeSnippet
+          lang="html"
+          tags="react"
+          allowCopy={true}
+          code={`
+                  <GoabMicrositeHeader type="live"></GoabMicrositeHeader>
+                  <GoabAppHeader
+                    url="https://example.com"
+                    heading="Design System"
+                    onMenuClick={handleMenuClick}
+                    fullMenuBreakpoint={1500}>
+                      <a href="#">Services</a>
+                      <GoabAppHeaderMenu heading="John Smith" leadingIcon="person-circle">
+                          <a href="#">Manage account</a>
+                          <a href="#">Request new staff account</a>
+                          <a href="#">System admin</a>
+                          <a href="#" className="interactive">Sign out</a>
+                      </GoabAppHeaderMenu>
+                  </GoabAppHeader>
+              `}
+        />
+      )}
+    </Sandbox>
+  )
+}
+
+export default HeaderLoggedInMenu;

--- a/src/examples/header-with-sign-in.tsx
+++ b/src/examples/header-with-sign-in.tsx
@@ -1,0 +1,94 @@
+import { Sandbox } from "@components/sandbox";
+import { CodeSnippet } from "@components/code-snippet/CodeSnippet.tsx";
+import { GoabAppHeader, GoabMicrositeHeader } from "@abgov/react-components";
+import { useContext } from "react";
+import { LanguageVersionContext } from "@contexts/LanguageVersionContext.tsx";
+
+export const HeaderSignIn = () => {
+  const {version} = useContext(LanguageVersionContext);
+  return (
+    <Sandbox fullWidth skipRender>
+      <GoabMicrositeHeader type="live"></GoabMicrositeHeader>
+      <GoabAppHeader
+        url="https://example.com"
+        heading="Service name"
+        fullMenuBreakpoint={1500}>
+        <a href="#" className="interactive">Sign in</a>
+      </GoabAppHeader>
+
+      {version === "old" && (
+        <CodeSnippet
+          lang="html"
+          tags="angular"
+          allowCopy={true}
+          code={`
+                <goa-microsite-header type="live"></goa-microsite-header>
+                <goa-app-header
+                  url="https://example.com"
+                  heading="Design System"
+                  [fullmenubreakpoint]="1500"
+                  [hasmenuclickhandler]="true"
+                  (_menuClick)="handleMenuClick()"
+                >
+                  <a href="#" className="interactive">Sign in</a>
+                </goa-app-header>
+              `}
+        />
+      )}
+
+      {version === "new" && (
+        <CodeSnippet
+          lang="html"
+          tags="angular"
+          allowCopy={true}
+          code={`
+                <goab-microsite-header type="live"></goab-microsite-header>
+                <goab-app-header
+                  url="https://example.com"
+                  heading="Design System"
+                  [fullMenuBreakpoint]="1500"
+                  (onMenuClick)="handleMenuClick()"
+                >
+                  <a href="#" className="interactive">Sign in</a>
+                </goab-app-header>
+              `}
+        />
+      )}
+
+      {version === "old" && (
+        <CodeSnippet
+          lang="html"
+          tags="react"
+          allowCopy={true}
+          code={`
+              <GoAMicrositeHeader type="live"></GoAMicrositeHeader>
+              <GoAAppHeader
+                url="https://example.com"
+                heading="Service name"
+                fullMenuBreakpoint={1500}>
+                <a href="#" className="interactive">Sign in</a>
+              </GoAAppHeader>
+              `}
+        />
+      )}
+      {version === "new" && (
+        <CodeSnippet
+          lang="html"
+          tags="react"
+          allowCopy={true}
+          code={`
+              <GoabMicrositeHeader type="live"></GoabMicrositeHeader>
+              <GoabAppHeader
+                url="https://example.com"
+                heading="Service name"
+                fullMenuBreakpoint={1500}>
+                <a href="#" className="interactive">Sign in</a>
+              </GoabAppHeader>
+              `}
+        />
+      )}
+    </Sandbox>
+  )
+}
+
+export default HeaderSignIn;

--- a/src/routes/components/AppHeader.tsx
+++ b/src/routes/components/AppHeader.tsx
@@ -182,7 +182,7 @@ export default function AppHeaderPage() {
             heading={
               <>
                 Examples
-                <GoabBadge type="information" content="2" />
+                <GoabBadge type="information" content="4" />
               </>
             }
           >


### PR DESCRIPTION
Added the following examples:

- Sign in using the site header
<img width="885" height="542" alt="image" src="https://github.com/user-attachments/assets/03e81570-ddad-4d73-a31b-12497e99acda" />

- Access user settings in the site header
<img width="893" height="675" alt="image" src="https://github.com/user-attachments/assets/53c05b56-ecaa-4f5f-824f-ad5eaa4a8064" />
