### PR TITLE
fix(#3511): use correct v2 Docs URL for migration guide

### DIFF
--- a/src/components/version-language-switcher/VersionUpdateNotification.tsx
+++ b/src/components/version-language-switcher/VersionUpdateNotification.tsx
@@ -6,7 +6,7 @@ import { getV2Link } from "../../utils";
 
 export function VersionUpdateNotification() {
   const { isDismissed, dismiss, newLinkRef } = useVersionUpdateNotification();
-  const v2UpgradeLink = getV2Link("/upgrade-guide");
+  const v2UpgradeLink = getV2Link("/get-started/migration-guide");
 
   useEffect(() => {
     const el = document.querySelector("goa-notification");


### PR DESCRIPTION
This PR fixes the link to the v2 Migration Guide: https://design.alberta.ca/get-started/migration-guide/