### PR TITLE
fix(#3378): Updated old version goa-text-area

### DIFF
--- a/src/components/sandbox/AngularReactiveSerializer.ts
+++ b/src/components/sandbox/AngularReactiveSerializer.ts
@@ -104,7 +104,7 @@ export class AngularReactiveSerializer extends BaseSerializer implements Seriali
     const oldPrefix = "goa";
     let tail = name.replace(currentPrefix, "");
 
-    if (tail === "TextArea" && this.version === "new") {
+    if (tail === "TextArea") {
       tail = "Textarea"
     }
 

--- a/src/components/sandbox/AngularSerializer.ts
+++ b/src/components/sandbox/AngularSerializer.ts
@@ -94,7 +94,7 @@ export class AngularSerializer extends BaseSerializer implements Serializer {
     if (tail === "OneColumnLayout" && this.version === "new") {
       tail = "ColumnLayout";
     }
-    if (tail === "TextArea" && this.version === "new") {
+    if (tail === "TextArea") {
       tail = "Textarea"
     }
     return `${this.version === "old" ? "goa" : "goab"}-${this.dasherize(tail)}`;


### PR DESCRIPTION
Angular documentation for `GoaTextArea` for v3 should now look like `goa-textarea` instead of `goa-text-area`.