### PR TITLE
feat(#2120): table - added and modified contextual examples

### DIFF
--- a/src/examples/display-numbers-in-a-table-so-they-can-be-scanned-easily.tsx
+++ b/src/examples/display-numbers-in-a-table-so-they-can-be-scanned-easily.tsx
@@ -15,14 +15,24 @@ export const DisplayNumbersInATableSoTheyCanBeScannedEasily = () => {
           </thead>
           <tbody>
             <tr>
-              <td>Item 1</td>
-              <td>Item 2</td>
-              <td className="goa-table-number-column">54</td>
+              <td>Christian</td>
+              <td>Batz</td>
+              <td className="goa-table-number-column">54356456</td>
             </tr>
             <tr>
-              <td>Item 1</td>
-              <td>Item 2</td>
-              <td className="goa-table-number-column">4567</td>
+              <td>Brian</td>
+              <td>Wisozk</td>
+              <td className="goa-table-number-column">23212321</td>
+            </tr>
+            <tr>
+              <td>Neha</td>
+              <td>Jones</td>
+              <td className="goa-table-number-column">23197213</td>
+            </tr>
+            <tr>
+              <td>Tristan</td>
+              <td>Buckridge</td>
+              <td className="goa-table-number-column">76312313</td>
             </tr>
           </tbody>
         </GoabTable>

--- a/src/examples/filter-data-in-a-table.tsx
+++ b/src/examples/filter-data-in-a-table.tsx
@@ -9,6 +9,9 @@ import {
   GoabInput,
   GoabTable,
   GoabText,
+  GoabPopover,
+  GoabRadioGroup,
+  GoabRadioItem
 } from "@abgov/react-components";
 import type {
   GoabBadgeType,
@@ -17,10 +20,12 @@ import type {
 } from "@abgov/ui-components-common";
 import { LanguageVersionContext } from "@contexts/LanguageVersionContext.tsx";
 import { CodeSnippet } from "@components/code-snippet/CodeSnippet.tsx";
+import { GoabRadioGroupOnChangeDetail } from "@abgov/ui-components-common";
 
 export const FilterDataInATable = () => {
   const { version } = useContext(LanguageVersionContext);
 
+  const [selectedFilter, setSelectedFilter] = useState<string | null>(null);
   const [typedChips, setTypedChips] = useState<string[]>([]);
   const [inputValue, setInputValue] = useState("");
   const [inputError, setInputError] = useState("");
@@ -62,6 +67,12 @@ export const FilterDataInATable = () => {
     []
   );
   const [dataFiltered, setDataFiltered] = useState(data);
+
+  const target = (
+      <GoabButton type="tertiary" leadingIcon="funnel" size="compact" aria-label="Filter table">
+          Filter
+      </GoabButton>
+  );
 
   const handleInputChange = (detail: GoabInputOnChangeDetail) => {
     const newValue = detail.value.trim();
@@ -103,31 +114,43 @@ export const FilterDataInATable = () => {
     );
   }, []);
 
+  function radioGroupOnChange(event: GoabRadioGroupOnChangeDetail) {
+      setSelectedFilter(event.value);
+  }
+
   const getFilteredData = useCallback(
-    (typedChips: string[]) => {
-      if (typedChips.length === 0) {
-        return data;
+    (typedChips: string[], selectedFilter: string | null) => {
+      let filteredData = data;
+
+      if (typedChips.length > 0) {
+        filteredData = filteredData.filter((item: any) =>
+          typedChips.every(chip => checkNested(item, chip))
+        );
       }
-      const filteredData = data.filter((item: object) =>
-        typedChips.every(chip => checkNested(item, chip))
-      );
+
+      if (selectedFilter) {
+        filteredData = filteredData.filter(
+          (item: any) => item.status && item.status.text === selectedFilter
+        );
+      }
 
       return filteredData;
     },
     [checkNested, data]
   );
 
+
   useEffect(() => {
-    setDataFiltered(getFilteredData(typedChips));
-  }, [getFilteredData, typedChips]);
+    setDataFiltered(getFilteredData(typedChips, selectedFilter));
+  }, [getFilteredData, typedChips, selectedFilter]);
 
   return (
     // NOTE: Input onKeyPress functionality breaks when wrapped in Sandbox component
     // <Sandbox fullWidth skipRender>
     <>
       <GoabContainer width="full" mt="m" mb="none">
-        <GoabFormItem id="filterChipInput" error={inputError} mb="m">
-          <GoabBlock gap="xs" direction="row" alignment="start">
+        <GoabFormItem id="filterChipInput" error={inputError}>
+          <GoabBlock gap="xs" direction="row" alignment="center">
             <GoabInput
               name="filterChipInput"
               aria-labelledby="filterChipInput"
@@ -136,34 +159,59 @@ export const FilterDataInATable = () => {
               onChange={handleInputChange}
               onKeyPress={handleInputKeyPress}
             />
-            <GoabButton type="secondary" onClick={applyFilter} leadingIcon="filter">
-              Filter
-            </GoabButton>
+            
+            <GoabPopover target={target} minWidth="150px">
+                <form>
+                    <GoabFormItem label="Status">
+                        <GoabRadioGroup name="item" onChange={radioGroupOnChange} value={selectedFilter ?? ""}>
+                            <GoabRadioItem value="In progress" label="In progress" />
+                            <GoabRadioItem value="Completed" label="Completed" />
+                            <GoabRadioItem value="Updated" label="Updated" />
+                        </GoabRadioGroup>
+                    </GoabFormItem>
+                </form>
+            </GoabPopover>
           </GoabBlock>
         </GoabFormItem>
 
-        {typedChips.length > 0 && (
+        {(typedChips.length > 0 || selectedFilter) && (
           <div>
-            <GoabText tag="span" color="secondary" mb="xs" mr="xs">
+            <GoabText tag="span" color="secondary" mb="xs" mr="xs" mt="l">
               Filter:
             </GoabText>
-            {typedChips.length > 0 &&
-              typedChips.map((typedChip, index) => (
-                <GoabFilterChip
-                  key={index}
-                  content={typedChip}
-                  mb="xs"
-                  mr="xs"
-                  onClick={() => removeTypedChip(typedChip)}
-                />
-              ))}
-            <GoabButton type="tertiary" size="compact" mb="xs" onClick={() => setTypedChips([])}>
-              Clear all
-            </GoabButton>
+            {typedChips.map((typedChip, index) => (
+              <GoabFilterChip
+                key={index}
+                content={typedChip}
+                mb="xs"
+                mr="xs"
+                mt="l"
+                onClick={() => removeTypedChip(typedChip)}
+              />
+            ))}
+            {selectedFilter && (
+              <GoabFilterChip
+                content={selectedFilter}
+                mb="xs"
+                mr="xs"
+                mt="l"
+                onClick={() => {
+                  setSelectedFilter(null);
+                }}
+              />
+            )}
+            {(typedChips.length > 0 || selectedFilter) && (
+              <GoabButton type="tertiary" size="compact" mb="xs" onClick={() => {
+                setTypedChips([]);
+                setSelectedFilter(null);
+              }}>
+                Clear all
+              </GoabButton>
+            )}
           </div>
         )}
 
-        <GoabTable width="100%">
+        <GoabTable width="100%" mt="s">
           <thead>
             <tr>
               <th>Status</th>
@@ -198,102 +246,123 @@ export const FilterDataInATable = () => {
             tags="angular"
             allowCopy={true}
             code={`
-export class TableComponent {
-  typedChips: string[] = [];
-  inputValue = "";
-  inputError = "";
-  readonly errorEmpty = "Empty filter";
-  readonly errorDuplicate = "Enter a unique filter";
-  readonly data = [
-    {
-      status: { type: "information", text: "In progress" },
-      name: "Ivan Schmidt",
-      id: "7838576954",
-    },
-    {
-      status: { type: "success", text: "Completed" },
-      name: "Luz Lakin",
-      id: "8576953364",
-    },
-    {
-      status: { type: "information", text: "In progress" },
-      name: "Keith McGlynn",
-      id: "9846041345",
-    },
-    {
-      status: { type: "success", text: "Completed" },
-      name: "Melody Frami",
-      id: "7385256175",
-    },
-    {
-      status: { type: "important", text: "Updated" },
-      name: "Frederick Skiles",
-      id: "5807570418",
-    },
-    {
-      status: { type: "success", text: "Completed" },
-      name: "Dana Pfannerstill",
-      id: "5736306857",
-    },
-  ];
-  dataFiltered = this.getFilteredData(this.typedChips);
+              export class TablePopoverComponent {
+                typedChips: string[] = [];
 
-  handleInputChange(event: Event): void {
-    const newValue = (event.target as HTMLInputElement).value.trim();
-    this.inputValue = newValue;
-  }
+                inputValue = '';
+                inputError = '';
+                readonly errorEmpty = 'Empty filter';
+                readonly errorDuplicate = 'Enter a unique filter';
 
-  handleInputKeyPress(event: KeyboardEvent): void {
-    if (event.key === "Enter") {
-      this.applyFilter();
-    }
-  }
+                // Radio filter state
+                selectedFilter: string | null = null;
 
-  applyFilter() {
-    if (this.inputValue === "") {
-			this.inputError = this.errorEmpty;
-      return;
-    }
-    if (this.typedChips.includes(this.inputValue)) {
-      this.inputError = this.errorDuplicate;
-      return;
-    }
-    this.typedChips = [...this.typedChips, this.inputValue];
-    this.inputValue = "";
-    this.inputError = "";
-    this.dataFiltered = this.getFilteredData(this.typedChips);
-  }
+                // Table data
+                popoverValues: PopoverValue[] = [
+                  {
+                    status: { type: "information", text: "In progress" },
+                    name: "Ivan Schmidt",
+                    id: "7838576954",
+                  },
+                  {
+                    status: { type: "success", text: "Completed" },
+                    name: "Luz Lakin",
+                    id: "8576953364",
+                  },
+                  {
+                    status: { type: "information", text: "In progress" },
+                    name: "Keith McGlynn",
+                    id: "9846041345",
+                  },
+                  {
+                    status: { type: "success", text: "Completed" },
+                    name: "Melody Frami",
+                    id: "7385256175",
+                  },
+                  {
+                    status: { type: "important", text: "Updated" },
+                    name: "Frederick Skiles",
+                    id: "5807570418",
+                  },
+                  {
+                    status: { type: "success", text: "Completed" },
+                    name: "Dana Pfannerstill",
+                    id: "5736306857",
+                  },
+                ];
 
-  removeTypedChip(chip: string) {
-    this.typedChips = this.typedChips.filter((c) => c !== chip);
-    this.dataFiltered = this.getFilteredData(this.typedChips);
-    this.inputError = "";
-  }
+                get filteredData(): PopoverValue[] {
+                  let filtered = this.popoverValues;
 
-  removeAllTypedChips() {
-    this.typedChips = [];
-    this.dataFiltered = this.getFilteredData(this.typedChips);
-    this.inputError = "";
-  }
+                  // Apply radio filter
+                  if (this.selectedFilter) {
+                    filtered = filtered.filter(item => item.status === this.selectedFilter);
+                  }
 
-  getFilteredData(typedChips: string[]) {
-    if (typedChips.length === 0) {
-      return this.data;
-    }
-    const filteredData = this.data.filter((item) =>
-      typedChips.every((chip) => this.checkNested(item, chip)),
-    );
-    return filteredData;
-  }
+                  // Apply chip filters (all chips must match)
+                  if (this.typedChips.length > 0) {
+                    filtered = filtered.filter(item =>
+                      this.typedChips.every(chip =>
+                        Object.values(item).some(val =>
+                          typeof val === 'string' && val.toLowerCase().includes(chip.toLowerCase())
+                        )
+                      )
+                    );
+                  }
 
-  checkNested(obj: object, chip: string): boolean {
-    return Object.values(obj).some((value) =>
-      typeof value === "object" && value !== null
-        ? this.checkNested(value, chip)
-        : typeof value === "string" && value.toLowerCase().includes(chip.toLowerCase()),
-    );
-  }
-}
+                  return filtered;
+                }
+
+                handleInputChange(event: any): void {
+                  this.inputValue = event.target.value.trim();
+                }
+
+                handleInputKeyPress(event: KeyboardEvent): void {
+                  if (event.key === 'Enter') {
+                    this.applyFilter();
+                  }
+                }
+
+                applyFilter() {
+                  if (this.inputValue === '') {
+                    this.inputError = this.errorEmpty;
+                    return;
+                  }
+                  if (this.typedChips.includes(this.inputValue)) {
+                    this.inputError = this.errorDuplicate;
+                    return;
+                  }
+                  this.typedChips = [...this.typedChips, this.inputValue];
+                  this.inputValue = '';
+                  this.inputError = '';
+                }
+
+                removeTypedChip(chip: string) {
+                  this.typedChips = this.typedChips.filter(c => c !== chip);
+                  this.inputError = '';
+                }
+
+                removeAllTypedChips() {
+                  this.typedChips = [];
+                  this.inputError = '';
+                }
+
+                radioGroupOnChange(value: string) {
+                  this.selectedFilter = value;
+                }
+
+                clearRadioFilter() {
+                  this.selectedFilter = null;
+                }
+
+                checkNested(obj: object, chip: string): boolean {
+                  return Object.values(obj).some((value) =>
+                    typeof value === "object" && value !== null
+                      ? this.checkNested(value, chip)
+                      : typeof value === "string" && value.toLowerCase().includes(chip.toLowerCase()),
+                  );
+                }
+              }
 						`}
           />
           <CodeSnippet
@@ -301,67 +370,87 @@ export class TableComponent {
             tags="angular"
             allowCopy={true}
             code={`
-<goa-form-item id="filterChipInput" [error]="inputError" mb="m">
-  <goa-block gap="xs" direction="row" alignment="start">
-    <goa-input
-      name="filterChipInput"
-      aria-labelledby="filterChipInput"
-      [value]="inputValue"
-      maxlength="100"
-      size="large"
-      leadingIcon="search"
-      (_change)="handleInputChange($event)"
-      (keydown)="handleInputKeyPress($event)"
-    ></goa-input>
+              <goa-form-item id="filterChipInput" [error]="inputError" mb="m">
+                <goa-block gap="xs" direction="row" alignment="start">
+                  <input
+                    name="filterChipInput"
+                    aria-labelledby="filterChipInput"
+                    [value]="inputValue"
+                    (input)="handleInputChange($event)"
+                    (keydown)="handleInputKeyPress($event)"
+                    placeholder="Type to filter"
+                  />
 
-    <goa-button
-      type="secondary"
-      (_click)="applyFilter()"
-      leadingIcon="filter"
-    >
-      Filter
-    </goa-button>
-  </goa-block>
-</goa-form-item>
+                  <goa-popover>
+                    <form>
+                      <goa-form-item label="Status">
+                        <goa-radio-group
+                          name="item"
+                          [value]="selectedFilter"
+                          (_change)="radioGroupOnChange($event.target.value)">
+                          <goa-radio-item value="In progress" label="In progress"></goa-radio-item>
+                          <goa-radio-item value="Completed" label="Completed"></goa-radio-item>
+                          <goa-radio-item value="Updated" label="Updated"></goa-radio-item>
+                        </goa-radio-group>
+                      </goa-form-item>
+                      <goa-button type="tertiary" mt="m" (_click)="clearRadioFilter()">
+                        Remove filter
+                      </goa-button>
+                    </form>
+                    <div slot="target">
+                      <goa-button
+                        type="tertiary"
+                        leadingIcon="funnel"
+                        size="compact"
+                        aria-label="Filter table">
+                        Filter
+                      </goa-button>
+                    </div>
+                  </goa-popover>
+                  <goa-button type="secondary" (_click)="applyFilter()" leadingIcon="filter">
+                    Filter
+                  </goa-button>
+                </goa-block>
+              </goa-form-item>
 
-<ng-container *ngIf="typedChips.length > 0">
-  <goa-text as="span" color="secondary" mb="xs" mr="xs">
-    Filter:
-  </goa-text>
-  <goa-filter-chip
-    *ngFor="let typedChip of typedChips; let index = index"
-    [content]="typedChip"
-    mb="xs"
-    mr="xs"
-    (_click)="removeTypedChip(typedChip)"
-  ></goa-filter-chip>
-  <goa-button type="tertiary" size="compact" mb="xs" (_click)="removeAllTypedChips()">
-    Clear all
-  </goa-button>
-</ng-container>
+              <ng-container *ngIf="typedChips.length > 0">
+                <goa-text tag="span" color="secondary" mb="xs" mr="xs">
+                  Filter:
+                </goa-text>
+                <goa-filter-chip
+                  *ngFor="let typedChip of typedChips"
+                  [content]="typedChip"
+                  mb="xs"
+                  mr="xs"
+                  (_click)="removeTypedChip(typedChip)">
+                </goa-filter-chip>
+                <goa-button type="tertiary" size="compact" mb="xs" (_click)="removeAllTypedChips()">
+                  Clear all
+                </goa-button>
+              </ng-container>
 
-<goa-table width="100%">
-  <thead>
-    <tr>
-      <th>Status</th>
-      <th>Name</th>
-      <th className="goa-table-number-header">ID Number</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr *ngFor="let item of dataFiltered">
-      <td>
-        <goa-badge [type]="item.status.type" [content]="item.status.text"></goa-badge>
-      </td>
-      <td>{{ item.name }}</td>
-      <td className="goa-table-number-column">{{ item.id }}</td>
-    </tr>
-  </tbody>
-</goa-table>
+              <goa-table width="100%" mb="xl">
+                <thead>
+                  <tr>
+                    <th>Status</th>
+                    <th>Text</th>
+                    <th class="goa-table-number-header">Number</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr *ngFor="let u of filteredData">
+                    <td>
+                      <goa-badge [type]="u.type" [content]="u.status"></goa-badge>
+                    </td>
+                    <td>Lorem ipsum</td>
+                    <td class="goa-table-number-column">{{ u.key }}</td>
+                  </tr>
+                </tbody>
+              </goa-table>
 
-<goa-block mt="l" mb="l" *ngIf="dataFiltered.length === 0 && data.length > 0">
-  No results found
-</goa-block>
+              <goa-block mt="l" mb="l" *ngIf="dataFiltered.length === 0 && data.length > 0">
+                No results found
+              </goa-block>
             `}
           />
           <CodeSnippet
@@ -369,105 +458,123 @@ export class TableComponent {
             tags="react"
             allowCopy={true}
             code={`
-  const [typedChips, setTypedChips] = useState<string[]>([]);
-  const [inputValue, setInputValue] = useState("");
-  const [inputError, setInputError] = useState("");
-  const errorEmpty = "Empty filter";
-  const errorDuplicate = "Enter a unique filter";
-  const data = useMemo(
-    () => [
-      {
-        status: { type: "information" as GoABadgeType, text: "In progress" },
-        name: "Ivan Schmidt",
-        id: "7838576954",
-      },
-      {
-        status: { type: "success" as GoABadgeType, text: "Completed" },
-        name: "Luz Lakin",
-        id: "8576953364",
-      },
-      {
-        status: { type: "information" as GoABadgeType, text: "In progress" },
-        name: "Keith McGlynn",
-        id: "9846041345",
-      },
-      {
-        status: { type: "success" as GoABadgeType, text: "Completed" },
-        name: "Melody Frami",
-        id: "7385256175",
-      },
-      {
-        status: { type: "important" as GoABadgeType, text: "Updated" },
-        name: "Frederick Skiles",
-        id: "5807570418",
-      },
-      {
-        status: { type: "success" as GoABadgeType, text: "Completed" },
-        name: "Dana Pfannerstill",
-        id: "5736306857",
-      },
-    ],
-    [],
-  );
-  const [dataFiltered, setDataFiltered] = useState(data);
+              const [selectedFilter, setSelectedFilter] = useState<string | null>(null);
+              const [typedChips, setTypedChips] = useState<string[]>([]);
+              const [inputValue, setInputValue] = useState("");
+              const [inputError, setInputError] = useState("");
+              const errorEmpty = "Empty filter";
+              const errorDuplicate = "Enter a unique filter";
+              const data = useMemo(
+                () => [
+                  {
+                    status: { type: "information" as GoABadgeType, text: "In progress" },
+                    name: "Ivan Schmidt",
+                    id: "7838576954",
+                  },
+                  {
+                    status: { type: "success" as GoABadgeType, text: "Completed" },
+                    name: "Luz Lakin",
+                    id: "8576953364",
+                  },
+                  {
+                    status: { type: "information" as GoABadgeType, text: "In progress" },
+                    name: "Keith McGlynn",
+                    id: "9846041345",
+                  },
+                  {
+                    status: { type: "success" as GoABadgeType, text: "Completed" },
+                    name: "Melody Frami",
+                    id: "7385256175",
+                  },
+                  {
+                    status: { type: "important" as GoABadgeType, text: "Updated" },
+                    name: "Frederick Skiles",
+                    id: "5807570418",
+                  },
+                  {
+                    status: { type: "success" as GoABadgeType, text: "Completed" },
+                    name: "Dana Pfannerstill",
+                    id: "5736306857",
+                  },
+                ],
+                [],
+              );
+              const [dataFiltered, setDataFiltered] = useState(data);
 
-  const handleInputChange = (_name: string, value: string) => {
-    const newValue = value.trim();
-    setInputValue(newValue);
-  };
+              const target = (
+                  <GoAButton type="tertiary" leadingIcon="funnel" size="compact" aria-label="Filter table">
+                      Filter
+                  </GoAButton>
+              );
 
-  const handleInputKeyPress = (_name: string, _value: string, key: string) => {
-    if (key === "Enter") {
-      applyFilter();
-    }
-  };
+              const handleInputChange = (_name: string, value: string) => {
+                const newValue = value.trim();
+                setInputValue(newValue);
+              };
 
-  const applyFilter = () => {
-    if (inputValue === "") {
-			setInputError(errorEmpty);
-      return;
-    }
-    if (typedChips.length > 0 && typedChips.includes(inputValue)) {
-      setInputError(errorDuplicate);
-      return;
-    }
-    setTypedChips([...typedChips, inputValue]);
-    setTimeout(() => {
-      setInputValue("");
-    }, 0);
-    setInputError("");
-  };
+              const handleInputKeyPress = (_name: string, _value: string, key: string) => {
+                if (key === "Enter") {
+                  applyFilter();
+                }
+              };
 
-  const removeTypedChip = (chip: string) => {
-    setTypedChips(typedChips.filter((c) => c !== chip));
-    setInputError("");
-  };
+              const applyFilter = () => {
+                if (inputValue === "") {
+                  setInputError(errorEmpty);
+                  return;
+                }
+                if (typedChips.length > 0 && typedChips.includes(inputValue)) {
+                  setInputError(errorDuplicate);
+                  return;
+                }
+                setTypedChips([...typedChips, inputValue]);
+                setTimeout(() => {
+                  setInputValue("");
+                }, 0);
+                setInputError("");
+              };
 
-  const checkNested = useCallback((obj: object, chip: string): boolean => {
-    return Object.values(obj).some((value) =>
-      typeof value === "object" && value !== null
-        ? checkNested(value, chip)
-        : typeof value === "string" && value.toLowerCase().includes(chip.toLowerCase()),
-    );
-  }, []);
+              const removeTypedChip = (chip: string) => {
+                setTypedChips(typedChips.filter((c) => c !== chip));
+                setInputError("");
+              };
 
-  const getFilteredData = useCallback(
-    (typedChips: string[]) => {
-      if (typedChips.length === 0) {
-        return data;
-      }
-      const filteredData = data.filter((item: object) =>
-        typedChips.every((chip) => checkNested(item, chip)),
-      );
+              const checkNested = useCallback((obj: object, chip: string): boolean => {
+                return Object.values(obj).some((value) =>
+                  typeof value === "object" && value !== null
+                    ? checkNested(value, chip)
+                    : typeof value === "string" && value.toLowerCase().includes(chip.toLowerCase()),
+                );
+              }, []);
 
-      return filteredData;
-    },
-    [checkNested, data],
-  );
+              const handleInputChange = (_name: string, value: string) => {
+                setSelectedFilter(value);
+              };
 
-  useEffect(() => {
-    setDataFiltered(getFilteredData(typedChips));
-  }, [getFilteredData, typedChips]);
+              const getFilteredData = useCallback(
+                (typedChips: string[], selectedFilter: string | null) => {
+                  let filteredData = data;
+
+                  if (typedChips.length > 0) {
+                    filteredData = filteredData.filter((item: any) =>
+                      typedChips.every(chip => checkNested(item, chip))
+                    );
+                  }
+
+                  if (selectedFilter) {
+                    filteredData = filteredData.filter(
+                      (item: any) => item.status && item.status.text === selectedFilter
+                    );
+                  }
+
+                  return filteredData;
+                },
+                [checkNested, data]
+              );
+
+              useEffect(() => {
+                setDataFiltered(getFilteredData(typedChips, selectedFilter));
+              }, [getFilteredData, typedChips, selectedFilter]);
             `}
           />
 
@@ -476,78 +583,96 @@ export class TableComponent {
             tags="react"
             allowCopy={true}
             code={`
-    <>
-      <GoAFormItem id="filterChipInput" error={inputError} mb="m">
-        <GoABlock gap="xs" direction="row" alignment="start">
-          <GoAInput
-            name="filterChipInput"
-            aria-labelledby="filterChipInput"
-            value={inputValue}
-            leadingIcon="search"
-            onChange={handleInputChange}
-            onKeyPress={handleInputKeyPress}
-          />
-          <GoAButton
-            type="secondary"
-            onClick={applyFilter}
-            leadingIcon="filter"
-          >
-            Filter
-          </GoAButton>
-        </GoABlock>
-      </GoAFormItem>
+              <GoAContainer width="full" mt="m" mb="none">
+                <GoAFormItem id="filterChipInput" error={inputError}>
+                  <GoABlock gap="xs" direction="row" alignment="center">
+                    <GoAInput
+                      name="filterChipInput"
+                      aria-labelledby="filterChipInput"
+                      value={inputValue}
+                      leadingIcon="search"
+                      onChange={handleInputChange}
+                      onKeyPress={handleInputKeyPress}
+                    />
+                    
+                    <GoAPopover target={target} minWidth="150px">
+                        <form>
+                            <GoAFormItem label="Status">
+                                <GoARadioGroup name="item" onChange={radioGroupOnChange} value={selectedFilter ?? ""}>
+                                    <GoARadioItem value="In progress" label="In progress" />
+                                    <GoARadioItem value="Completed" label="Completed" />
+                                    <GoARadioItem value="Updated" label="Updated" />
+                                </GoARadioGroup>
+                            </GoAFormItem>
+                        </form>
+                    </GoAPopover>
+                  </GoABlock>
+                </GoAFormItem>
 
-      {typedChips.length > 0 && (
-        <div>
-          <GoAText as="span" color="secondary" mb="xs" mr="xs">
-            Filter:
-          </GoAText>
-          {typedChips.length > 0 &&
-            typedChips.map((typedChip, index) => (
-              <GoAFilterChip
-                key={index}
-                content={typedChip}
-                mb="xs"
-                mr="xs"
-                onClick={() => removeTypedChip(typedChip)}
-              />
-            ))}
-          <GoAButton
-            type="tertiary"
-            size="compact"
-            mb="xs"
-            onClick={() => setTypedChips([])}
-          >
-            Clear all
-          </GoAButton>
-        </div>
-      )}
+                {(typedChips.length > 0 || selectedFilter) && (
+                  <div>
+                    <GoAText tag="span" color="secondary" mb="xs" mr="xs" mt="l">
+                      Filter:
+                    </GoAText>
+                    {typedChips.map((typedChip, index) => (
+                      <GoAFilterChip
+                        key={index}
+                        content={typedChip}
+                        mb="xs"
+                        mr="xs"
+                        mt="l"
+                        onClick={() => removeTypedChip(typedChip)}
+                      />
+                    ))}
+                    {selectedFilter && (
+                      <GoAFilterChip
+                        content={selectedFilter}
+                        mb="xs"
+                        mr="xs"
+                        mt="l"
+                        onClick={() => {
+                          setSelectedFilter(null);
+                        }}
+                      />
+                    )}
+                    {(typedChips.length > 0 || selectedFilter) && (
+                      <GoAButton type="tertiary" size="compact" mb="xs" onClick={() => {
+                        setTypedChips([]);
+                        setSelectedFilter(null);
+                      }}>
+                        Clear all
+                      </GoAButton>
+                    )}
+                  </div>
+                )}
 
-      <GoATable width="100%">
-        <thead>
-          <tr>
-            <th>Status</th>
-            <th>Name</th>
-            <th className="goa-table-number-header">ID Number</th>
-          </tr>
-        </thead>
-        <tbody>
-          {dataFiltered.map((item) => (
-            <tr key={item.id}>
-              <td>
-                <GoABadge type={item.status.type} content={item.status.text} />
-              </td>
-              <td>{item.name}</td>
-              <td className="goa-table-number-column">{item.id}</td>
-            </tr>
-          ))}
-        </tbody>
-      </GoATable>
+                <GoATable width="100%" mt="s">
+                  <thead>
+                    <tr>
+                      <th>Status</th>
+                      <th>Name</th>
+                      <th className="goa-table-number-header">ID Number</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {dataFiltered.map(item => (
+                      <tr key={item.id}>
+                        <td>
+                          <GoABadge type={item.status.type} content={item.status.text} />
+                        </td>
+                        <td>{item.name}</td>
+                        <td className="goa-table-number-column">{item.id}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </GoATable>
 
-      {dataFiltered.length === 0 && data.length > 0 && (
-        <GoABlock mt="l" mb="l">No results found</GoABlock>
-      )}
-    </>
+                {dataFiltered.length === 0 && data.length > 0 && (
+                  <GoABlock mt="l" mb="l">
+                    No results found
+                  </GoABlock>
+                )}
+              </GoAContainer>
             `}
           />
         </>
@@ -560,102 +685,125 @@ export class TableComponent {
             tags="angular"
             allowCopy={true}
             code={`
-export class TableComponent {
-  typedChips: string[] = [];
-  inputValue = "";
-  inputError = "";
-  readonly errorEmpty = "Empty filter";
-  readonly errorDuplicate = "Enter a unique filter";
-  readonly data = [
-    {
-      status: { type: "information" as GoabBadgeType, text: "In progress" },
-      name: "Ivan Schmidt",
-      id: "7838576954",
-    },
-    {
-      status: { type: "success" as GoabBadgeType, text: "Completed" },
-      name: "Luz Lakin",
-      id: "8576953364",
-    },
-    {
-      status: { type: "information" as GoabBadgeType, text: "In progress" },
-      name: "Keith McGlynn",
-      id: "9846041345",
-    },
-    {
-      status: { type: "success" as GoabBadgeType, text: "Completed" },
-      name: "Melody Frami",
-      id: "7385256175",
-    },
-    {
-      status: { type: "important" as GoabBadgeType, text: "Updated" },
-      name: "Frederick Skiles",
-      id: "5807570418",
-    },
-    {
-      status: { type: "success" as GoabBadgeType, text: "Completed" },
-      name: "Dana Pfannerstill",
-      id: "5736306857",
-    },
-  ];
-  dataFiltered = this.getFilteredData(this.typedChips);
+              
+              export class TablePopoverComponent {
+                typedChips: string[] = [];
 
-  handleInputChange(detail: GoabInputOnChangeDetail): void {
-    const newValue = detail.value.trim();
-    this.inputValue = newValue;
-  }
+                inputValue = '';
+                inputError = '';
+                readonly errorEmpty = 'Empty filter';
+                readonly errorDuplicate = 'Enter a unique filter';
 
-  handleInputKeyPress(detail: GoabInputOnKeyPressDetail): void {
-    if (detail.key === "Enter") {
-      this.applyFilter();
-    }
-  }
+                // Radio filter state
+                selectedFilter: string | null = null;
 
-  applyFilter() {
-    if (this.inputValue === "") {
-			this.inputError = this.errorEmpty;
-      return;
-    }
-    if (this.typedChips.includes(this.inputValue)) {
-      this.inputError = this.errorDuplicate;
-      return;
-    }
-    this.typedChips = [...this.typedChips, this.inputValue];
-    this.inputValue = "";
-    this.inputError = "";
-    this.dataFiltered = this.getFilteredData(this.typedChips);
-  }
+                // Table data
+                popoverValues: PopoverValue[] = [
+                  {
+                    status: { type: "information" as GoabBadgeType, text: "In progress" },
+                    name: "Ivan Schmidt",
+                    id: "7838576954",
+                  },
+                  {
+                    status: { type: "success" as GoabBadgeType, text: "Completed" },
+                    name: "Luz Lakin",
+                    id: "8576953364",
+                  },
+                  {
+                    status: { type: "information" as GoabBadgeType, text: "In progress" },
+                    name: "Keith McGlynn",
+                    id: "9846041345",
+                  },
+                  {
+                    status: { type: "success" as GoabBadgeType, text: "Completed" },
+                    name: "Melody Frami",
+                    id: "7385256175",
+                  },
+                  {
+                    status: { type: "important" as GoabBadgeType, text: "Updated" },
+                    name: "Frederick Skiles",
+                    id: "5807570418",
+                  },
+                  {
+                    status: { type: "success" as GoabBadgeType, text: "Completed" },
+                    name: "Dana Pfannerstill",
+                    id: "5736306857",
+                  },
+                ];
 
-  removeTypedChip(chip: string) {
-    this.typedChips = this.typedChips.filter((c) => c !== chip);
-    this.dataFiltered = this.getFilteredData(this.typedChips);
-    this.inputError = "";
-  }
+                get filteredData(): PopoverValue[] {
+                  let filtered = this.popoverValues;
 
-  removeAllTypedChips() {
-    this.typedChips = [];
-    this.dataFiltered = this.getFilteredData(this.typedChips);
-    this.inputError = "";
-  }
+                  // Apply radio filter
+                  if (this.selectedFilter) {
+                    filtered = filtered.filter(item => item.status === this.selectedFilter);
+                  }
 
-  getFilteredData(typedChips: string[]) {
-    if (typedChips.length === 0) {
-      return this.data;
-    }
-    const filteredData = this.data.filter((item) =>
-      typedChips.every((chip) => this.checkNested(item, chip)),
-    );
-    return filteredData;
-  }
+                  // Apply chip filters (all chips must match)
+                  if (this.typedChips.length > 0) {
+                    filtered = filtered.filter(item =>
+                      this.typedChips.every(chip =>
+                        Object.values(item).some(val =>
+                          typeof val === 'string' && val.toLowerCase().includes(chip.toLowerCase())
+                        )
+                      )
+                    );
+                  }
 
-  checkNested(obj: object, chip: string): boolean {
-    return Object.values(obj).some((value) =>
-      typeof value === "object" && value !== null
-        ? this.checkNested(value, chip)
-        : typeof value === "string" && value.toLowerCase().includes(chip.toLowerCase()),
-    );
-  }
-}
+                  return filtered;
+                }
+
+                handleInputChange(detail: GoabInputOnChangeDetail): void {
+                  const newValue = detail.value.trim();
+                  this.inputValue = newValue;
+                }
+
+                handleInputKeyPress(detail: GoabInputOnKeyPressDetail): void {
+                  if (detail.key === "Enter") {
+                    this.applyFilter();
+                  }
+                }
+
+                applyFilter() {
+                  if (this.inputValue === '') {
+                    this.inputError = this.errorEmpty;
+                    return;
+                  }
+                  if (this.typedChips.includes(this.inputValue)) {
+                    this.inputError = this.errorDuplicate;
+                    return;
+                  }
+                  this.typedChips = [...this.typedChips, this.inputValue];
+                  this.inputValue = '';
+                  this.inputError = '';
+                }
+
+                removeTypedChip(chip: string) {
+                  this.typedChips = this.typedChips.filter(c => c !== chip);
+                  this.inputError = '';
+                }
+
+                removeAllTypedChips() {
+                  this.typedChips = [];
+                  this.inputError = '';
+                }
+
+                radioGroupOnChange(event: GoabRadioGroupOnChangeDetail) {
+                  this.selectedFilter = event.value;
+                }
+
+                clearRadioFilter() {
+                  this.selectedFilter = null;
+                }
+
+                checkNested(obj: object, chip: string): boolean {
+                  return Object.values(obj).some((value) =>
+                    typeof value === "object" && value !== null
+                      ? this.checkNested(value, chip)
+                      : typeof value === "string" && value.toLowerCase().includes(chip.toLowerCase()),
+                  );
+                }
+              }
 						`}
           />
           <CodeSnippet
@@ -663,67 +811,84 @@ export class TableComponent {
             tags="angular"
             allowCopy={true}
             code={`
-<goab-form-item id="filterChipInput" [error]="inputError" mb="m">
-  <goab-block gap="xs" direction="row" alignment="start">
-    <goab-input
-      name="filterChipInput"
-      aria-labelledby="filterChipInput"
-      [value]="inputValue"
-      maxlength="100"
-      size="large"
-      leadingIcon="search"
-      (onChange)="handleInputChange($event)"
-      (onKeyPress)="handleInputKeyPress($event)"
-    ></goab-input>
+              <goab-form-item id="filterChipInput" [error]="inputError" mb="m">
+                <goab-block gap="xs" direction="row" alignment="start">
+                  <input
+                    name="filterChipInput"
+                    aria-labelledby="filterChipInput"
+                    [value]="inputValue"
+                    (input)="handleInputChange($event)"
+                    (keydown)="handleInputKeyPress($event)"
+                    placeholder="Type to filter"
+                  />
 
-    <goab-button
-      type="secondary"
-      (onClick)="applyFilter()"
-      leadingIcon="filter"
-    >
-      Filter
-    </goab-button>
-  </goab-block>
-</goab-form-item>
+                  <goab-popover>
+                    <form>
+                      <goab-form-item label="Status">
+                        <goab-radio-group
+                          name="item"
+                          [value]="selectedFilter"
+                          (onChange)="radioGroupOnChange($event.target.value)">
+                          <goab-radio-item value="In progress" label="In progress"></goab-radio-item>
+                          <goab-radio-item value="Completed" label="Completed"></goab-radio-item>
+                          <goab-radio-item value="Updated" label="Updated"></goab-radio-item>
+                        </goab-radio-group>
+                      </goab-form-item>
+                    </form>
+                    <div slot="target">
+                      <goab-button
+                        type="tertiary"
+                        leadingIcon="funnel"
+                        size="compact"
+                        aria-label="Filter table">
+                        Filter
+                      </goab-button>
+                    </div>
+                  </goab-popover>
+                  <goab-button type="secondary" (click)="applyFilter()" leadingIcon="filter">
+                    Filter
+                  </goab-button>
+                </goab-block>
+              </goab-form-item>
 
-<ng-container *ngIf="typedChips.length > 0">
-  <goab-text tag="span" color="secondary" mb="xs" mr="xs">
-    Filter:
-  </goab-text>
-  <goab-filter-chip
-    *ngFor="let typedChip of typedChips; let index = index"
-    [content]="typedChip"
-    mb="xs"
-    mr="xs"
-    (onClick)="removeTypedChip(typedChip)"
-  ></goab-filter-chip>
-  <goab-button type="tertiary" size="compact" mb="xs" (onClick)="removeAllTypedChips()">
-    Clear all
-  </goab-button>
-</ng-container>
+              <ng-container *ngIf="typedChips.length > 0">
+                <goab-text tag="span" color="secondary" mb="xs" mr="xs">
+                  Filter:
+                </goab-text>
+                <goab-filter-chip
+                  *ngFor="let typedChip of typedChips"
+                  [content]="typedChip"
+                  mb="xs"
+                  mr="xs"
+                  (click)="removeTypedChip(typedChip)">
+                </goab-filter-chip>
+                <goab-button type="tertiary" size="compact" mb="xs" (click)="removeAllTypedChips()">
+                  Clear all
+                </goab-button>
+              </ng-container>
 
-<goab-table width="100%">
-  <thead>
-    <tr>
-      <th>Status</th>
-      <th>Name</th>
-      <th className="goa-table-number-header">ID Number</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr *ngFor="let item of dataFiltered">
-      <td>
-        <goab-badge [type]="item.status.type" [content]="item.status.text"></goab-badge>
-      </td>
-      <td>{{ item.name }}</td>
-      <td className="goa-table-number-column">{{ item.id }}</td>
-    </tr>
-  </tbody>
-</goab-table>
+              <goab-table width="100%" mb="xl">
+                <thead>
+                  <tr>
+                    <th>Status</th>
+                    <th>Text</th>
+                    <th class="goa-table-number-header">Number</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr *ngFor="let u of filteredData">
+                    <td>
+                      <goab-badge [type]="u.type" [content]="u.status"></goab-badge>
+                    </td>
+                    <td>Lorem ipsum</td>
+                    <td class="goa-table-number-column">{{ u.key }}</td>
+                  </tr>
+                </tbody>
+              </goab-table>
 
-<goab-block mt="l" mb="l" *ngIf="dataFiltered.length === 0 && data.length > 0">
-  No results found
-</goab-block>
+              <goab-block mt="l" mb="l" *ngIf="dataFiltered.length === 0 && data.length > 0">
+                No results found
+              </goab-block>
             `}
           />
           <CodeSnippet
@@ -731,105 +896,124 @@ export class TableComponent {
             tags="react"
             allowCopy={true}
             code={`
-  const [typedChips, setTypedChips] = useState<string[]>([]);
-  const [inputValue, setInputValue] = useState("");
-  const [inputError, setInputError] = useState("");
-  const errorEmpty = "Empty filter";
-  const errorDuplicate = "Enter a unique filter";
-  const data = useMemo(
-    () => [
-      {
-        status: { type: "information" as GoabBadgeType, text: "In progress" },
-        name: "Ivan Schmidt",
-        id: "7838576954",
-      },
-      {
-        status: { type: "success" as GoabBadgeType, text: "Completed" },
-        name: "Luz Lakin",
-        id: "8576953364",
-      },
-      {
-        status: { type: "information" as GoabBadgeType, text: "In progress" },
-        name: "Keith McGlynn",
-        id: "9846041345",
-      },
-      {
-        status: { type: "success" as GoabBadgeType, text: "Completed" },
-        name: "Melody Frami",
-        id: "7385256175",
-      },
-      {
-        status: { type: "important" as GoabBadgeType, text: "Updated" },
-        name: "Frederick Skiles",
-        id: "5807570418",
-      },
-      {
-        status: { type: "success" as GoabBadgeType, text: "Completed" },
-        name: "Dana Pfannerstill",
-        id: "5736306857",
-      },
-    ],
-    []
-  );
-  const [dataFiltered, setDataFiltered] = useState(data);
+              const [selectedFilter, setSelectedFilter] = useState<string | null>(null);
+              const [typedChips, setTypedChips] = useState<string[]>([]);
+              const [inputValue, setInputValue] = useState("");
+              const [inputError, setInputError] = useState("");
+              const errorEmpty = "Empty filter";
+              const errorDuplicate = "Enter a unique filter";
+              const data = useMemo(
+                () => [
+                  {
+                    status: { type: "information" as GoabBadgeType, text: "In progress" },
+                    name: "Ivan Schmidt",
+                    id: "7838576954",
+                  },
+                  {
+                    status: { type: "success" as GoabBadgeType, text: "Completed" },
+                    name: "Luz Lakin",
+                    id: "8576953364",
+                  },
+                  {
+                    status: { type: "information" as GoabBadgeType, text: "In progress" },
+                    name: "Keith McGlynn",
+                    id: "9846041345",
+                  },
+                  {
+                    status: { type: "success" as GoabBadgeType, text: "Completed" },
+                    name: "Melody Frami",
+                    id: "7385256175",
+                  },
+                  {
+                    status: { type: "important" as GoabBadgeType, text: "Updated" },
+                    name: "Frederick Skiles",
+                    id: "5807570418",
+                  },
+                  {
+                    status: { type: "success" as GoabBadgeType, text: "Completed" },
+                    name: "Dana Pfannerstill",
+                    id: "5736306857",
+                  },
+                ],
+                []
+              );
+              const [dataFiltered, setDataFiltered] = useState(data);
 
-  const handleInputChange = (detail: GoabInputOnChangeDetail) => {
-    const newValue = detail.value.trim();
-    setInputValue(newValue);
-  };
+              const target = (
+                  <GoabButton type="tertiary" leadingIcon="funnel" size="compact" aria-label="Filter table">
+                      Filter
+                  </GoabButton>
+              );
 
-  const handleInputKeyPress = (detail: GoabInputOnKeyPressDetail) => {
-    if (detail.key === "Enter") {
-      applyFilter();
-    }
-  };
+              const handleInputChange = (detail: GoabInputOnChangeDetail) => {
+                const newValue = detail.value.trim();
+                setInputValue(newValue);
+              };
 
-  const applyFilter = () => {
-    if (inputValue === "") {
-			setInputError(errorEmpty);
-      return;
-    }
-    if (typedChips.length > 0 && typedChips.includes(inputValue)) {
-      setInputError(errorDuplicate);
-      return;
-    }
-    setTypedChips([...typedChips, inputValue]);
-    setTimeout(() => {
-      setInputValue("");
-    }, 0);
-    setInputError("");
-  };
+              const handleInputKeyPress = (detail: GoabInputOnKeyPressDetail) => {
+                if (detail.key === "Enter") {
+                  applyFilter();
+                }
+              };
 
-  const removeTypedChip = (chip: string) => {
-    setTypedChips(typedChips.filter(c => c !== chip));
-    setInputError("");
-  };
+              const applyFilter = () => {
+                if (inputValue === "") {
+                  setInputError(errorEmpty);
+                  return;
+                }
+                if (typedChips.length > 0 && typedChips.includes(inputValue)) {
+                  setInputError(errorDuplicate);
+                  return;
+                }
+                setTypedChips([...typedChips, inputValue]);
+                setTimeout(() => {
+                  setInputValue("");
+                }, 0);
+                setInputError("");
+              };
 
-  const checkNested = useCallback((obj: object, chip: string): boolean => {
-    return Object.values(obj).some(value =>
-      typeof value === "object" && value !== null
-        ? checkNested(value, chip)
-        : typeof value === "string" && value.toLowerCase().includes(chip.toLowerCase())
-    );
-  }, []);
+              const removeTypedChip = (chip: string) => {
+                setTypedChips(typedChips.filter(c => c !== chip));
+                setInputError("");
+              };
 
-  const getFilteredData = useCallback(
-    (typedChips: string[]) => {
-      if (typedChips.length === 0) {
-        return data;
-      }
-      const filteredData = data.filter((item: object) =>
-        typedChips.every(chip => checkNested(item, chip))
-      );
+              const checkNested = useCallback((obj: object, chip: string): boolean => {
+                return Object.values(obj).some(value =>
+                  typeof value === "object" && value !== null
+                    ? checkNested(value, chip)
+                    : typeof value === "string" && value.toLowerCase().includes(chip.toLowerCase())
+                );
+              }, []);
 
-      return filteredData;
-    },
-    [checkNested, data]
-  );
+              function radioGroupOnChange(event: GoabRadioGroupOnChangeDetail) {
+                  setSelectedFilter(event.value);
+              }
 
-  useEffect(() => {
-    setDataFiltered(getFilteredData(typedChips));
-  }, [getFilteredData, typedChips]);
+              const getFilteredData = useCallback(
+                (typedChips: string[], selectedFilter: string | null) => {
+                  let filteredData = data;
+
+                  if (typedChips.length > 0) {
+                    filteredData = filteredData.filter((item: any) =>
+                      typedChips.every(chip => checkNested(item, chip))
+                    );
+                  }
+
+                  if (selectedFilter) {
+                    filteredData = filteredData.filter(
+                      (item: any) => item.status && item.status.text === selectedFilter
+                    );
+                  }
+
+                  return filteredData;
+                },
+                [checkNested, data]
+              );
+
+
+              useEffect(() => {
+                setDataFiltered(getFilteredData(typedChips, selectedFilter));
+              }, [getFilteredData, typedChips, selectedFilter]);
             `}
           />
 
@@ -838,72 +1022,96 @@ export class TableComponent {
             tags="react"
             allowCopy={true}
             code={`
-    <>
-      <GoabFormItem id="filterChipInput" error={inputError} mb="m">
-        <GoabBlock gap="xs" direction="row" alignment="start">
-          <GoabInput
-            name="filterChipInput"
-            aria-labelledby="filterChipInput"
-            value={inputValue}
-            leadingIcon="search"
-            onChange={handleInputChange}
-            onKeyPress={handleInputKeyPress}
-          />
-          <GoabButton
-            type="secondary"
-            onClick={applyFilter}
-            leadingIcon="filter">
-            Filter
-          </GoabButton>
-        </GoabBlock>
-      </GoabFormItem>
+              <GoabContainer width="full" mt="m" mb="none">
+                <GoabFormItem id="filterChipInput" error={inputError}>
+                  <GoabBlock gap="xs" direction="row" alignment="center">
+                    <GoabInput
+                      name="filterChipInput"
+                      aria-labelledby="filterChipInput"
+                      value={inputValue}
+                      leadingIcon="search"
+                      onChange={handleInputChange}
+                      onKeyPress={handleInputKeyPress}
+                    />
+                    
+                    <GoabPopover target={target} minWidth="150px">
+                        <form>
+                            <GoabFormItem label="Status">
+                                <GoabRadioGroup name="item" onChange={radioGroupOnChange} value={selectedFilter ?? ""}>
+                                    <GoabRadioItem value="In progress" label="In progress" />
+                                    <GoabRadioItem value="Completed" label="Completed" />
+                                    <GoabRadioItem value="Updated" label="Updated" />
+                                </GoabRadioGroup>
+                            </GoabFormItem>
+                        </form>
+                    </GoabPopover>
+                  </GoabBlock>
+                </GoabFormItem>
 
-      {typedChips.length > 0 && (
-        <div>
-          <GoabText tag="span" color="secondary" mb="xs" mr="xs">
-            Filter:
-          </GoabText>
-          {typedChips.length > 0 &&
-            typedChips.map((typedChip, index) => (
-              <GoabFilterChip
-                key={index}
-                content={typedChip}
-                mb="xs"
-                mr="xs"
-                onClick={() => removeTypedChip(typedChip)}
-              />
-            ))}
-          <GoabButton type="tertiary" size="compact" mb="xs" onClick={() => setTypedChips([])}>
-            Clear all
-          </GoabButton>
-        </div>
-      )}
+                {(typedChips.length > 0 || selectedFilter) && (
+                  <div>
+                    <GoabText tag="span" color="secondary" mb="xs" mr="xs" mt="l">
+                      Filter:
+                    </GoabText>
+                    {typedChips.map((typedChip, index) => (
+                      <GoabFilterChip
+                        key={index}
+                        content={typedChip}
+                        mb="xs"
+                        mr="xs"
+                        mt="l"
+                        onClick={() => removeTypedChip(typedChip)}
+                      />
+                    ))}
+                    {selectedFilter && (
+                      <GoabFilterChip
+                        content={selectedFilter}
+                        mb="xs"
+                        mr="xs"
+                        mt="l"
+                        onClick={() => {
+                          setSelectedFilter(null);
+                        }}
+                      />
+                    )}
+                    {(typedChips.length > 0 || selectedFilter) && (
+                      <GoabButton type="tertiary" size="compact" mb="xs" onClick={() => {
+                        setTypedChips([]);
+                        setSelectedFilter(null);
+                      }}>
+                        Clear all
+                      </GoabButton>
+                    )}
+                  </div>
+                )}
 
-      <GoabTable width="100%">
-        <thead>
-          <tr>
-            <th>Status</th>
-            <th>Name</th>
-            <th className="goa-table-number-header">ID Number</th>
-          </tr>
-        </thead>
-        <tbody>
-          {dataFiltered.map(item => (
-            <tr key={item.id}>
-              <td>
-                <GoabBadge type={item.status.type} content={item.status.text} />
-              </td>
-              <td>{item.name}</td>
-              <td className="goa-table-number-column">{item.id}</td>
-            </tr>
-          ))}
-        </tbody>
-      </GoabTable>
+                <GoabTable width="100%" mt="s">
+                  <thead>
+                    <tr>
+                      <th>Status</th>
+                      <th>Name</th>
+                      <th className="goa-table-number-header">ID Number</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {dataFiltered.map(item => (
+                      <tr key={item.id}>
+                        <td>
+                          <GoabBadge type={item.status.type} content={item.status.text} />
+                        </td>
+                        <td>{item.name}</td>
+                        <td className="goa-table-number-column">{item.id}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </GoabTable>
 
-      {dataFiltered.length === 0 && data.length > 0 && (
-        <GoabBlock mt="l" mb="l">No results found</GoabBlock>
-      )}
-    </>
+                {dataFiltered.length === 0 && data.length > 0 && (
+                  <GoabBlock mt="l" mb="l">
+                    No results found
+                  </GoabBlock>
+                )}
+              </GoabContainer>
             `}
           />
         </>

--- a/src/examples/tables/TablesExamples.tsx
+++ b/src/examples/tables/TablesExamples.tsx
@@ -1,5 +1,4 @@
 import SortDataInATable from "@examples/sort-data-in-a-table.tsx";
-import DisplayNumbersInATableSoTheyCanBeScannedEasily from "@examples/display-numbers-in-a-table-so-they-can-be-scanned-easily.tsx";
 import ZebraStripesInATable from "@examples/zebra-stripes-in-a-table.tsx";
 import FilterDataInATable from "@examples/filter-data-in-a-table.tsx";
 import { SandboxHeader } from "@components/sandbox/sandbox-header/sandboxHeader.tsx";
@@ -8,13 +7,6 @@ import './tables-page-examples.css';
 export const TablesExamples = () => {
   return (
     <>
-
-      <SandboxHeader
-        exampleTitle="Display numbers in a table so they can be scanned easily"
-        figmaExample="https://www.figma.com/design/aIRjvBzpIUH0GbkffjbL04/%E2%9D%96-Patterns-library-%7C-DDD?node-id=6312-97673&t=X0IQW5flDDaj8Vyg-4">
-      </SandboxHeader>
-      <DisplayNumbersInATableSoTheyCanBeScannedEasily />
-
       <SandboxHeader
         exampleTitle="Table with filters"
         figmaExample="https://www.figma.com/design/aIRjvBzpIUH0GbkffjbL04/%E2%9D%96-Patterns-library-%7C-DDD?node-id=7104-1626357&t=WrSJODVw0mryQrrA-4">

--- a/src/examples/tables/TablesExamples.tsx
+++ b/src/examples/tables/TablesExamples.tsx
@@ -1,16 +1,13 @@
 import SortDataInATable from "@examples/sort-data-in-a-table.tsx";
 import DisplayNumbersInATableSoTheyCanBeScannedEasily from "@examples/display-numbers-in-a-table-so-they-can-be-scanned-easily.tsx";
+import ZebraStripesInATable from "@examples/zebra-stripes-in-a-table.tsx";
 import FilterDataInATable from "@examples/filter-data-in-a-table.tsx";
 import { SandboxHeader } from "@components/sandbox/sandbox-header/sandboxHeader.tsx";
+import './tables-page-examples.css';
 
 export const TablesExamples = () => {
   return (
     <>
-      <SandboxHeader
-        exampleTitle="Sort data in a table"
-        figmaExample="https://www.figma.com/design/aIRjvBzpIUH0GbkffjbL04/%E2%9D%96-Patterns-library-%7C-DDD?node-id=6312-97462&t=X0IQW5flDDaj8Vyg-4">
-      </SandboxHeader>
-      <SortDataInATable />
 
       <SandboxHeader
         exampleTitle="Display numbers in a table so they can be scanned easily"
@@ -19,10 +16,22 @@ export const TablesExamples = () => {
       <DisplayNumbersInATableSoTheyCanBeScannedEasily />
 
       <SandboxHeader
-        exampleTitle="Filter data in a table"
+        exampleTitle="Table with filters"
         figmaExample="https://www.figma.com/design/aIRjvBzpIUH0GbkffjbL04/%E2%9D%96-Patterns-library-%7C-DDD?node-id=7104-1626357&t=WrSJODVw0mryQrrA-4">
       </SandboxHeader>
       <FilterDataInATable />
+
+      <SandboxHeader
+        exampleTitle="Table with zebra stripes"
+        figmaExample="">
+      </SandboxHeader>
+      <ZebraStripesInATable />
+
+      <SandboxHeader
+        exampleTitle="Table with sortable columns"
+        figmaExample="https://www.figma.com/design/aIRjvBzpIUH0GbkffjbL04/%E2%9D%96-Patterns-library-%7C-DDD?node-id=6312-97462&t=X0IQW5flDDaj8Vyg-4">
+      </SandboxHeader>
+      <SortDataInATable />
     </>
   );
 };

--- a/src/examples/tables/tables-page-examples.css
+++ b/src/examples/tables/tables-page-examples.css
@@ -1,3 +1,3 @@
 .goa-table-zebra-stripes > tr:nth-child(even) {
-    background-color: #F8F8F8;
+    background-color: var(--goa-color-greyscale-50);
 }

--- a/src/examples/tables/tables-page-examples.css
+++ b/src/examples/tables/tables-page-examples.css
@@ -1,0 +1,3 @@
+.goa-table-zebra-stripes > tr:nth-child(even) {
+    background-color: #F8F8F8;
+}

--- a/src/examples/zebra-stripes-in-a-table.tsx
+++ b/src/examples/zebra-stripes-in-a-table.tsx
@@ -52,7 +52,7 @@ export const ZebraStripesInATable = () => {
           allowCopy={true}
           code={`
             .goa-table-zebra-stripes > tr:nth-child(even) {
-                background-color: #F8F8F8;
+                background-color: var(--goa-color-greyscale-50);
             }
           `}
         />

--- a/src/examples/zebra-stripes-in-a-table.tsx
+++ b/src/examples/zebra-stripes-in-a-table.tsx
@@ -1,0 +1,88 @@
+import { 
+  GoabButton,
+  GoabBadge,
+  GoabTable 
+} from "@abgov/react-components";
+import type {
+  GoabBadgeType,
+} from "@abgov/ui-components-common";
+import { Sandbox } from "@components/sandbox";
+import { CodeSnippet } from "@components/code-snippet/CodeSnippet.tsx";
+
+export const ZebraStripesInATable = () => {
+  const filteredData = [
+    {
+      status: { type: "information" as GoabBadgeType, text: "In progress" },
+      name: "Ivan Schmidt",
+      id: "76954",
+    },
+    {
+      status: { type: "success" as GoabBadgeType, text: "Completed" },
+      name: "Luz Lakin",
+      id: "53364",
+    },
+    {
+      status: { type: "information" as GoabBadgeType, text: "In progress" },
+      name: "Keith McGlynn",
+      id: "41345",
+    },
+    {
+      status: { type: "success" as GoabBadgeType, text: "Completed" },
+      name: "Melody Frami",
+      id: "56175",
+    },
+    {
+      status: { type: "important" as GoabBadgeType, text: "Updated" },
+      name: "Frederick Skiles",
+      id: "70418",
+    },
+    {
+      status: { type: "success" as GoabBadgeType, text: "Completed" },
+      name: "Dana Pfannerstill",
+      id: "06857",
+    },
+  ];
+
+  return (
+    <>
+      <Sandbox fullWidth>
+        {/*CSS Code Snippet*/}
+        <CodeSnippet
+          lang="css"
+          allowCopy={true}
+          code={`
+            .goa-table-zebra-stripes > tr:nth-child(even) {
+                background-color: #F8F8F8;
+            }
+          `}
+        />
+        <GoabTable width="100%">
+          <thead>
+            <tr>
+              <th>Status</th>
+              <th>Assigned to</th>
+              <th className="goa-table-number-header">Number</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody className="goa-table-zebra-stripes">
+           {filteredData.map((item) => (
+              <tr key={item.id}>
+                <td>
+                  <GoabBadge type={item.status.type} content={item.status.text} />
+                </td>
+                <td>{item.name}</td>
+                <td className="goa-table-number-column">{item.id}</td>
+                <td>
+                    <GoabButton type="tertiary">Action</GoabButton>
+                </td>
+              </tr>
+          ))}
+          </tbody>
+        </GoabTable>
+      </Sandbox>
+    </>
+  );
+};
+
+export default ZebraStripesInATable;

--- a/src/routes/components/Table.tsx
+++ b/src/routes/components/Table.tsx
@@ -199,7 +199,7 @@ export default function TablePage() {
             heading={
               <>
                 Examples
-                <GoabBadge type="information" content="3" />
+                <GoabBadge type="information" content="4" />
               </>
             }>
             <TablesExamples />

--- a/src/routes/components/Table.tsx
+++ b/src/routes/components/Table.tsx
@@ -199,7 +199,7 @@ export default function TablePage() {
             heading={
               <>
                 Examples
-                <GoabBadge type="information" content="4" />
+                <GoabBadge type="information" content="3" />
               </>
             }>
             <TablesExamples />


### PR DESCRIPTION
**Added the following example:**

- _Zebra Stripes_
<img width="885" height="1072" alt="image" src="https://github.com/user-attachments/assets/49af01a3-552c-4fcf-8d45-45582ba173aa" />

**Modified the following examples:**
- _Table with filters_ -- Combined filtering through text input with filtering with radio buttons. "Filter" button now makes popover appear. Text input filtering actions through the Enter key
<img width="866" height="556" alt="image" src="https://github.com/user-attachments/assets/8932054b-a6f2-4295-ab39-e07f59dc676d" />

-_Display numbers in a table so they can be scanned easily_ -- In the Issue ticket, it was noted that this one should be removed. However, with the example on the Figma file, I kept it in. Please confirm if this should be kept or not.
<img width="895" height="483" alt="image" src="https://github.com/user-attachments/assets/d3aa9a27-4b20-4895-9d34-a77fa44a5c20" />
